### PR TITLE
BUG: Fixed issue of writing Python errors to stdout instead of stderr

### DIFF
--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
@@ -424,5 +424,5 @@ void ctkAbstractPythonManager::printStdout(const QString& text)
 //-----------------------------------------------------------------------------
 void ctkAbstractPythonManager::printStderr(const QString& text)
 {
-  std::cout << qPrintable(text);
+  std::cerr << qPrintable(text);
 }


### PR DESCRIPTION
ctkAbstractPythonManager::printStderr printed text on std::cout. Probably it's a copy-paste error (copied from the ctkAbstractPythonManager::printStdout method above)
