### PR TITLE
Fix for #325 to build on mac

### DIFF
--- a/Applications/ctkCommandLineModuleExplorer/ctkCommandLineModuleExplorerMain.cpp
+++ b/Applications/ctkCommandLineModuleExplorer/ctkCommandLineModuleExplorerMain.cpp
@@ -29,8 +29,8 @@
 
 #include <QDebug>
 
-#include <QtXmlPatterns/QXmlQuery>
-#include <QtUiTools/QUiLoader>
+#include <QXmlQuery>
+#include <QUiLoader>
 
 // CTK includes
 #include <ctkCommandLineParser.h>


### PR DESCRIPTION
Including the QtUiTools prefix to the include directive causes the compile
failure below, so this removes it.  Oddly, the QtXmlPatters prefix
did not cause a build error, but I remove it anyway to be consistent
with other uses of that header in the rest of the code.

[ 93%] Building CXX object Applications/ctkCommandLineModuleExplorer/CMakeFiles/ctkCommandLineModuleExplorer.dir/ctkCommandLineModuleExplorerMain.cpp.o
/Users/pieper/ctk/latest/CTK/Applications/ctkCommandLineModuleExplorer/ctkCommandLineModuleExplorerMain.cpp:33:10: fatal error: 'QtUiTools/QUiLoader' file not found
# include <QtUiTools/QUiLoader>

```
     ^
```

1 error generated.
make[2]: **\* [Applications/ctkCommandLineModuleExplorer/CMakeFiles/ctkCommandLineModuleExplorer.dir/ctkCommandLineModuleExplorerMain.cpp.o] Error 1
make[1]: **\* [Applications/ctkCommandLineModuleExplorer/CMakeFiles/ctkCommandLineModuleExplorer.dir/all] Error 2
make: **\* [all] Error 2
