### PR TITLE
ENH: Use platform-specific EOL character in log file

### DIFF
--- a/Libs/Core/ctkFileLogger.cpp
+++ b/Libs/Core/ctkFileLogger.cpp
@@ -136,7 +136,7 @@ void ctkFileLogger::logMessage(const QString& msg)
     return;
     }
   QTextStream s(&f);
-  s << msg << "\n";
+  s << msg << endl;
   f.close();
 }
 


### PR DESCRIPTION
By default text files have \r\n ending on Windows and \n on Linux/Mac. The old implementation had \n end-of-line character hardcoded for all platforms.
On Windows, when trying to open a file (or copy-paste contents) that use \n as end-of-line character in a simple editor, such as Notepad, all the lines appear in one single line. This is very confusing for average users.
The fix uses the correct platform-specific end-of-line characters (\n or \r\n) instead of a hardcoded \n character.