### PR TITLE
BUG: Fix ctkVTKHistogram handling of NaN's.

### DIFF
--- a/Libs/Visualization/VTK/Core/Testing/Cpp/ctkVTKHistogramTest4.cpp
+++ b/Libs/Visualization/VTK/Core/Testing/Cpp/ctkVTKHistogramTest4.cpp
@@ -12,6 +12,7 @@
 // STD includes
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 
 int ctkVTKHistogramTest4( int argc, char * argv [])
 {
@@ -31,6 +32,14 @@ int ctkVTKHistogramTest4( int argc, char * argv [])
   dataArray->InsertNextTuple1( 220.0001);
   dataArray->InsertNextTuple1(1234.0);
   dataArray->InsertNextTuple1(220.0);
+  if(std::numeric_limits<float>::has_quiet_NaN)
+    {
+    // These should be ignored.
+    const float positiveNaN = std::numeric_limits<float>::quiet_NaN();
+    dataArray->InsertNextTuple1(positiveNaN);
+    const float negativeNaN = - positiveNaN;
+    dataArray->InsertNextTuple1(negativeNaN);
+    }
   histogram.setDataArray(dataArray);
   if (histogram.dataArray() != dataArray)
     {

--- a/Libs/Visualization/VTK/Core/ctkVTKHistogram.cpp
+++ b/Libs/Visualization/VTK/Core/ctkVTKHistogram.cpp
@@ -296,8 +296,8 @@ void populateIrregularBins(vtkIntArray* bins, const ctkVTKHistogram* histogram)
   ptr += component;
   for (; ptr < endPtr; ptr += componentNumber)
     {
-    if (std::numeric_limits<T>::has_quiet_NaN && 
-        std::numeric_limits<T>::quiet_NaN() == *ptr)
+    if (std::numeric_limits<T>::has_quiet_NaN &&
+        vtkMath::IsNan(*ptr))
       {
       continue;
       }


### PR DESCRIPTION
The previous implementation would not catch the NaN's and would segfault.  vtkMath::IsNan is used instead.

NaN values are added in the tests.
