### PR TITLE
Fix compilation of tests against VTK6

### DIFF
--- a/Libs/Visualization/VTK/Core/Testing/Cpp/vtkLightBoxRendererManagerTest1.cpp
+++ b/Libs/Visualization/VTK/Core/Testing/Cpp/vtkLightBoxRendererManagerTest1.cpp
@@ -215,7 +215,12 @@ int vtkLightBoxRendererManagerTest1(int argc, char* argv[])
     return EXIT_FAILURE;
     }
 
+
+#if (VTK_MAJOR_VERSION <= 5)
   lightBoxRendererManager->SetImageData(image);
+#else
+  lightBoxRendererManager->SetImageDataConnection(imagePort);
+#endif
   lightBoxRendererManager->SetRenderWindowLayout(4, 5);
   lightBoxRendererManager->SetHighlighted(2,2,true);
   lightBoxRendererManager->SetColorWindowAndLevel(100, 100);

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMagnifyViewTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMagnifyViewTest2.cpp
@@ -245,9 +245,9 @@ int ctkVTKMagnifyViewTest2(int argc, char * argv [] )
   imageReader->SetFileName(imageFilename.toLatin1());
   imageReader->Update();
 #if (VTK_MAJOR_VERSION <= 5)
-  vtkSmartPointer<vtkImageData> image = imageReader->GetOutput();
+  vtkImageData* image = imageReader->GetOutput();
 #else
-  vtkSmartPointer<vtkAlgorithmOutput> imagePort = imageReader->GetOutputPort();
+  vtkAlgorithmOutput* imagePort = imageReader->GetOutputPort();
 #endif
 
   // Setup the slice views

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest2.cpp
@@ -84,8 +84,13 @@ int ctkVTKSliceViewTest2(int argc, char * argv [] )
 
   // Read image
   imageReader->SetFileName(imageFilename.toLatin1());
+#if (VTK_MAJOR_VERSION <= 5)
   imageReader->Update();
-  vtkSmartPointer<vtkImageData> image = imageReader->GetOutput();
+  vtkImageData* image = imageReader->GetOutput();
+#else
+  imageReader->Update(); // XXX This shouldn't be needed. See issue #467
+  vtkAlgorithmOutput* imagePort = imageReader->GetOutputPort();
+#endif
 
   // Top level widget
   QWidget widget;
@@ -118,7 +123,11 @@ int ctkVTKSliceViewTest2(int argc, char * argv [] )
   ctkVTKSliceView * sliceView = new ctkVTKSliceView;
   sliceView->setRenderEnabled(true);
   sliceView->setMinimumSize(600, 600);
+#if (VTK_MAJOR_VERSION <= 5)
   sliceView->setImageData(image);
+#else
+  sliceView->setImageDataConnection(imagePort);
+#endif
   sliceView->setHighlightedBoxColor(QColor(Qt::yellow));
   sliceView->lightBoxRendererManager()->SetRenderWindowLayout(defaultRowCount, defaultColumnCount);
   sliceView->lightBoxRendererManager()->SetHighlighted(0, 0, true);


### PR DESCRIPTION
This commit allows CTK to be compiler against VTK6 with testing enabled.
That said, there are some tests failing to pass. Issues #467, #468, #469
and #471 track the failure most likely related to VTK6.
