### PR TITLE
BUG: Prevent VTK render call in ctkVTKRenderView::setupRendering

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp
@@ -76,11 +76,6 @@ void ctkVTKRenderViewPrivate::setupRendering()
   // Add renderer
   this->RenderWindow->AddRenderer(this->Renderer);
   this->ctkVTKAbstractViewPrivate::setupRendering();
-  // The interactor in RenderWindow exists after the renderwindow is set to
-  // the QVTKWidet
-  this->Orientation->SetInteractor(this->RenderWindow->GetInteractor());
-  this->Orientation->SetEnabled(1);
-  this->Orientation->InteractiveOff();
 }
 
 //----------------------------------------------------------------------------
@@ -205,6 +200,12 @@ ctkVTKRenderView::ctkVTKRenderView(QWidget* parentWidget)
 {
   Q_D(ctkVTKRenderView);
   d->init();
+
+  // The interactor in RenderWindow exists after the renderwindow is set to
+  // the QVTKWidet
+  d->Orientation->SetInteractor(d->RenderWindow->GetInteractor());
+  d->Orientation->SetEnabled(1);
+  d->Orientation->InteractiveOff();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes error reported below by moving the call to
"InteractiveOff" in the setOrientationWidgetVisible() method.

//------
invalid drawable

ERROR: In /path/to/Rendering/OpenGL/vtkOpenGLRenderer.cxx, line 1202
vtkOpenGLRenderer (0x7ff6f45225e0): failed after Clear 1 OpenGL errors detected
  0 : (1286) Invalid framebuffer operation
//------

As suggested in [1], this change was needed because:

  (1) (after enabling the widget) calling "InteractiveOff()"
implies a call to vtkRenderWindow::Render()

and

  (2) changing the interactivity of the widget when the widget is
disabled lead to a warning [2].

This solution is sub-optimal because the user of the widget will have
to make sure that he updates the marker visibility after the RenderWindow
has been initialized.

[1] http://www.vtk.org/Wiki/VTK/OpenGL_Errors#Apple_Mac_OSX

[2] https://github.com/Kitware/VTK/blob/5e5b0e99ba4c6ea36ad97800f95edaf5f9737f2a/Interaction/Widgets/vtkOrientationMarkerWidget.cxx#L531
