### PR TITLE
ENH: Add ctkSpinBox DecimalsStyle::UseShortcut

### DIFF
--- a/Libs/Widgets/Resources/UI/ctkScreenshotDialog.ui
+++ b/Libs/Widgets/Resources/UI/ctkScreenshotDialog.ui
@@ -155,6 +155,9 @@
         <property name="toolTip">
          <string>Select an integer scale factor (between 0.5 and 5) for the image file, e.g. a value of &quot;2&quot; will save an image twice the size.</string>
         </property>
+        <property name="decimalsOption">
+         <enum>ctkSpinBox::Fixed</enum>
+        </property>
         <property name="decimals">
          <number>1</number>
         </property>

--- a/Libs/Widgets/Testing/Cpp/ctkRangeWidgetEventTranslatorPlayerTest1.xml
+++ b/Libs/Widgets/Testing/Cpp/ctkRangeWidgetEventTranslatorPlayerTest1.xml
@@ -59,11 +59,11 @@
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/Slider" command="set_min_double" arguments="35"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/Slider" command="set_min_double" arguments="36"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/Slider" command="set_min_double" arguments="37"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MaximumSpinBox" command="spin" arguments="down"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MaximumSpinBox" command="spin" arguments="down"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MaximumSpinBox" command="spin" arguments="down"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MinimumSpinBox" command="spin" arguments="down"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MinimumSpinBox" command="spin" arguments="down"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MinimumSpinBox" command="spin" arguments="down"/>
+        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MaximumSpinBox/1QDoubleSpinBox0" command="set_double" arguments="70"/>
+        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MaximumSpinBox/1QDoubleSpinBox0" command="set_double" arguments="71"/>
+        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MaximumSpinBox/1QDoubleSpinBox0" command="set_double" arguments="72"/>
+        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MinimumSpinBox/1QDoubleSpinBox0" command="set_double" arguments="32"/>
+        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MinimumSpinBox/1QDoubleSpinBox0" command="set_double" arguments="33"/>
+        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget1/MinimumSpinBox/1QDoubleSpinBox0" command="set_double" arguments="34"/>
     </events>
 </QtTesting>

--- a/Libs/Widgets/Testing/Cpp/ctkRangeWidgetEventTranslatorPlayerTest2.xml
+++ b/Libs/Widgets/Testing/Cpp/ctkRangeWidgetEventTranslatorPlayerTest2.xml
@@ -17,7 +17,7 @@
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget2/Slider" command="set_max_double" arguments="0.4"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget2/Slider" command="set_max_double" arguments="-4.6"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget2/Slider" command="set_max_double" arguments="-9.6"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget2/MinimumSpinBox" command="spin" arguments="up"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget2/MinimumSpinBox" command="spin" arguments="up"/>
+        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget2/MinimumSpinBox/1QDoubleSpinBox0" command="set_double" arguments="-36"/>
+        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/RangeWidget2/MinimumSpinBox/1QDoubleSpinBox0" command="set_double" arguments="-35"/>
     </events>
 </QtTesting>

--- a/Libs/Widgets/Testing/Cpp/ctkSliderWidgetTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSliderWidgetTest1.cpp
@@ -152,13 +152,14 @@ int ctkSliderWidgetTest1(int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-  sliderSpinBox.setAutoSpinBoxWidth(false);
+  sliderSpinBox.setSynchronizeSiblings(ctkSliderWidget::NoSynchronize);
 
-  if (sliderSpinBox.isAutoSpinBoxWidth() != false || 
+  if (sliderSpinBox.synchronizeSiblings().testFlag(
+      ctkSliderWidget::SynchronizeWidth) != false ||
       !qFuzzyCompare(sliderSpinBox.value(), 80.6))
     {
     std::cerr << "ctkSliderWidget::setAutoSpinBoxWidth failed."
-              << sliderSpinBox.isAutoSpinBoxWidth() << " "
+              << sliderSpinBox.synchronizeSiblings() << " "
               << sliderSpinBox.value() << std::endl;
     return EXIT_FAILURE;
     }

--- a/Libs/Widgets/ctkCoordinatesWidget.cpp
+++ b/Libs/Widgets/ctkCoordinatesWidget.cpp
@@ -63,6 +63,9 @@ void ctkCoordinatesWidget::addSpinBox()
   spinBox->setMaximum(this->Maximum);
   connect( spinBox, SIGNAL(valueChanged(double)),
            this, SLOT(updateCoordinate(double)));
+  // Same number of decimals within the spinboxes.
+  connect( spinBox, SIGNAL(decimalsChanged(int)),
+           this, SLOT(setDecimals(int)));
   this->layout()->addWidget(spinBox);
 }
 

--- a/Libs/Widgets/ctkCoordinatesWidget.h
+++ b/Libs/Widgets/ctkCoordinatesWidget.h
@@ -59,9 +59,8 @@ public:
   void setDimension(int dim);
   int dimension() const;
 
-  /// Set/Get the number of decimals of each coordinate spin box
+  /// Get the number of decimals of each coordinate spin box
   /// The default number of decimals is 3.
-  void setDecimals(int decimals);
   int decimals() const;
 
   /// Set/Get the single step of each coordinate spin box
@@ -105,6 +104,9 @@ public:
 
 public Q_SLOTS:
   void normalize();
+
+  /// Set the number of decimals of each coordinate spin box.
+  void setDecimals(int decimals);
 
 Q_SIGNALS:
   ///

--- a/Libs/Widgets/ctkMatrixWidget.cpp
+++ b/Libs/Widgets/ctkMatrixWidget.cpp
@@ -56,6 +56,9 @@ namespace
       this->setMaximum(matrixWidget->maximum());
       this->setDecimals(matrixWidget->decimals());
       this->setSingleStep(matrixWidget->singleStep());
+
+      this->connect(this, SIGNAL(decimalsChanged(int)),
+        matrixWidget, SLOT(setDecimals(int)));
     }
   };
 }

