### PR TITLE
BUG: listen for unique signals from the title text property

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarBarWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarBarWidget.cpp
@@ -61,9 +61,22 @@ void ctkVTKScalarBarWidgetPrivate::init()
                    q, SLOT(setMaxNumberOfColors(int)));
   QObject::connect(this->NumberOfLabelsSpinBox, SIGNAL(valueChanged(int)),
                    q, SLOT(setNumberOfLabels(int)));
+
   QObject::connect(this->TitleTextPropertyWidget, SIGNAL(textChanged(QString)),
                    q, SLOT(setTitle(QString)));
-  
+  QObject::connect(this->TitleTextPropertyWidget, SIGNAL(colorChanged(QColor)),
+                   q, SIGNAL(modified()));
+  QObject::connect(this->TitleTextPropertyWidget, SIGNAL(opacityChanged(double)),
+                   q, SIGNAL(modified()));
+  QObject::connect(this->TitleTextPropertyWidget, SIGNAL(fontFamilyChanged(QString)),
+                   q, SIGNAL(modified()));
+  QObject::connect(this->TitleTextPropertyWidget, SIGNAL(boldChanged(bool)),
+                   q, SIGNAL(modified()));
+  QObject::connect(this->TitleTextPropertyWidget, SIGNAL(italicChanged(bool)),
+                   q, SIGNAL(modified()));
+  QObject::connect(this->TitleTextPropertyWidget, SIGNAL(shadowChanged(bool)),
+                   q, SIGNAL(modified()));
+
   QObject::connect(this->LabelsTextPropertyWidget, SIGNAL(textChanged(QString)),
                    q, SLOT(setLabelsFormat(QString)));
   QObject::connect(this->LabelsTextPropertyWidget, SIGNAL(colorChanged(QColor)),


### PR DESCRIPTION
Previous fix (see pull request 311) set up the scalar bar widget to listen for the new
unique signals from the text property widget and emit a modfieid,
but only for the labels. This change adds that functionality for
the title text property.
The ctkVTKScalarBarWidget now will emit a modified() signal when
the color, opacity, font, or font style changes for the title.
This fixes the bug that the vtkScalarBarActor wasn't updating
on changes in the ctkVTKScalarBarWidget Title section.

Slicer issue #3027
http://www.na-mic.org/Bug/view.php?id=3027
