### PR TITLE
Add QImageToVtkImageData. Use VTK's vtkQImageToImageSource internally.

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKWidgetsUtils.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKWidgetsUtils.cpp
@@ -30,6 +30,8 @@
 // VTK includes
 #include <QVTKWidget.h>
 #include <vtkImageData.h>
+#include <vtkNew.h>
+#include <vtkQImageToImageSource.h>
 
 //----------------------------------------------------------------------------
 QImage ctk::grabVTKWidget(QWidget* widget, QRect rectangle)
@@ -89,4 +91,19 @@ QImage ctk::vtkImageDataToQImage(vtkImageData* imageData)
     rgbPtr -= width * 2;
     }
   return image;
+}
+
+//----------------------------------------------------------------------------
+bool ctk::qImageToVtkImageData(const QImage& qImage, vtkImageData* vtkimage)
+{
+  if (vtkimage == 0)
+    {
+    return false;
+    }
+  QImage img = qImage;
+  vtkNew<vtkQImageToImageSource> converter;
+  converter->SetQImage(&img);
+  converter->Update();
+  vtkimage = converter->GetOutput();
+  return true;
 }

--- a/Libs/Visualization/VTK/Widgets/ctkVTKWidgetsUtils.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKWidgetsUtils.h
@@ -46,6 +46,11 @@ QImage CTK_VISUALIZATION_VTK_WIDGETS_EXPORT grabVTKWidget(QWidget* widget, QRect
 /// Convert a vtkImageData into a QImage
 QImage CTK_VISUALIZATION_VTK_WIDGETS_EXPORT vtkImageDataToQImage(vtkImageData* imageData);
 
+///
+/// \ingroup Visualization_VTK_Widgets
+/// Convert a QImage into a vtkImageData.
+bool CTK_VISUALIZATION_VTK_WIDGETS_EXPORT qImageToVtkImageData(const QImage& qImage, vtkImageData* vtkimage);
+
 }
 
 #endif


### PR DESCRIPTION
For some reason `vtkimage->DeepCopy(converter->GetOutput())` wasn't working as I expected, but this does appear to work for me.
