### PR TITLE
ENH: qvtkConnect and qvtkDisconnect performance improvement

### DIFF
--- a/Libs/Visualization/VTK/Core/Testing/Cpp/ctkVTKObjectTestHelper.cpp
+++ b/Libs/Visualization/VTK/Core/Testing/Cpp/ctkVTKObjectTestHelper.cpp
@@ -118,24 +118,6 @@ bool ctkVTKObjectTest::test()
     return false;
     }
 
-  int numberOfConnections=10000;
-  qCritical() << "Create "<<numberOfConnections<<" connections...";
-  vtkSmartPointer<vtkTimerLog> timerLog = vtkSmartPointer<vtkTimerLog>::New();
-  timerLog->StartTimer();
-  for (int i = 0; i < numberOfConnections; ++i)
-    {
-    connection = this->qvtkConnect(object, i, 
-                                 this, SLOT(onVTKObjectModifiedPublic()));
-    }
-  for (int i = 0; i < numberOfConnections; ++i)
-    {
-    connection = this->qvtkDisconnect(object, i, 
-                                 this, SLOT(onVTKObjectModifiedPublic()));
-    }
-  timerLog->StopTimer();
-  double t1 = timerLog->GetElapsedTime();
-  qCritical() << "  elapsed time: " << t1 << "seconds";
-
   object->Modified();
 
   if (d->PublicSlotCalled != 1)

--- a/Libs/Visualization/VTK/Core/ctkVTKConnection.cpp
+++ b/Libs/Visualization/VTK/Core/ctkVTKConnection.cpp
@@ -282,7 +282,7 @@ bool ctkVTKConnection::isValid(vtkObject* vtk_obj, unsigned long vtk_event,
     {
     return false;
     }
-  if (qt_slot == 0 || qt_slot[0] == 0)
+  if (qt_slot == 0 || strlen(qt_slot) == 0)
     {
     return false;
     }

--- a/Libs/Visualization/VTK/Core/ctkVTKObjectEventsObserver.cpp
+++ b/Libs/Visualization/VTK/Core/ctkVTKObjectEventsObserver.cpp
@@ -168,7 +168,7 @@ ctkVTKObjectEventsObserverPrivate::findConnection(
   Q_Q(const ctkVTKObjectEventsObserver);
 
   if(vtk_obj != NULL && qt_slot != NULL &&
-     qt_obj != NULL || vtk_event != vtkCommand::NoEvent)
+     qt_obj != NULL && vtk_event != vtkCommand::NoEvent)
     {
     // All information is specified, so we can use the index to find the connection
     unsigned long hash=generateConnectionIndexHash(vtk_obj, vtk_event, qt_obj);
@@ -211,7 +211,7 @@ ctkVTKObjectEventsObserverPrivate::findConnections(
   QList<ctkVTKConnection*> foundConnections;
 
   if(vtk_obj != NULL && qt_slot != NULL &&
-     qt_obj != NULL || vtk_event != vtkCommand::NoEvent)
+     qt_obj != NULL && vtk_event != vtkCommand::NoEvent)
     {
     // All information is specified, so we can use the index to find the connection
     ctkVTKConnection* connection=findConnection(vtk_obj, vtk_event, qt_obj, qt_slot);


### PR DESCRIPTION
Whenever a new connection is added or deleted, it's searched in the list of already existing connections using ctkVTKObjectEventsObserverPrivate::findConnection(). This findConnection() method is very slow if there are many connections, because the time-consuming ctkVTKConnection::isEqual() method is executed for each existing connection (before this commit, 40% of the time was spent in vtkConnection::isEqual while creating 10000 connections).

To solve this performance issue, added a ConnectionIndex structure, which stores a pointer to each connection object using a hash map. When searching for a fully specified connection, the ConnectionIndex is used to find the connection directly, instead of iterating through all the children.

Result of the optimization (ctkVTKObjectTest1):
Create 10000 connections: 2.343 sec => 1.019 sec (2.3x speed improvement)
Remove 10000 connections: 3.599 sec => 2.031 sec (1.77x speed improvement)
