### PR TITLE
BUG: Changes cursor when mouse enters ctkSearchBox clear button.

### DIFF
--- a/Libs/Widgets/ctkSearchBox.cpp
+++ b/Libs/Widgets/ctkSearchBox.cpp
@@ -318,7 +318,7 @@ void ctkSearchBox::mouseMoveEvent(QMouseEvent *e)
   if(d->clearRect().contains(e->pos()) ||
      (d->showSearchIcon && d->searchRect().contains(e->pos())))
     {
-    this->setCursor(Qt::ArrowCursor);
+    this->setCursor(Qt::PointingHandCursor);
     }
   else
     {


### PR DESCRIPTION
See http://na-mic.org/Mantis/view.php?id=1347

I don't really like the choice of cursor, but didn't find another good one.  At the same time, I don't know that an eraser bitmap is applicable here either.  Here is a good list of cursor shapes: http://qt-project.org/doc/qt-4.8/qt.html#CursorShape-enum
