### PR TITLE
Fix qMRMLSliceControllerWidgetEventTranslatorPlayerTest1 on MacOSX

### DIFF
--- a/Libs/Widgets/ctkBasePopupWidget.cpp
+++ b/Libs/Widgets/ctkBasePopupWidget.cpp
@@ -437,10 +437,12 @@ void ctkBasePopupWidgetPrivate::hideAll()
   // Before hiding, transfer the active window flag to its parent, this will
   // prevent the application to send a ApplicationDeactivate signal that
   // doesn't need to be done.
+#ifndef Q_OS_MAC // See Slicer issue #3850
   if (q->isActiveWindow() && !this->BaseWidget.isNull())
     {
     qApp->setActiveWindow(this->BaseWidget->window());
     }
+#endif
 
   q->hide();
   this->PopupPixmapWidget->hide();


### PR DESCRIPTION
On MacOSX, Slicer test qMRMLSliceControllerWidgetEventTranslatorPlayerTest1
was failing with the backtrace reported below. This commit skips the
faulty call on MacOSX.

For more details, see http://na-mic.org/Mantis/view.php?id=3850

// -----------
0  0x00000001127ea248 in QWidgetPrivate::reparentFocusWidgets ()
1  0x00000001127fe296 in QWidget::setParent ()
2  0x0000000112800ff1 in QWidgetPrivate::init ()
3  0x00000001128013a0 in QWidget::QWidget ()
4  0x0000000112c21551 in QFocusFrame::QFocusFrame ()
5  0x000000011276e124 in QMacStyle::event ()
6  0x00000001127a45ed in QApplicationPrivate::notify_helper ()
7  0x00000001127aac64 in QApplication::notify ()
8  0x00000001136e5bdc in QCoreApplication::notifyInternal ()
9  0x00000001127a8151 in QApplicationPrivate::setFocusWidget ()
10 0x00000001127f4a07 in QWidget::setFocus ()
11 0x00000001127aa2d5 in QApplication::setActiveWindow ()
12 0x00000001049c7fac in ctkBasePopupWidgetPrivate::hideAll (this=0x11ce47010) at /Volumes/Dashboard
s/Experimental/Slicer-Superbuild-Experimental-VTK6/CTK/Libs/Widgets/ctkBasePopupWidget.cpp:442
13 0x0000000104a55613 in ctkPopupWidgetPrivate::temporarilyHiddenOn (this=0x11ce47010) at /Volumes/D
ashboards/Experimental/Slicer-Superbuild-Experimental-VTK6/CTK/Libs/Widgets/ctkPopupWidget.cpp:237
14 0x0000000104a5682e in ctkPopupWidget::eventFilter (this=0x11ce211a0, obj=0x11ce482d0, event=0x7ff
f5fbfefa0) at /Volumes/Dashboards/Experimental/Slicer-Superbuild-Experimental-VTK6/CTK/Libs/Widgets/
ctkPopupWidget.cpp:463
15 0x00000001136e5687 in QCoreApplicationPrivate::sendThroughObjectEventFilters ()
16 0x00000001127a45be in QApplicationPrivate::notify_helper ()
17 0x00000001127aac64 in QApplication::notify ()
18 0x00000001136e5bdc in QCoreApplication::notifyInternal ()
19 0x00000001127f7de5 in QWidgetPrivate::hideChildren ()
20 0x00000001127f7cea in QWidgetPrivate::hideChildren ()
21 0x00000001127f7cea in QWidgetPrivate::hideChildren ()
22 0x00000001127f7f5c in QWidgetPrivate::hide_helper ()
23 0x00000001127fdf79 in QWidget::setVisible ()
24 0x00000001127f6f28 in QWidgetPrivate::close_helper ()
25 0x00000001127f7aef in QWidget::~QWidget ()
26 0x00000001028e892d in ctkEventTranslatorPlayerWidget::~ctkEventTranslatorPlayerWidget (this=0x7ff
f5fbff4c0) at /Volumes/Dashboards/Experimental/Slicer-Superbuild-Experimental-VTK6/CTK/Libs/QtTestin
g/ctkEventTranslatorPlayerWidget.cpp:78
27 0x00000001028e8885 in ctkEventTranslatorPlayerWidget::~ctkEventTranslatorPlayerWidget (this=0x7ff
f5fbff4c0) at /Volumes/Dashboards/Experimental/Slicer-Superbuild-Experimental-VTK6/CTK/Libs/QtTestin
g/ctkEventTranslatorPlayerWidget.cpp:75
28 0x0000000100084231 in qMRMLSliceControllerWidgetEventTranslatorPlayerTest1 (argc=2, argv=0x7fff5f
bff5e0) at /Volumes/Dashboards/Experimental/Slicer-1/Libs/MRML/Widgets/Testing/qMRMLSliceControllerW
idgetEventTranslatorPlayerTest1.cxx:86
29 0x0000000100037f53 in main (ac=2, av=0x7fff5fbff5e0) at /Volumes/Dashboards/Experimental/Slicer-S
uperbuild-Experimental-VTK6/Slicer-build/Libs/MRML/Widgets/Testing/qMRMLWidgetsCppTests.cxx:591