### PR TITLE
Fix check indicator on ctkCheckablePushButton.

### DIFF
--- a/Libs/Widgets/ctkCheckablePushButton.cpp
+++ b/Libs/Widgets/ctkCheckablePushButton.cpp
@@ -340,7 +340,7 @@ void ctkCheckablePushButton::paintEvent(QPaintEvent * _event)
   int indicatorSpacing = this->style()->pixelMetric(QStyle::PM_CheckBoxLabelSpacing, &opt, this);
   int buttonMargin = this->style()->pixelMetric(QStyle::PM_ButtonMargin, &opt, this);
   // Draw Indicator
-  QStyleOption indicatorOpt;
+  QStyleOptionButton indicatorOpt;
   indicatorOpt.init(this);
   if (!(d->CheckBoxFlags & Qt::ItemIsUserCheckable))
     {


### PR DESCRIPTION
Under QCleanLooksStyle the check indicator was hided.

Pull request for Julien Finet
