### PR TITLE
Fixed duplicate connection to Qt signal/slots in ctkDICOMTableView

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
@@ -382,7 +382,6 @@ void ctkDICOMTableView::setTableSectionSize(int size)
 {
   Q_D(ctkDICOMTableView);
   d->tblDicomDatabaseView->verticalHeader()->setDefaultSectionSize(size);
-  d->setUpTableView();
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
@@ -91,7 +91,7 @@ void ctkDICOMTableViewPrivate::init()
 
   if (this->dicomDatabase != 0)
     {
-      this->setUpTableView();
+      q->setDicomDataBase(this->dicomDatabase);
     }
 }
 
@@ -217,7 +217,13 @@ ctkDICOMTableView::~ctkDICOMTableView()
 void ctkDICOMTableView::setDicomDataBase(ctkDICOMDatabase *dicomDatabase)
 {
   Q_D(ctkDICOMTableView);
+
+  //Do nothing if no database is set
+  if (!dicomDatabase)
+    return;
+
   d->dicomDatabase = dicomDatabase;
+  d->setUpTableView();
   //Create connections for new database
   QObject::connect(d->dicomDatabase, SIGNAL(instanceAdded(const QString&)),
                    this, SLOT(onInstanceAdded()));


### PR DESCRIPTION
The reason was an unnecessary call of setUpTableView which performed the connection
to the signal/slots every time when invoked.