### PR TITLE
Fix virtual dtor warnings

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKPropertyWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKPropertyWidget.cpp
@@ -38,7 +38,7 @@ protected:
 public:
   ctkVTKPropertyWidgetPrivate(ctkVTKPropertyWidget& object);
 
-  virtual void setupUi(QWidget *widget);
+  void setupUi(QWidget *widget);
 
   vtkSmartPointer<vtkProperty> Property;
 };

--- a/Libs/Widgets/ctkSimpleLayoutManager.h
+++ b/Libs/Widgets/ctkSimpleLayoutManager.h
@@ -31,6 +31,7 @@ class ctkSimpleLayoutManagerPrivate;
 /// \ingroup Widgets
 struct ctkWidgetInstanciator
 {
+  virtual ~ctkWidgetInstanciator() {}
   virtual void beginSetupLayout(){}
   virtual void endSetupLayout(){}
   virtual QWidget* createWidget() = 0;


### PR DESCRIPTION
Fix warnings about classes with virtual methods but non-virtual dtors by adding a virtual dtor to `ctkWidgetInstanciator`, and removing a gratuitous `virtual` from `ctkVTKPropertyWidgetPrivate`.