--- a/Libs/Widgets/ctkMatrixWidget.h
+++ b/Libs/Widgets/ctkMatrixWidget.h
@@ -122,7 +122,6 @@ public:
   /// Dictates how many decimals will be used for displaying and interpreting doubles by the spinbox
   /// used to adjust the value of a matrix element.
   int decimals()const;
-  void setDecimals(int decimals);
 
   ///
   /// Reimplemented from QAbstractScrollArea
@@ -134,6 +133,11 @@ public Q_SLOTS:
   ///
   /// Reset the matrix to identity
   void identity();
+
+  ///
+  /// Set how many decimals will be used for displaying and interpreting
+  /// doubles by the spinbox used to adjust the value of a matrix element.
+  void setDecimals(int decimals);
 
 Q_SIGNALS:
   void matrixChanged();

--- a/Libs/Widgets/ctkRangeWidget.cpp
+++ b/Libs/Widgets/ctkRangeWidget.cpp
@@ -92,6 +92,10 @@ void ctkRangeWidgetPrivate::connectSlider()
                    q, SLOT(setMinimumToMaximumSpinBox(double)));
   QObject::connect(this->MaximumSpinBox, SIGNAL(valueChanged(double)),
                    q, SLOT(setMaximumToMinimumSpinBox(double)));
+  QObject::connect(this->MinimumSpinBox, SIGNAL(decimalsChanged(int)),
+                   q, SLOT(setDecimals(int)));
+  QObject::connect(this->MaximumSpinBox, SIGNAL(decimalsChanged(int)),
+                   q, SLOT(setDecimals(int)));
 
   QObject::connect(this->Slider, SIGNAL(sliderPressed()),
                    q, SLOT(startChanging()));

--- a/Libs/Widgets/ctkRangeWidget.h
+++ b/Libs/Widgets/ctkRangeWidget.h
@@ -118,10 +118,7 @@ public:
 
   ///
   /// This property holds the precision of the spin box, in decimals.
-  /// Sets how many decimals the spinbox will use for displaying and
-  /// interpreting doubles.
   int decimals()const;
-  void setDecimals(int decimals);
 
   ///
   /// This property holds the spin box's prefix.
@@ -191,6 +188,10 @@ public Q_SLOTS:
   ///
   /// Utility function that set the min and max values at once
   void setValues(double minValue, double maxValue);
+
+  /// Sets how many decimals the spinbox will use for displaying and
+  /// interpreting doubles.
+  void setDecimals(int decimals);
 
 Q_SIGNALS:
   /// Use with care:

--- a/Libs/Widgets/ctkSliderWidget.h
+++ b/Libs/Widgets/ctkSliderWidget.h
@@ -52,13 +52,36 @@ class CTK_WIDGETS_EXPORT ctkSliderWidget : public QWidget
   Q_PROPERTY(QString suffix READ suffix WRITE setSuffix)
   Q_PROPERTY(double tickInterval READ tickInterval WRITE setTickInterval)
   Q_PROPERTY(QSlider::TickPosition tickPosition READ tickPosition WRITE setTickPosition)
