### PR TITLE
Add location to ctkVTKDataSetModel

### DIFF
--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKDataSetModelTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKDataSetModelTest1.cpp
@@ -21,6 +21,7 @@
 // Qt includes
 #include <QApplication>
 #include <QComboBox>
+#include <QMap>
 #include <QTimer>
 #include <QDebug>
 
@@ -28,6 +29,7 @@
 #include "ctkVTKDataSetModel.h"
 
 // VTK includes
+#include <vtkAssignAttribute.h>
 #include <vtkCellData.h>
 #include <vtkFloatArray.h>
 #include <vtkIntArray.h>
@@ -43,7 +45,10 @@
 namespace
 {
 //-----------------------------------------------------------------------------
-bool checkItems(int line, const QList<vtkAbstractArray*>& expectedAttributeArrays, ctkVTKDataSetModel* dataSetModel)
+bool checkItems(int line,
+                const QList<vtkAbstractArray*>& expectedAttributeArrays,
+                ctkVTKDataSetModel* dataSetModel,
+                QMap<vtkAbstractArray*, int> locations)
 {
   foreach(vtkAbstractArray* expectedDataArray, expectedAttributeArrays)
     {
@@ -64,15 +69,27 @@ bool checkItems(int line, const QList<vtkAbstractArray*>& expectedAttributeArray
                    "\tCurrent: " << currentDataArray << "\n";
       return false;
       }
+
+    int loc = dataSetModel->locationFromItem(items.at(0));
+    if (locations[expectedDataArray] != loc)
+      {
+      std::cerr << "Line " << line << " - Problem with model - Incorrect location associated with item name:" << expectedDataArray->GetName() << "\n"
+                   "\tExpected: " << locations[expectedDataArray] << "\n"
+                   "\tCurrent: " << loc << "\n";
+      return false;
+      }
     }
   return true;
 }
-}
+
+} // end namespace
 
 //-----------------------------------------------------------------------------
 int ctkVTKDataSetModelTest1(int argc, char * argv [] )
 {
   QApplication app(argc, argv);
+
+  QMap<vtkAbstractArray*, int> locations;
 
   vtkNew<vtkPolyData> dataSet;
 
@@ -80,6 +97,7 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
   {
     ints->SetName("Ints");
     int added = dataSet->GetPointData()->AddArray(ints.GetPointer());
+    locations[ints.GetPointer()] = vtkAssignAttribute::POINT_DATA;
     if (added == -1)
       {
       std::cerr << "Line " << __LINE__ << " - Failed to add Ints array";
@@ -91,6 +109,7 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
   {
     floats->SetName("Floats");
     int added = dataSet->GetCellData()->AddArray(floats.GetPointer());
+    locations[floats.GetPointer()] = vtkAssignAttribute::CELL_DATA;
     if (added == -1)
       {
       std::cerr << "Line " << __LINE__ << " - Failed to add Floats array";
@@ -102,6 +121,7 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
   {
     strings->SetName("Strings");
     int added = dataSet->GetCellData()->AddArray(strings.GetPointer());
+    locations[strings.GetPointer()] = vtkAssignAttribute::CELL_DATA;
     if (added == -1)
       {
       std::cerr << "Line " << __LINE__ << " - Failed to add Strings array";
@@ -114,6 +134,7 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
     scalars->SetName("Scalars");
     scalars->SetNumberOfComponents(0);
     int added = dataSet->GetPointData()->SetScalars(scalars.GetPointer());
+    locations[scalars.GetPointer()] = vtkAssignAttribute::POINT_DATA;
     if (added == -1)
       {
       std::cerr << "Line " << __LINE__ << " - Failed to add Scalars array";
@@ -126,6 +147,7 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
     vectors->SetNumberOfComponents(3);
     vectors->SetName("Vectors");
     int added = dataSet->GetPointData()->SetVectors(vectors.GetPointer());
+    locations[vectors.GetPointer()] = vtkAssignAttribute::POINT_DATA;
     if (added == -1)
       {
       std::cerr << "Line " << __LINE__ << " - Failed to add Vectors array";
@@ -138,6 +160,7 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
     normals->SetNumberOfComponents(3);
     normals->SetName("Normals");
     int added = dataSet->GetPointData()->SetNormals(normals.GetPointer());
+    locations[normals.GetPointer()] = vtkAssignAttribute::POINT_DATA;
     if (added == -1)
       {
       std::cerr << "Line " << __LINE__ << " - Failed to add Normals array";
@@ -150,6 +173,7 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
     tcoords->SetNumberOfComponents(3);
     tcoords->SetName("Tcoords");
     int added = dataSet->GetPointData()->SetTCoords(tcoords.GetPointer());
+    locations[tcoords.GetPointer()] = vtkAssignAttribute::POINT_DATA;
     if (added == -1)
       {
       std::cerr << "Line " << __LINE__ << " - Failed to add Tcoords array";
@@ -162,6 +186,7 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
     tensors->SetNumberOfComponents(9);
     tensors->SetName("Tensors");
     int added = dataSet->GetPointData()->SetTensors(tensors.GetPointer());
+    locations[tensors.GetPointer()] = vtkAssignAttribute::POINT_DATA;
     if (added == -1)
       {
       std::cerr << "Line " << __LINE__ << " - Failed to add Tensors array";
@@ -174,6 +199,7 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
     globalids->SetNumberOfComponents(1);
     globalids->SetName("GlobalIDs");
     int added = dataSet->GetPointData()->SetGlobalIds(globalids.GetPointer());
+    locations[globalids.GetPointer()] = vtkAssignAttribute::POINT_DATA;
     if (added == -1)
       {
       std::cerr << "Line " << __LINE__ << " - Failed to add GlobalIDs array";
@@ -186,6 +212,7 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
     pedigreeids->SetNumberOfComponents(1);
     pedigreeids->SetName("PedigreeIDs");
     int added = dataSet->GetPointData()->SetPedigreeIds(pedigreeids.GetPointer());
+    locations[pedigreeids.GetPointer()] = vtkAssignAttribute::POINT_DATA;
     if (added == -1)
       {
       std::cerr << "Line " << __LINE__ << " - Failed to add PedigreeIDs array";
@@ -199,97 +226,112 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
   QList<vtkAbstractArray*> notAttributeArrays;
   notAttributeArrays << ints.GetPointer() << floats.GetPointer();
 
-  if (!checkItems(__LINE__, notAttributeArrays, &dataSetModel))
+  if (!checkItems(__LINE__, notAttributeArrays, &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::ScalarsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << scalars.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << scalars.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::NoAttribute | ctkVTKDataSetModel::ScalarsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << scalars.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << scalars.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::VectorsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << vectors.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << vectors.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::VectorsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << vectors.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << vectors.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::NoAttribute | ctkVTKDataSetModel::VectorsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << vectors.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << vectors.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::NormalsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << normals.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << normals.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::NoAttribute | ctkVTKDataSetModel::NormalsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << normals.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << normals.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::TCoordsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << tcoords.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << tcoords.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::NoAttribute | ctkVTKDataSetModel::TCoordsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << tcoords.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << tcoords.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::TensorsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << tensors.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << tensors.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::NoAttribute | ctkVTKDataSetModel::TensorsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << tensors.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << tensors.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::GlobalIDsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << globalids.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << globalids.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::NoAttribute | ctkVTKDataSetModel::GlobalIDsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << globalids.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << globalids.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::PedigreeIDsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << pedigreeids.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << pedigreeids.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
 
   dataSetModel.setAttributeTypes(ctkVTKDataSetModel::NoAttribute | ctkVTKDataSetModel::PedigreeIDsAttribute);
-  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << pedigreeids.GetPointer(), &dataSetModel))
+  if (!checkItems(__LINE__, QList<vtkAbstractArray*>() << notAttributeArrays << pedigreeids.GetPointer(),
+                  &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }
@@ -299,7 +341,7 @@ int ctkVTKDataSetModelTest1(int argc, char * argv [] )
                   << scalars.GetPointer() << vectors.GetPointer()
                   << normals.GetPointer() << tcoords.GetPointer()
                   << tensors.GetPointer() << globalids.GetPointer()
-                  << pedigreeids.GetPointer(), &dataSetModel))
+                  << pedigreeids.GetPointer(), &dataSetModel, locations))
     {
     return EXIT_FAILURE;
     }

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDataSetArrayComboBox.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDataSetArrayComboBox.cpp
@@ -42,6 +42,7 @@ public:
   int indexFromArray(vtkAbstractArray* dataArray)const;
   vtkAbstractArray* arrayFromIndex(int index)const;
   QString arrayNameFromIndex(int index)const;
+  int locationFromIndex(int index)const;
 };
 
 // --------------------------------------------------------------------------
@@ -97,6 +98,13 @@ QString ctkVTKDataSetArrayComboBoxPrivate::arrayNameFromIndex(int index)const
 }
 
 // --------------------------------------------------------------------------
+int ctkVTKDataSetArrayComboBoxPrivate::locationFromIndex(int index)const
+{
+  return this->dataSetModel()->locationFromIndex(
+    this->dataSetModel()->index(index, 0));
+}
+
+// --------------------------------------------------------------------------
 // ctkVTKDataSetArrayComboBox methods
 
 // --------------------------------------------------------------------------
@@ -125,6 +133,13 @@ QString ctkVTKDataSetArrayComboBox::currentArrayName()const
 {
   vtkAbstractArray* dataArray = this->currentArray();
   return dataArray ? dataArray->GetName() : "";
+}
+
+// --------------------------------------------------------------------------
+int ctkVTKDataSetArrayComboBox::currentArrayLocation()const
+{
+  Q_D(const ctkVTKDataSetArrayComboBox);
+  return d->locationFromIndex(this->currentIndex());
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDataSetArrayComboBox.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDataSetArrayComboBox.h
@@ -53,6 +53,11 @@ public:
   QString currentArrayName()const;
   vtkDataSet* dataSet()const;
 
+  /// Return the current array location, i.e. whether it's a point data
+  /// array or a cell data array.
+  /// \sa currentArrayChanged(int), ctkVTKDataSetModel::locationFromItem()
+  int currentArrayLocation()const;
+
   ctkVTKDataSetModel::AttributeTypes attributeTypes()const;
   void setAttributeTypes(const ctkVTKDataSetModel::AttributeTypes& attributeTypes);
 
@@ -72,6 +77,7 @@ public Q_SLOTS:
 Q_SIGNALS:
   void currentArrayChanged(vtkAbstractArray*);
   void currentArrayChanged(const QString& name);
+
 protected Q_SLOTS:
   void onCurrentIndexChanged(int);
 protected:

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDataSetModel.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDataSetModel.h
@@ -37,7 +37,8 @@ class vtkAbstractArray;
 namespace ctkVTK
 {
  enum ItemDataRole {
-   PointerRole = Qt::UserRole + 1
+   PointerRole = Qt::UserRole + 1,
+   LocationRole,
  };
 };
 
@@ -87,7 +88,19 @@ public:
   /// Return the vtkAbstractArray associated to the index.
   /// 0 if the index doesn't contain a vtkAbstractArray
   inline vtkAbstractArray* arrayFromIndex(const QModelIndex& arrayIndex)const;
+
+  /// Return the location from a given item. Fails and returns -1 if either
+  /// the given index points to a null item or an invisible item.
+  /// \sa locationFromItem()
+  inline int locationFromIndex(const QModelIndex& arrayIndex)const;
+
   vtkAbstractArray* arrayFromItem(QStandardItem* nodeItem)const;
+
+  /// Return the location from a given item. Fails and returns -1 if either
+  /// the given item is null or should be invisible).
+  /// \sa locationFromIndex(), invisibleRootItem()
+  int locationFromItem(QStandardItem* nodeItem)const;
+
   inline QModelIndex indexFromArray(vtkAbstractArray* array, int column = 0)const;
   QStandardItem* itemFromArray(vtkAbstractArray* array, int column = 0)const;
   QModelIndexList indexes(vtkAbstractArray* array)const;
@@ -101,9 +114,9 @@ protected:
 
   ctkVTKDataSetModel(ctkVTKDataSetModelPrivate* pimpl, QObject *parent=0);
 
-  virtual void insertArray(vtkAbstractArray* array);
-  virtual void insertArray(vtkAbstractArray* array, int row);
-  virtual void updateItemFromArray(QStandardItem* item, vtkAbstractArray* array, int column);
+  virtual void insertArray(vtkAbstractArray* array, int location);
+  virtual void insertArray(vtkAbstractArray* array, int location, int row);
+  virtual void updateItemFromArray(QStandardItem* item, vtkAbstractArray* array, int location, int column);
   virtual void updateArrayFromItem(vtkAbstractArray* array, QStandardItem* item);
   virtual void updateDataSet();
   virtual void populateDataSet();
@@ -121,6 +134,12 @@ Q_DECLARE_OPERATORS_FOR_FLAGS(ctkVTKDataSetModel::AttributeTypes);
 vtkAbstractArray* ctkVTKDataSetModel::arrayFromIndex(const QModelIndex &nodeIndex)const
 {
   return this->arrayFromItem(this->itemFromIndex(nodeIndex));
+}
+
+// -----------------------------------------------------------------------------
+int ctkVTKDataSetModel::locationFromIndex(const QModelIndex &nodeIndex)const
+{
+  return this->locationFromItem(this->itemFromIndex(nodeIndex));
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
When using both the cell data and the point data, one must be able to
know where the current array comes from to be able to appropriately use it
(for example with a vtkAssignAttribute filter).
This commits add the location, i.e. provenance of the array in the model's,
items along the corresponding functions for reading. No writing functions
were added as the location is completly related to the array itself.
Changing the array location probably doesn't make sense unless it's done
explicitly on the data.

This prompted a change on the ctkVTKDataSetArrayComboBox to add an read
methods on the current location.

The ctkVTKDataSetModel testing was modified accordingly.
