### PR TITLE
373 - Added check to only grab visible child widgets

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKWidgetsUtils.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKWidgetsUtils.cpp
@@ -47,6 +47,10 @@ QImage ctk::grabVTKWidget(QWidget* widget, QRect rectangle)
   painter.begin(&widgetImage);
   foreach(QVTKWidget* vtkWidget, widget->findChildren<QVTKWidget*>())
     {
+    if (!vtkWidget->isVisible())
+    {
+      continue;
+    }
     QRect subWidgetRect = QRect(vtkWidget->mapTo(widget, QPoint(0,0)), vtkWidget->size());
     if (!rectangle.intersects(subWidgetRect))
       {

--- a/Libs/Widgets/ctkWidgetsUtils.cpp
+++ b/Libs/Widgets/ctkWidgetsUtils.cpp
@@ -56,6 +56,10 @@ QImage ctk::grabWidget(QWidget* widget, QRect rectangle)
   painter.begin(&widgetImage);
   foreach(QGLWidget* glWidget, widget->findChildren<QGLWidget*>())
     {
+    if (!glWidget->isVisible())
+    {
+      continue;
+    }
     QRect subWidgetRect = QRect(glWidget->mapTo(widget, QPoint(0,0)), glWidget->size());
     if (!rectangle.intersects(subWidgetRect))
       {


### PR DESCRIPTION
Trying to grab a non-visible widget may lead to an application hang, because glGetError may never clear the error if a GL context is not created.
See details at http://www.na-mic.org/Bug/view.php?id=3438
