### PR TITLE
Build of CTKPluginFrameworkTestUtil fails on Mingw

### DIFF
--- a/Libs/PluginFramework/Testing/Cpp/ctkPluginFrameworkTestRunner.cpp
+++ b/Libs/PluginFramework/Testing/Cpp/ctkPluginFrameworkTestRunner.cpp
@@ -199,7 +199,7 @@ void ctkPluginFrameworkTestRunner::addPluginPath(const QString& path, bool insta
   Q_D(ctkPluginFrameworkTestRunner);
   d->pluginPaths.push_back(qMakePair(path, install));
 #ifdef _WIN32
-  if(_putenv_s("PATH", path.toLatin1().data()))
+  if(_putenv(QString("PATH=%1").arg(path).toLatin1().data()))
   {
     LPVOID lpMsgBuf;
     DWORD dw = GetLastError(); 


### PR DESCRIPTION
The Mingw runtime is missing the <code>_putenv_s</code> function. Therefore the following compilation error is thrown: 

<pre>F:\libWin\src\CTK\Libs\PluginFramework\Testing\Cpp\ctkPluginFrameworkTestRunner.cpp:202:46: error: '_putenv_s' was not declared in this scope</pre>

I replaced <code>_putenv_s</code> by <code>_putenv</code>.
