### PR TITLE
Fix mac compilation by removing librt  Issue #325

### DIFF
--- a/Libs/PluginFramework/Testing/org.commontk.eventadmintest.perf/CMakeLists.txt
+++ b/Libs/PluginFramework/Testing/org.commontk.eventadmintest.perf/CMakeLists.txt
@@ -24,7 +24,7 @@ set(PLUGIN_resources
 
 ctkFunctionGetTargetLibraries(PLUGIN_target_libraries)
 
-if(UNIX)
+if(UNIX AND NOT APPLE)
   list(APPEND PLUGIN_target_libraries rt)
 endif()
 

--- a/Libs/PluginFramework/Testing/org.commontk.eventadmintest/CMakeLists.txt
+++ b/Libs/PluginFramework/Testing/org.commontk.eventadmintest/CMakeLists.txt
@@ -36,7 +36,7 @@ set(PLUGIN_resources
 
 ctkFunctionGetTargetLibraries(PLUGIN_target_libraries)
 
-if(UNIX)
+if(UNIX AND NOT APPLE)
   list(APPEND PLUGIN_target_libraries rt)
 endif()
 

--- a/Libs/PluginFramework/Testing/org.commontk.pluginfwtest.perf/CMakeLists.txt
+++ b/Libs/PluginFramework/Testing/org.commontk.pluginfwtest.perf/CMakeLists.txt
@@ -24,7 +24,7 @@ set(PLUGIN_resources
 
 ctkFunctionGetTargetLibraries(PLUGIN_target_libraries)
 
-if(UNIX)
+if(UNIX AND NOT APPLE)
   list(APPEND PLUGIN_target_libraries rt)
 endif()
 

--- a/Plugins/org.commontk.eventadmin/CMakeLists.txt
+++ b/Plugins/org.commontk.eventadmin/CMakeLists.txt
@@ -114,7 +114,7 @@ set(PLUGIN_CACHED_RESOURCEFILES
 
 ctkFunctionGetTargetLibraries(PLUGIN_target_libraries)
 
-if(UNIX)
+if(UNIX AND NOT APPLE)
   list(APPEND PLUGIN_target_libraries rt)
 endif()
 


### PR DESCRIPTION
This fixes some of the compilation issues on mac - but not all.  See #325 for newer build error.
