### PR TITLE
BUG: Fixed missing list elements problem

### DIFF
--- a/Libs/Widgets/ctkMenuComboBox.cpp
+++ b/Libs/Widgets/ctkMenuComboBox.cpp
@@ -248,7 +248,7 @@ void ctkMenuComboBoxPrivate::addActionToCompleter(QAction *action)
     this->SearchCompleter->sourceModel());
   Q_ASSERT(model);
   QModelIndex start = model->index(0,0);
-  QModelIndexList indexList = model->match(start, 0, action->text());
+  QModelIndexList indexList = model->match(start, 0, action->text(), 1, Qt::MatchFixedString|Qt::MatchWrap);
   if (indexList.count())
     {
     return;


### PR DESCRIPTION
When there are two strings with the only difference that one is longer (e.g., "Label Statistics" and "Label Statistics (BRAINS)") then one of them is missing from the search results.

The problem was that QAbstractItemModel::match was used for checking if the string is already in the model and by default Match uses Qt::MatchStartsWith option.

Fixed by using Qt::MatchFixedString.
