### PR TITLE
Uses of obsolete class ctkXnatSessionFactory are removed

### DIFF
--- a/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
+++ b/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
@@ -71,7 +71,7 @@ void ctkXnatTreeBrowserMainWindow::loginButtonPushed()
   }
   else
   {
-    ctkXnatLoginDialog loginDialog(m_SessionFactory);
+    ctkXnatLoginDialog loginDialog;
     if (loginDialog.exec() == QDialog::Accepted)
     {
       m_Session = loginDialog.session();

--- a/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.h
+++ b/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.h
@@ -27,7 +27,6 @@
 class QModelIndex;
 
 class ctkXnatSession;
-class ctkXnatSessionFactory;
 class ctkXnatTreeModel;
 
 namespace Ui {
@@ -51,7 +50,6 @@ private Q_SLOTS:
 private:
   Ui::ctkXnatTreeBrowserMainWindow* ui;
 
-  ctkXnatSessionFactory* m_SessionFactory;
   ctkXnatSession* m_Session;
   ctkXnatTreeModel* m_TreeModel;
 };

--- a/Libs/XNAT/Widgets/ctkXnatLoginDialog.cpp
+++ b/Libs/XNAT/Widgets/ctkXnatLoginDialog.cpp
@@ -37,14 +37,12 @@
 class ctkXnatLoginDialogPrivate
 {
 public:
-  ctkXnatLoginDialogPrivate(ctkXnatSessionFactory* f)
-  : Factory(f)
+  ctkXnatLoginDialogPrivate()
   {
   }
 
   ctkXnatSettings* Settings;
 
-  ctkXnatSessionFactory* Factory;
   ctkXnatSession* Session;
 
   QMap<QString, ctkXnatLoginProfile*> Profiles;
@@ -56,10 +54,10 @@ public:
 };
 
 //----------------------------------------------------------------------------
-ctkXnatLoginDialog::ctkXnatLoginDialog(ctkXnatSessionFactory* f, QWidget* parent, Qt::WindowFlags flags)
+ctkXnatLoginDialog::ctkXnatLoginDialog(QWidget* parent, Qt::WindowFlags flags)
 : QDialog(parent, flags)
 , ui(0)
-, d_ptr(new ctkXnatLoginDialogPrivate(f))
+, d_ptr(new ctkXnatLoginDialogPrivate())
 {
   Q_D(ctkXnatLoginDialog);
 

--- a/Libs/XNAT/Widgets/ctkXnatLoginDialog.h
+++ b/Libs/XNAT/Widgets/ctkXnatLoginDialog.h
@@ -31,7 +31,6 @@
 #include "ctkXnatLoginProfile.h"
 
 class ctkXnatSession;
-class ctkXnatSessionFactory;
 class ctkXnatLoginDialogPrivate;
 class ctkXnatSettings;
 
@@ -43,7 +42,7 @@ class CTK_XNAT_WIDGETS_EXPORT ctkXnatLoginDialog : public QDialog
   Q_OBJECT
 
 public:
-  explicit ctkXnatLoginDialog(ctkXnatSessionFactory* f, QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  explicit ctkXnatLoginDialog(QWidget* parent = 0, Qt::WindowFlags flags = 0);
   virtual ~ctkXnatLoginDialog();
 
   ctkXnatSettings* settings() const;


### PR DESCRIPTION
The ctkXnatSessionFactory class has been removed from the ctkXNATCore library, but it was still used from ctkXNATWidgets and the tree browser application.
