### PR TITLE
Clear image mapper input when RenderWindowItem is destroyed

### DIFF
--- a/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
+++ b/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
@@ -59,6 +59,7 @@ class RenderWindowItem
 public:
   RenderWindowItem(const double rendererBackgroundColor[3], const double highlightedBoxColor[3],
                    double colorWindow, double colorLevel);
+  ~RenderWindowItem();
   void SetViewport(double xMin, double yMin, double viewportWidth, double viewportHeight);
 
   /// Create the actor supporing the image mapper
@@ -92,6 +93,12 @@ RenderWindowItem::RenderWindowItem(const double rendererBackgroundColor[3],
 
   this->SetupImageMapperActor(colorWindow, colorLevel);
   this->SetupHighlightedBoxActor(highlightedBoxColor);
+}
+
+//-----------------------------------------------------------------------------
+RenderWindowItem::~RenderWindowItem()
+{
+  this->ImageMapper->SetInput(0);
 }
 
 //-----------------------------------------------------------------------------
@@ -606,8 +613,6 @@ void vtkLightBoxRendererManager::SetRenderWindowLayout(int rowCount, int columnC
     - static_cast<int>(this->Internal->RenderWindowItemList.size());
   if (extraItem > 0)
     {
-    //std::cout << "Creating " << extraItem << " RenderWindowItem";
-
     // Create extra RenderWindowItem(s)
     while(extraItem > 0)
       {
@@ -623,8 +628,6 @@ void vtkLightBoxRendererManager::SetRenderWindowLayout(int rowCount, int columnC
     }
   else
     {
-    //std::cout << "Removing " << extraItem << " RenderWindowItem";
-
     // Remove extra RenderWindowItem(s)
     extraItem = extraItem >= 0 ? extraItem : -extraItem; // Compute Abs
     while(extraItem > 0)


### PR DESCRIPTION
Since the ImageActor is still in the renderer even after the
light box mode has changed, a paint event can lead to a Render
being called even though the input pipeline has already
been torn down.  This can lead to the image being rendered
with null data in the vtkImageData, and then a crash as
described in http://na-mic.org/Bug/view.php?id=2512