-  Q_PROPERTY(bool autoSpinBoxWidth READ isAutoSpinBoxWidth WRITE setAutoSpinBoxWidth)
+  Q_FLAGS(SynchronizeSiblings)
+  Q_PROPERTY(SynchronizeSiblings SynchronizeSibling READ synchronizeSiblings WRITE setSynchronizeSiblings)
   Q_PROPERTY(Qt::Alignment spinBoxAlignment READ spinBoxAlignment WRITE setSpinBoxAlignment)
   Q_PROPERTY(bool tracking READ hasTracking WRITE setTracking)
   Q_PROPERTY(bool spinBoxVisible READ isSpinBoxVisible WRITE setSpinBoxVisible);
   Q_PROPERTY(bool popupSlider READ hasPopupSlider WRITE setPopupSlider);
 
 public:
+
+  /// Synchronize properties of the slider siblings:
+  /// NoSynchronize:
+  /// The slider widget siblings aren't updated and this widget does not update
+  /// from its siblings.
+  /// SynchronizeWidth:
+  /// The width of the SpinBox is set to the same width of the largest QSpinBox
+  /// of its ctkSliderWidget siblings.
+  /// SynchronizeDecimals:
+  /// Whenever one of the siblings changes its number of decimals, all its
+  /// siblings Synchronize to the new number of decimals.
+  ///
+  /// Default is SynchronizeWidth |SynchronizeDecimals.
+  /// \sa SynchronizeSiblings(), setSynchronizeSiblings()
+  enum SynchronizeSibling
+    {
+    NoSynchronize = 0x000,
+    SynchronizeWidth = 0x001,
+    SynchronizeDecimals = 0x002,
+    };
+  Q_DECLARE_FLAGS(SynchronizeSiblings, SynchronizeSibling)
+
   /// Superclass typedef
   typedef QWidget Superclass;
 
@@ -116,9 +139,7 @@ public:
 
   /// 
   /// This property holds the precision of the spin box, in decimals.
-  /// Sets how many decimals the spinbox will use for displaying and interpreting doubles.
   int decimals()const;
-  void setDecimals(int decimals);
 
   ///
   /// This property holds the spin box's prefix.
@@ -140,7 +161,7 @@ public:
   /// If it is 0, the slider will choose between lineStep() and pageStep().
   /// The default value is 0.
   double tickInterval()const;
-  void setTickInterval(double ti);
+  void setTickInterval(double tick);
 
   /// 
   /// This property holds the tickmark position for the slider.
@@ -166,12 +187,12 @@ public:
   bool hasTracking()const;
 
   /// 
-  /// Set/Get the auto spinbox width
-  /// When the autoSpinBoxWidth property is on, the width of the SpinBox is
-  /// set to the same width of the largest QSpinBox of its
-  // ctkSliderWidget siblings.
-  bool isAutoSpinBoxWidth()const;
-  void setAutoSpinBoxWidth(bool autoWidth);
+  /// Set/Get the synchronize siblings mode. This helps when having multiple
+  /// ctkSliderWidget stacked upon each other.
+  /// Default flag is SynchronizeWidth | SynchronizeDecimals.
+  /// \sa SynchronizeSiblingsModes
+  ctkSliderWidget::SynchronizeSiblings synchronizeSiblings() const;
+  void setSynchronizeSiblings(ctkSliderWidget::SynchronizeSiblings options);
 
   ///
   /// The Spinbox visibility can be controlled using setSpinBoxVisible() and
@@ -212,6 +233,10 @@ public Q_SLOTS:
   void setValue(double value);
   void setSpinBoxVisible(bool);
 
+  /// Sets how many decimals the spinbox uses for displaying and
+  /// interpreting doubles.
+  void setDecimals(int decimals);
+
 Q_SIGNALS:
   /// When tracking is on (default), valueChanged is emitted when the
   /// user drags the slider.
@@ -231,7 +256,7 @@ protected Q_SLOTS:
   void startChanging();
   void stopChanging();
   void changeValue(double value);
-  
+
 protected:
   virtual bool eventFilter(QObject *obj, QEvent *event);
   
@@ -243,5 +268,7 @@ private:
   Q_DISABLE_COPY(ctkSliderWidget);
 
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(ctkSliderWidget::SynchronizeSiblings);
 
 #endif

--- a/Libs/Widgets/ctkSpinBox.h
+++ b/Libs/Widgets/ctkSpinBox.h
@@ -27,6 +27,9 @@
 #include <QWidget>
 
 class QDoubleSpinBox;
