### PR TITLE
Prevent reentrant calling of ctkProxyStyle::ensureBaseStyle()

### DIFF
--- a/Libs/Widgets/ctkProxyStyle.cpp
+++ b/Libs/Widgets/ctkProxyStyle.cpp
@@ -38,11 +38,13 @@ public:
 private:
   ctkProxyStylePrivate(ctkProxyStyle& object);
   mutable QPointer <QStyle> baseStyle;
+  mutable bool ensureBaseStyleInProgress;
 };
 
 // ----------------------------------------------------------------------------
 ctkProxyStylePrivate::ctkProxyStylePrivate(ctkProxyStyle& object)
   : q_ptr(&object)
+  , ensureBaseStyleInProgress(false)
 {
 }
 
@@ -102,6 +104,12 @@ ctkProxyStyle::~ctkProxyStyle()
 void ctkProxyStyle::ensureBaseStyle() const
 {
   Q_D(const ctkProxyStyle);
+  if (d->ensureBaseStyleInProgress)
+  {
+    // avoid infinite loop
+    return;
+  }
+  d->ensureBaseStyleInProgress = true;  
   d->baseStyle = this->baseStyle();
   // Set the proxy to the entire hierarchy.
   QProxyStyle* proxyStyle = const_cast<QProxyStyle*>(qobject_cast<const QProxyStyle*>(
@@ -115,6 +123,7 @@ void ctkProxyStyle::ensureBaseStyle() const
     baseStyle = proxy ? proxy->baseStyle() : 0;
     }
   d->setBaseStyle(proxyStyle, proxyBaseStyle);
+  d->ensureBaseStyleInProgress = false;
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
If ctkProxyStyle::ensureBaseStyle() is already in progress for an object then further ctkProxyStyle::ensureBaseStyle() calls for the same object are ignored.
This patch is tested and does prevent the crashes. There doesn't seem to be any side-effect.
