### PR TITLE
Fix for ctkWorkflowGroupBox to re-size properly.

### DIFF
--- a/Libs/Widgets/Resources/UI/ctkWorkflowGroupBox.ui
+++ b/Libs/Widgets/Resources/UI/ctkWorkflowGroupBox.ui
@@ -83,7 +83,7 @@
              <item>
               <widget class="ctkFittedTextBrowser" name="SubTitleTextBrowser">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -106,7 +106,7 @@
              <item>
               <widget class="ctkFittedTextBrowser" name="PreTextBrowser">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <sizepolicy hsizetype="Ignored" vsizetype="Maximum">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -147,7 +147,7 @@
              <item>
               <widget class="ctkFittedTextBrowser" name="PostTextBrowser">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -160,7 +160,7 @@
              <item>
               <widget class="ctkFittedTextBrowser" name="ErrorTextBrowser">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>


### PR DESCRIPTION
When using ctkWorkflow and calling the class ctkFittedTextBrowser,
this fix will allow the module GUI to expand and shrink properly,
the ctkFittedTextBrowser will not try to take all the space
and set a minimum size for the module.
Closes #302
