### PR TITLE
ENH: Add static method to set multisampling

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.h
@@ -141,6 +141,18 @@ public:
   /// \sa useDepthPeeling
   bool useDepthPeeling()const;
 
+  /// Set multisampling default.
+  /// WARNING: Multisampling should be set *before* creation of the
+  /// OpenGL context (e.g., initializing the rendering window) in order
+  /// to have an effect. Consider using setUseMultisamples before
+  /// instantiating ctkVTKAbstractView objects.
+  /// \sa useMultiSamples
+  static void setUseMultiSamples(bool);
+
+  /// Return the current multisamples default
+  /// \sa setUseMultiSamples()
+  static bool useMultiSamples();
+
   virtual QSize minimumSizeHint()const;
   virtual QSize sizeHint()const;
   virtual bool hasHeightForWidth()const;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
@@ -65,6 +65,7 @@ public:
   bool                                          FPSVisible;
   QTimer*                                       FPSTimer;
   int                                           FPS;
+  static bool                                   UseMultiSamples;
 
   vtkSmartPointer<vtkCornerAnnotation>          CornerAnnotation;
 };


### PR DESCRIPTION
Suggested fix for enabling multisampling (FSAA). This should be done _before_ creating views, so having a static class method that one can call before instantiating objects seems like a decent way to go.

Closes #463.
