### PR TITLE
BUG: notify the scalar bar widget when text properties change.

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarBarWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarBarWidget.cpp
@@ -66,7 +66,17 @@ void ctkVTKScalarBarWidgetPrivate::init()
   
   QObject::connect(this->LabelsTextPropertyWidget, SIGNAL(textChanged(QString)),
                    q, SLOT(setLabelsFormat(QString)));
-  QObject::connect(this->LabelsTextPropertyWidget, SIGNAL(modified()),
+  QObject::connect(this->LabelsTextPropertyWidget, SIGNAL(colorChanged(QColor)),
+                   q, SIGNAL(modified()));
+  QObject::connect(this->LabelsTextPropertyWidget, SIGNAL(opacityChanged(double)),
+                   q, SIGNAL(modified()));
+  QObject::connect(this->LabelsTextPropertyWidget, SIGNAL(fontFamilyChanged(QString)),
+                   q, SIGNAL(modified()));
+  QObject::connect(this->LabelsTextPropertyWidget, SIGNAL(boldChanged(bool)),
+                   q, SIGNAL(modified()));
+  QObject::connect(this->LabelsTextPropertyWidget, SIGNAL(italicChanged(bool)),
+                   q, SIGNAL(modified()));
+  QObject::connect(this->LabelsTextPropertyWidget, SIGNAL(shadowChanged(bool)),
                    q, SIGNAL(modified()));
 }
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKTextPropertyWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKTextPropertyWidget.cpp
@@ -199,7 +199,7 @@ void ctkVTKTextPropertyWidget::setColor(const QColor& color)
     }
   d->TextProperty->SetColor(color.redF(), color.greenF(), color.blueF());
 
-  emit modified();
+  emit colorChanged(color);
 }
 
 //-----------------------------------------------------------------------------
@@ -219,7 +219,7 @@ void ctkVTKTextPropertyWidget::setOpacity(double opacity)
     }
   d->TextProperty->SetOpacity(opacity);
 
-  emit modified();
+  emit opacityChanged(opacity);
 }
 
 //-----------------------------------------------------------------------------
@@ -239,7 +239,7 @@ void ctkVTKTextPropertyWidget::setFont(const QString& font)
     }
   d->TextProperty->SetFontFamilyAsString(font.toStdString().data());
   
-  emit modified();
+  emit fontFamilyChanged(font);
 }
 
 //-----------------------------------------------------------------------------
@@ -259,7 +259,7 @@ void ctkVTKTextPropertyWidget::setBold(bool enable)
     }
   d->TextProperty->SetBold(enable);
   
-  emit modified();
+  emit boldChanged(enable);
 }
 
 //-----------------------------------------------------------------------------
@@ -279,7 +279,7 @@ void ctkVTKTextPropertyWidget::setItalic(bool enable)
     }
   d->TextProperty->SetItalic(enable);
   
-  emit modified();
+  emit italicChanged(enable);
 }
 
 //-----------------------------------------------------------------------------
@@ -299,5 +299,5 @@ void ctkVTKTextPropertyWidget::setShadow(bool enable)
     }
   d->TextProperty->SetShadow(enable);
   
-  emit modified();
+  emit shadowChanged(enable);
 }

--- a/Libs/Visualization/VTK/Widgets/ctkVTKTextPropertyWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKTextPropertyWidget.h
@@ -82,7 +82,12 @@ public Q_SLOTS:
 
 Q_SIGNALS:
   void textChanged(const QString& text);
-  void modified();
+  void colorChanged(const QColor& color);
+  void opacityChanged(double opacity);
+  void fontFamilyChanged(const QString &font);
+  void boldChanged(bool enable);
+  void italicChanged(bool enable);
+  void shadowChanged(bool enable);
 
 protected Q_SLOTS:
   void updateFromTextProperty();


### PR DESCRIPTION
The ctkVTKTextPropertyWidget was emitting a textChanged signal when
the label format changed, but no signals were emitted when the color,
opacity, font, or font style were changed. Added the modified
signal on the ctkVTKTextPropertyWidget and pass it through as a
modified signal on the ctkVTKScalarBarWidget so that anyone observing
the modified signal can respond to text property changes.

Slicer4 Issue #3027
http://www.na-mic.org/Bug/view.php?id=3027
