### PR TITLE
Check bitness using void ptr size instead of system processor name

### DIFF
--- a/CMake/ctkMacroBuildLib.cmake
+++ b/CMake/ctkMacroBuildLib.cmake
@@ -167,7 +167,7 @@ macro(ctkMacroBuildLib)
 
   # Library properties specific to STATIC build
   if(MY_LIBRARY_TYPE STREQUAL "STATIC")
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8) # 64-bit
       set_target_properties(${lib_name} PROPERTIES COMPILE_FLAGS "-fPIC")
     endif()
   endif()

--- a/CMake/ctkMacroBuildLibWrapper.cmake
+++ b/CMake/ctkMacroBuildLibWrapper.cmake
@@ -102,7 +102,7 @@ macro(ctkMacroBuildLibWrapper)
   add_library(${lib_name}PythonQt ${MY_WRAPPER_LIBRARY_TYPE} ${KIT_PYTHONQT_SRCS})
   target_link_libraries(${lib_name}PythonQt ${lib_name} ${my_EXTRA_PYTHON_LIBRARIES})
   if(MY_WRAPPER_LIBRARY_TYPE STREQUAL "STATIC")
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8) # 64-bit
       set_target_properties(${lib_name}PythonQt PROPERTIES COMPILE_FLAGS "-fPIC")
     endif()
   endif()


### PR DESCRIPTION
This approach is more robust and doesn't really on the system
processor name.
