### PR TITLE
Fix copy/paste in ctkConsole

### DIFF
--- a/Libs/Widgets/ctkConsole_p.h
+++ b/Libs/Widgets/ctkConsole_p.h
@@ -121,6 +121,17 @@ public Q_SLOTS:
   /// Update the value of ScrollbarAtBottom given the current position of the scollbar
   void onScrollBarValueChanged(int value);
 
+protected:
+  /// Return true if the cursor position is in the history area
+  /// false if it is after the InteractivePosition.
+  bool isCursorInHistoryArea()const;
+
+  /// Reimplemented to make sure there is no text added into the
+  /// history logs.
+  virtual void insertFromMimeData(const QMimeData* source);
+
+  /// Paste text at the current text cursor position.
+  void pasteText(const QString& text);
 public:
 
   /// A custom completer


### PR DESCRIPTION
In addition to support paste from Ctrl+V, it now supports any paste
(e.g. with middle mouse button).
Also, the behavior is changed to now support Ctrl+V even when
the cursor is in the history area. Pasted text is appended at the end of
the document.

Closes #294