+class QEvent;
+class QKeyEvent;
+class QObject;
 
 // CTK includes
 #include "ctkWidgetsExport.h"
@@ -42,6 +45,10 @@ class CTK_WIDGETS_EXPORT ctkSpinBox : public QWidget
   Q_OBJECT
   Q_ENUMS(SetMode)
   Q_PROPERTY(SetMode setMode READ setMode WRITE setSetMode)
+
+  Q_FLAGS(DecimalsOption DecimalsOptions)
+  Q_PROPERTY(DecimalsOptions decimalsOption READ decimalsOption WRITE setDecimalsOption)
+
   Q_PROPERTY(Qt::Alignment alignment READ alignment WRITE setAlignment)
   Q_PROPERTY(bool frame READ hasFrame WRITE setFrame)
   Q_PROPERTY(QString prefix READ prefix WRITE setPrefix)
@@ -70,6 +77,25 @@ public:
     SetAlways,
     SetIfDifferent,
     };
+
+  /// DecimalsOption enums the input style of the spinbox decimals.
+  /// Fixed:
+  /// Behaves just like a QDoubleSpinBox. The maximum number of decimals
+  /// allowed is given by decimals().
+  /// UseShortcuts:
+  /// When the spinbox has focus, entering the shortcut "CTRL +"
+  /// adds decimals to the current number of decimals. "CTRL -" decreases the
+  /// number of decimals and "CTRL 0" returns it to its original decimals()
+  /// value.
+  ///
+  /// Default option is UseShortcuts.
+  /// \sa decimals(), currentDecimals()
+  enum DecimalsOption
+    {
+    Fixed =         0x0,
+    UseShortcuts =  0x01,
+    };
+  Q_DECLARE_FLAGS(DecimalsOptions, DecimalsOption)
 
   typedef QWidget Superclass;
 
@@ -128,9 +154,9 @@ public:
   void setMaximum(double max);
   void setRange(double min, double max);
 
-  /// Set/Get number of decimals displayed. For a spinbox dealing only with
-  /// integers, set this to 0.
-  /// \sa addOneDecimal(), removeOneDecimal()
+  /// Set/Get number of displayed decimals.
+  /// For a spinbox dealing only with integers, set this to 0.
+  /// \sa ctkSpinBox::DecimalsOption
   int decimals() const;
   void setDecimals(int decimal);
 
@@ -148,6 +174,11 @@ public:
   //// \sa round(), setValue(), setValueIfDifferent(), setValueAlways()
   ctkSpinBox::SetMode setMode() const;
   void setSetMode(SetMode mode);
+
+  /// Set/Get the option used to input the decimals.
+  /// \sa ctkSpinBox::DecimalsOption
+  ctkSpinBox::DecimalsOptions decimalsOption();
+  void setDecimalsOption(ctkSpinBox::DecimalsOptions option);
 
 public Q_SLOTS:
   /// Set the value of the spinbox following the current mode.
@@ -177,8 +208,13 @@ Q_SIGNALS:
   /// \sa QAbstractSpinbox::editingFinished
   void editingFinished();
 
+  /// Signal emitted when the decimals of the displayed are changed.
+  void decimalsChanged(int);
+
 protected:
   ctkSpinBoxPrivate* const d_ptr;
+
+  bool eventFilter(QObject *obj, QEvent *event);
 
 private:
   Q_DECLARE_PRIVATE(ctkSpinBox);
@@ -186,5 +222,6 @@ private:
 };
 
 Q_DECLARE_METATYPE(ctkSpinBox::SetMode)
+Q_DECLARE_OPERATORS_FOR_FLAGS(ctkSpinBox::DecimalsOptions)
 
 #endif //__ctkSpinBox_h


### PR DESCRIPTION
ctkSpinBox::DecimalsStyle controls how decimals are handled. In the
regular (Fixed) mode, the spinbox behaves like a QDoubleSpinBox, i.e.
the number of decimals is set by setDecimals().
With the UseShortcut flag, the ctkSpinBox responds to keyboard shortcuts to
add (CTRL +) decimals, remove (CTL -) decimals and restore the
default number of decimals (CTRL 0) initially set by setDecimals().

This led to the update of the ctk widgets that use the ctkSpinBox. For most
of them it's pretty straightforward as they can listen to the
decimalsChanged(int) event and update themselves.
In the case of the slider widget, the AutoSpinBoxWidth was extended to
support the change of width due to a change in decimals as well as the
change in decimals (that is propagated to the siblings).

See Slicer issue #2480
