### PR TITLE
Fixes to enable specifying multisamples

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
@@ -37,7 +37,7 @@
 //--------------------------------------------------------------------------
 static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkVTKAbstractView");
 //--------------------------------------------------------------------------
-bool ctkVTKAbstractViewPrivate::UseMultiSamples = false;  // Default for static var
+int ctkVTKAbstractViewPrivate::MultiSamples = 0;  // Default for static var
 //--------------------------------------------------------------------------
 
 // --------------------------------------------------------------------------
@@ -100,11 +100,13 @@ void ctkVTKAbstractViewPrivate::setupRendering()
 {
   Q_ASSERT(this->RenderWindow);
   this->RenderWindow->SetAlphaBitPlanes(1);
-  const int maxSamples = vtkOpenGLRenderWindow::GetGlobalMaximumNumberOfMultiSamples();
-  this->RenderWindow->SetMultiSamples(
-      ctkVTKAbstractView::useMultiSamples() ? maxSamples : 0);
+  int nSamples = ctkVTKAbstractView::multiSamples();
+  if (nSamples < 0)
+    {
+    nSamples = vtkOpenGLRenderWindow::GetGlobalMaximumNumberOfMultiSamples();
+    }
+  this->RenderWindow->SetMultiSamples(nSamples);
   this->RenderWindow->StereoCapableWindowOn();
-
   this->VTKWidget->SetRenderWindow(this->RenderWindow);
 }
 
@@ -458,20 +460,23 @@ void ctkVTKAbstractView::setUseDepthPeeling(bool useDepthPeeling)
     return;
     }
   this->renderWindow()->SetAlphaBitPlanes( useDepthPeeling ? 1 : 0);
-  const int maxSamples = vtkOpenGLRenderWindow::GetGlobalMaximumNumberOfMultiSamples();
-  this->renderWindow()->SetMultiSamples(
-    (useDepthPeeling || !ctkVTKAbstractView::useMultiSamples()) ? 0 : maxSamples);
+  int nSamples = ctkVTKAbstractView::multiSamples();
+  if (nSamples < 0)
+    {
+    nSamples = vtkOpenGLRenderWindow::GetGlobalMaximumNumberOfMultiSamples();
+    }
+  this->renderWindow()->SetMultiSamples(useDepthPeeling ? 0 : nSamples);
   renderer->SetUseDepthPeeling(useDepthPeeling ? 1 : 0);
 }
 
 //----------------------------------------------------------------------------
-bool ctkVTKAbstractView::useMultiSamples()
+int ctkVTKAbstractView::multiSamples()
 {
-  return ctkVTKAbstractViewPrivate::UseMultiSamples;
+  return ctkVTKAbstractViewPrivate::MultiSamples;
 }
 
 //----------------------------------------------------------------------------
-void ctkVTKAbstractView::setUseMultiSamples(bool use)
+void ctkVTKAbstractView::setMultiSamples(int number)
 {
-  ctkVTKAbstractViewPrivate::UseMultiSamples = use;
+  ctkVTKAbstractViewPrivate::MultiSamples = number;
 }

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.h
@@ -141,17 +141,20 @@ public:
   /// \sa useDepthPeeling
   bool useDepthPeeling()const;
 
-  /// Set multisampling default.
+  /// Set the default number of multisamples to use. Note that a negative
+  /// value means "auto", which means the renderer will attempt to select
+  /// the maximum number (but is not guaranteed to work).
+  ///
   /// WARNING: Multisampling should be set *before* creation of the
   /// OpenGL context (e.g., initializing the rendering window) in order
-  /// to have an effect. Consider using setUseMultisamples before
+  /// to have an effect. Consider using setMultisamples before
   /// instantiating ctkVTKAbstractView objects.
-  /// \sa useMultiSamples
-  static void setUseMultiSamples(bool);
+  /// \sa multiSamples
+  static void setMultiSamples(int);
 
   /// Return the current multisamples default
-  /// \sa setUseMultiSamples()
-  static bool useMultiSamples();
+  /// \sa setMultiSamples()
+  static int multiSamples();
 
   virtual QSize minimumSizeHint()const;
   virtual QSize sizeHint()const;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
@@ -65,7 +65,7 @@ public:
   bool                                          FPSVisible;
   QTimer*                                       FPSTimer;
   int                                           FPS;
-  static bool                                   UseMultiSamples;
+  static int                                    MultiSamples;
 
   vtkSmartPointer<vtkCornerAnnotation>          CornerAnnotation;
 };


### PR DESCRIPTION
Change behavior of multisampling defaults to allow specifically
setting the number of samples to use (instead of boolean on or off).
