### PR TITLE
Fix DCMTK build on mac

### DIFF
--- a/CMakeExternals/DCMTK.cmake
+++ b/CMakeExternals/DCMTK.cmake
@@ -52,7 +52,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     BINARY_DIR ${proj}-build
     PREFIX ${proj}${ep_suffix}
     ${location_args}
-    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
     CMAKE_ARGS
       -DDCMTK_INSTALL_BINDIR:STRING=bin/${CMAKE_CFG_INTDIR}
       -DDCMTK_INSTALL_LIBDIR:STRING=lib/${CMAKE_CFG_INTDIR}
@@ -72,7 +72,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )
-  set(DCMTK_DIR ${ep_install_dir})
+  set(DCMTK_DIR ${CMAKE_CURRENT_BINARY_DIR}/${proj}-build)
 
 else()
   ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})


### PR DESCRIPTION
On Mac it happens that the ctkDICOM2 application cannot be started because certain dcmtk libraries were not found. The reason therefor is, that the dcmtk libraries were installed e.g. into CMakeExternals/Install. This location is then used as DCMTK_DIR and thus these libraries are used for linking. However these libs do not have the correct install name but the ones which are located in the DCMTK-build directory. These should be used for linking.
