### PR TITLE
#435 ENH: replaced query results tree view with DICOM table manager in ctkDICOMQueryRetrieveWidget

### DIFF
--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMQueryRetrieveWidget.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMQueryRetrieveWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>843</width>
-    <height>613</height>
+    <height>815</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -114,11 +114,17 @@
     </widget>
    </item>
    <item>
-    <widget class="QTreeView" name="results"/>
+    <widget class="ctkDICOMTableManager" name="dicomTableManager"/>
    </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>ctkDICOMTableManager</class>
+   <extends>QWidget</extends>
+   <header>ctkDICOMTableManager.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>ctkDICOMQueryWidget</class>
    <extends>QWidget</extends>

--- a/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.h
@@ -30,7 +30,7 @@
 #include <QVariant>
 #include <QString>
 
-
+class ctkDICOMTableManager;
 // CTK includes
 #include <ctkDICOMDatabase.h>
 
@@ -40,11 +40,14 @@ class ctkDICOMQueryRetrieveWidgetPrivate;
 class CTK_DICOM_WIDGETS_EXPORT ctkDICOMQueryRetrieveWidget : public QWidget
 {
 Q_OBJECT;
+Q_PROPERTY(ctkDICOMTableManager* dicomTableManager READ dicomTableManager)
 public:
   typedef QWidget Superclass;
   explicit ctkDICOMQueryRetrieveWidget(QWidget* parent=0);
   virtual ~ctkDICOMQueryRetrieveWidget();
   QMap<QString,QVariant> getServerParameters();
+
+  ctkDICOMTableManager* dicomTableManager();
 
   QSharedPointer<ctkDICOMDatabase> retrieveDatabase()const;
 
@@ -56,7 +59,6 @@ public Q_SLOTS:
   void query();
   void retrieve();
   void cancel();
-  void onSelectionChanged(const QItemSelection &, const QItemSelection &);
 
 Q_SIGNALS:
   /// Signal emit when studies have been retrieved (user clicked on the


### PR DESCRIPTION
 Replace the query results tree view with DICOM table manager  which provides the ability to select to individual studies for retrieve. Currently retrieve button is applied to all of the query results.
