### PR TITLE
Set default sizePolicy for ctkFittedTextBrowser

### DIFF
--- a/Libs/Widgets/ctkFittedTextBrowser.cpp
+++ b/Libs/Widgets/ctkFittedTextBrowser.cpp
@@ -31,6 +31,8 @@ ctkFittedTextBrowser::ctkFittedTextBrowser(QWidget* _parent)
   : QTextBrowser(_parent)
 {
   this->connect(this, SIGNAL(textChanged()), SLOT(heightForWidthMayHaveChanged()));
+  QSizePolicy newSizePolicy = QSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+  this->setSizePolicy(newSizePolicy);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
By setting this sizePolicy as default we can ensure
the good behavior of ctkFittedTextBrowser:
for it to adapt to any horizontal space it has
