### PR TITLE
Fixed pluginLoader.load() fail because of missing library dependencies.

### DIFF
--- a/Libs/PluginFramework/ctkPluginStorageSQL.cpp
+++ b/Libs/PluginFramework/ctkPluginStorageSQL.cpp
@@ -28,6 +28,7 @@
 #include "ctkPluginStorage_p.h"
 #include "ctkPluginFrameworkUtil_p.h"
 #include "ctkPluginFrameworkContext_p.h"
+#include "ctkScopedCurrentDir.h"
 #include "ctkServiceException.h"
 
 #include <QFileInfo>
@@ -425,6 +426,7 @@ void ctkPluginStorageSQL::insertArchive(QSharedPointer<ctkPluginArchiveSQL> pa, 
 
   // Load the plugin and cache the resources
 
+  ctkScopedCurrentDir scopedCurrentDir(QFileInfo(pa->getLibLocation()).path());
   QPluginLoader pluginLoader;
   pluginLoader.setLoadHints(getPluginLoadHints());
   pluginLoader.setFileName(pa->getLibLocation());


### PR DESCRIPTION
Used ctkAbstractPluginFactory.tpp as reference implementation. It sets current directory to plugin library directory for plugin dependencies to be properly found and loaded.

The problem led to crash of MITK-based application during startup if plugin database contained plugins data with old timestamps (this is possible if plugins were rebuilt from source). This caused CTK to choose code path through ctkPluginStorageSQL::insertArchive and fail because plugin dependencies were not found.