### PR TITLE
ctkDICOMQueryRetrieveWidget::getServerParameters() definition added back

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
@@ -435,5 +435,12 @@ void ctkDICOMQueryRetrieveWidget::updateRetrieveProgress(int value)
 ctkDICOMTableManager* ctkDICOMQueryRetrieveWidget::dicomTableManager()
 {
   Q_D(ctkDICOMQueryRetrieveWidget);
-    return d->dicomTableManager;
+  return d->dicomTableManager;
+}
+
+//----------------------------------------------------------------------------
+QMap<QString,QVariant> ctkDICOMQueryRetrieveWidget::getServerParameters()
+{
+  Q_D(ctkDICOMQueryRetrieveWidget);
+  return d->ServerNodeWidget->parameters();
 }


### PR DESCRIPTION
The last commit on this file removed the definition of this function,
but left its declaration in the header file what caused linker error
with MITK that requires this function.
