### PR TITLE
Add new property to ctkMenuComboBox with a search icon.

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkMenuComboBoxTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkMenuComboBoxTest1.cpp
@@ -64,7 +64,9 @@ int ctkMenuComboBoxTest1(int argc, char * argv [] )
   Menu2->setDefaultText("Search");
   Menu2->setAutoFillBackground(true);
   Menu2->setMinimumContentsLength(25);
-  Menu2->setEditableBehavior(ctkMenuComboBox::EditableOnFocus);
+  Menu2->setSearchIconVisible(false);
+  Menu2->setSearchIconVisible(true);
+  //Menu2->setEditableBehavior(ctkMenuComboBox::EditableOnFocus);
   Menu2->setEditableBehavior(ctkMenuComboBox::EditableOnPopup);
   //Menu2->show();
 

--- a/Libs/Widgets/ctkMenuComboBox.h
+++ b/Libs/Widgets/ctkMenuComboBox.h
@@ -43,8 +43,9 @@ class ctkMenuComboBoxPrivate;
 ///   if it is disabled :
 /// the ctkMenuComboBox has the same behavior as a QPushButton. You can't filter the menu.
 
-/// By default ctkMenuComboBox is editable on double click.
+/// By default ctkMenuComboBox is not editable with the search icon visible.
 /// See ctkmenuComboBox::setEditableType() to change the default behavior.
+/// and setIconSearchVisible() to show/hide the icon.
 
 class CTK_WIDGETS_EXPORT ctkMenuComboBox : public QWidget
 {
@@ -53,6 +54,7 @@ class CTK_WIDGETS_EXPORT ctkMenuComboBox : public QWidget
   Q_PROPERTY(QString defaultText READ defaultText WRITE setDefaultText)
   Q_PROPERTY(QIcon defaultIcon READ defaultIcon WRITE setDefaultIcon)
   Q_PROPERTY(EditableBehavior editBehavior READ editableBehavior WRITE setEditableBehavior)
+  Q_PROPERTY(bool searchIconVisible READ isSearchIconVisible WRITE setSearchIconVisible)
 
 public:
   enum EditableBehavior{
@@ -87,10 +89,16 @@ public:
   void setEditableBehavior(EditableBehavior editBehavior);
   EditableBehavior editableBehavior()const;
 
+  /// set the icon search visible
+  void setSearchIconVisible(bool state);
+  bool isSearchIconVisible() const;
+
   /// See QComboBox::setMinimumContentsLength()
   void setMinimumContentsLength(int characters);
 
+protected:
   virtual bool eventFilter(QObject* target, QEvent* event);
+  virtual void resizeEvent(QResizeEvent *event);
 
 public slots:
   void clearActiveAction();

--- a/Libs/Widgets/ctkMenuComboBox_p.h
+++ b/Libs/Widgets/ctkMenuComboBox_p.h
@@ -28,6 +28,7 @@
 // CTK includes
 #include "ctkMenuComboBox.h"
 class ctkCompleter;
+class QToolButton;
 
 class ctkMenuComboBoxInternal: public QComboBox
 {
@@ -84,6 +85,7 @@ protected:
   ctkMenuComboBoxInternal*    MenuComboBox;
   ctkCompleter*               SearchCompleter;
   QWeakPointer<QMenu>         Menu;
+  QToolButton*                SearchButton;
 };
 
 #endif


### PR DESCRIPTION
Added a search icon next to the menu combobox.
New default behavior : ctkMenuComboBox is not editable with the search
icon visible.
