### PR TITLE
Allow CTK PythonQt python module to be imported outside of a Qt applicat...

### DIFF
--- a/CMake/ctkMacroWrapPythonQtModuleInit.cpp.in
+++ b/CMake/ctkMacroWrapPythonQtModuleInit.cpp.in
@@ -3,6 +3,8 @@
 #include <PythonQt.h>
 #include <Python.h>
 
+#include <QCoreApplication>
+
 //-----------------------------------------------------------------------------
 static PyMethodDef Py@TARGET_CONFIG@PythonQt_ClassMethods[] = {
 {NULL, NULL, 0, NULL}};
@@ -52,6 +54,12 @@ void copyAttributes(PyObject* orig_module, PyObject* dest_module)
 //-----------------------------------------------------------------------------
 void init@TARGET_CONFIG@PythonQt()
 {
+
+  if (!QCoreApplication::instance())
+    {
+    PythonQt::init(PythonQt::PythonAlreadyInitialized);
+    }
+
   static const char modulename[] = "@TARGET_CONFIG@PythonQt";
   PyObject *m;
 


### PR DESCRIPTION
...io,

On Linux, I was able to import the ctk module doing the following:

```
$ cd /path/to/CTK-build/CTK-build/bin
$ PYTHONPATH=./Python/ python
```

> > import ctk
> > import pprint as pp
> > pp.pprint(dir(ctk))
> > ['QAbstractButton',
> >  'QAbstractItemModel',
> >  [...]
> >  '**builtins**',
> >  '**doc**',
> >  '**file**',
> >  '**name**',
> >  '**package**',
> >  '**path**',
> >  'ctkActionsWidget',
> >  'ctkAddRemoveComboBox',
> >  'ctkAxesWidget',
> >  'ctkBasePopupWidget',
> >  'ctkButtonGroup',
> >  'ctkCallback',
> >  'ctkCheckBox',
> >  'ctkCheckBoxPixmaps',
> >  'ctkCheckableComboBox',
> >  'ctkCheckablePushButton',
> >  'ctkCollapsibleButton',
> >  'ctkCollapsibleGroupBox',
> >  'ctkColorDialog',
> >  'ctkColorPickerButton',
> >  'ctkComboBox',
> >  'ctkCommandLineParser',
> >  'ctkCompleter',
> >  'ctkConsole',
> >   [...]
