### PR TITLE
don't make the optionality of the channel element stand out in ctkCmdLineModule.xsd

### DIFF
--- a/Libs/CommandLineModules/Core/Resources/ctkCmdLineModule.xsd
+++ b/Libs/CommandLineModules/Core/Resources/ctkCmdLineModule.xsd
@@ -240,8 +240,7 @@
         </xsd:annotation>
       </xsd:element>
       
-      <!-- the 'channel' element is optional -->
-      <xsd:element minOccurs="0" maxOccurs="1" name="channel">
+      <xsd:element minOccurs="0" name="channel">
         <xsd:annotation>
           <xsd:documentation>Specifies whether the parameter is an input or output parameter. Output parameters can for
           example specify file paths where to write output data (e.g. using the "image" element) or they can represent


### PR DESCRIPTION
Currently, the channel element stands out, because its optionality is formulated differently, which confuses people like me who're not too proficient with XSD.
(The other optional elements do not have maxOccurs=1 or an extra comment.)
