### PR TITLE
Xnat download refactoring integration

### DIFF
--- a/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
+++ b/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
@@ -28,6 +28,13 @@
 #include "ctkXnatDataModel.h"
 #include "ctkXnatProject.h"
 #include "ctkXnatFile.h"
+#include "ctkXnatResource.h"
+#include "ctkXnatScan.h"
+#include "ctkXnatScanFolder.h"
+#include "ctkXnatAssessor.h"
+#include "ctkXnatAssessorFolder.h"
+#include "ctkXnatReconstruction.h"
+#include "ctkXnatReconstructionFolder.h"
 
 ctkXnatTreeBrowserMainWindow::ctkXnatTreeBrowserMainWindow(QWidget *parent) :
   QMainWindow(parent),
@@ -92,9 +99,17 @@ void ctkXnatTreeBrowserMainWindow::loginButtonPushed()
 void ctkXnatTreeBrowserMainWindow::itemSelected(const QModelIndex &index)
 {
   ctkXnatObject* xnatObject = m_TreeModel->xnatObject(index);
-  ctkXnatFile* xnatFile = dynamic_cast<ctkXnatFile*>(xnatObject);
-  ui->downloadButton->setEnabled(xnatFile != 0);
-  ui->downloadLabel->setVisible(!(xnatFile != 0));
+  bool downloadable = false;
+  downloadable |= dynamic_cast<ctkXnatFile*>(xnatObject)!=NULL;
+  downloadable |= dynamic_cast<ctkXnatScan*>(xnatObject)!=NULL;
+  downloadable |= dynamic_cast<ctkXnatScanFolder*>(xnatObject)!=NULL;
+  downloadable |= dynamic_cast<ctkXnatAssessor*>(xnatObject)!=NULL;
+  downloadable |= dynamic_cast<ctkXnatAssessorFolder*>(xnatObject)!=NULL;
+  downloadable |= dynamic_cast<ctkXnatResource*>(xnatObject)!=NULL;
+  downloadable |= dynamic_cast<ctkXnatReconstruction*>(xnatObject)!=NULL;
+  downloadable |= dynamic_cast<ctkXnatReconstructionFolder*>(xnatObject)!=NULL;
+  ui->downloadButton->setEnabled(downloadable);
+  ui->downloadLabel->setVisible(!downloadable);
 }
 
 void ctkXnatTreeBrowserMainWindow::downloadButtonClicked()

--- a/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.ui
+++ b/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>377</width>
+    <width>409</width>
     <height>325</height>
    </rect>
   </property>
@@ -72,7 +72,7 @@
 font: 75 10pt &quot;Lucida Grande&quot;;</string>
         </property>
         <property name="text">
-         <string>Select a xnat file to download...</string>
+         <string>Select a xnat file, resource, scan, or scan folder to download...</string>
         </property>
        </widget>
       </item>
@@ -85,8 +85,8 @@ font: 75 10pt &quot;Lucida Grande&quot;;</string>
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>377</width>
-     <height>22</height>
+     <width>409</width>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">

--- a/Libs/XNAT/Core/ctkXnatAssessor.cpp
+++ b/Libs/XNAT/Core/ctkXnatAssessor.cpp
@@ -26,6 +26,7 @@
 #include "ctkXnatObjectPrivate.h"
 #include "ctkXnatDefaultSchemaTypes.h"
 
+#include <QDebug>
 
 //----------------------------------------------------------------------------
 class ctkXnatAssessorPrivate : public ctkXnatObjectPrivate
@@ -74,4 +75,14 @@ void ctkXnatAssessor::fetchImpl()
 {
   this->fetchResources();
   this->fetchResources("/out/resources");
+}
+
+//----------------------------------------------------------------------------
+void ctkXnatAssessor::downloadImpl(const QString& filename)
+{
+  qDebug() << "ctkXnatAssessor::downloadImpl(const QString& filename) not yet tested";
+  QString query = this->resourceUri() + "/files";
+  ctkXnatSession::UrlParameters parameters;
+  parameters["format"] = "zip";
+  this->session()->download(filename, query, parameters);
 }

--- a/Libs/XNAT/Core/ctkXnatAssessor.h
+++ b/Libs/XNAT/Core/ctkXnatAssessor.h
@@ -49,6 +49,8 @@ private:
 
   virtual void fetchImpl();
 
+  virtual void downloadImpl(const QString&);
+
   Q_DECLARE_PRIVATE(ctkXnatAssessor)
 };
 

--- a/Libs/XNAT/Core/ctkXnatAssessorFolder.cpp
+++ b/Libs/XNAT/Core/ctkXnatAssessorFolder.cpp
@@ -27,6 +27,8 @@
 #include "ctkXnatObjectPrivate.h"
 #include "ctkXnatSession.h"
 
+#include <QDebug>
+
 //----------------------------------------------------------------------------
 class ctkXnatAssessorFolderPrivate : public ctkXnatObjectPrivate
 {
@@ -84,4 +86,14 @@ void ctkXnatAssessorFolder::fetchImpl()
     
     this->add(assessor);
   }
+}
+
+//----------------------------------------------------------------------------
+void ctkXnatAssessorFolder::downloadImpl(const QString& filename)
+{
+  qDebug() << "ctkXnatExperiment::downloadImpl(const QString& filename) not yet tested";
+  QString query = this->resourceUri() + "/ALL/resources/files";
+  ctkXnatSession::UrlParameters parameters;
+  parameters["format"] = "zip";
+  this->session()->download(filename, query, parameters);
 }

--- a/Libs/XNAT/Core/ctkXnatAssessorFolder.h
+++ b/Libs/XNAT/Core/ctkXnatAssessorFolder.h
@@ -48,7 +48,7 @@ private:
 
   friend class qRestResult;
   virtual void fetchImpl();
-
+  virtual void downloadImpl(const QString&);
   Q_DECLARE_PRIVATE(ctkXnatAssessorFolder)
 };
 

--- a/Libs/XNAT/Core/ctkXnatDataModel.cpp
+++ b/Libs/XNAT/Core/ctkXnatDataModel.cpp
@@ -82,6 +82,13 @@ QString ctkXnatDataModel::childDataType() const
 }
 
 // --------------------------------------------------------------------------
+ctkXnatSession* ctkXnatDataModel::session() const
+{
+  Q_D(const ctkXnatDataModel);
+  return d->session;
+}
+
+// --------------------------------------------------------------------------
 void ctkXnatDataModel::fetchImpl()
 {
   Q_D(ctkXnatDataModel);
@@ -100,9 +107,8 @@ void ctkXnatDataModel::fetchImpl()
   }
 }
 
-// --------------------------------------------------------------------------
-ctkXnatSession* ctkXnatDataModel::session() const
+//----------------------------------------------------------------------------
+void ctkXnatDataModel::downloadImpl(const QString& filename)
 {
-  Q_D(const ctkXnatDataModel);
-  return d->session;
+  qDebug() << "ctkXnatDataModel::downloadImpl(const QString& filename) not yet implemented or not available by REST API";
 }

--- a/Libs/XNAT/Core/ctkXnatDataModel.h
+++ b/Libs/XNAT/Core/ctkXnatDataModel.h
@@ -55,6 +55,8 @@ private:
 
   virtual void fetchImpl();
 
+  virtual void downloadImpl(const QString&);
+
   Q_DECLARE_PRIVATE(ctkXnatDataModel)
 };
 

--- a/Libs/XNAT/Core/ctkXnatExperiment.cpp
+++ b/Libs/XNAT/Core/ctkXnatExperiment.cpp
@@ -168,3 +168,9 @@ void ctkXnatExperiment::fetchImpl()
 
   this->fetchResources();
 }
+
+//----------------------------------------------------------------------------
+void ctkXnatExperiment::downloadImpl(const QString& filename)
+{
+  qDebug() << "ctkXnatExperiment::downloadImpl(const QString& filename) not yet implemented or not available by REST API";
+}

--- a/Libs/XNAT/Core/ctkXnatExperiment.h
+++ b/Libs/XNAT/Core/ctkXnatExperiment.h
@@ -58,6 +58,8 @@ private:
 
   virtual void fetchImpl();
 
+  virtual void downloadImpl(const QString&);
+
   Q_DECLARE_PRIVATE(ctkXnatExperiment)
 };
 

--- a/Libs/XNAT/Core/ctkXnatFile.cpp
+++ b/Libs/XNAT/Core/ctkXnatFile.cpp
@@ -111,12 +111,6 @@ QString ctkXnatFile::resourceUri() const
 }
 
 //----------------------------------------------------------------------------
-void ctkXnatFile::download(const QString& filename)
-{
-  this->session()->download(this, filename);
-}
-
-//----------------------------------------------------------------------------
 void ctkXnatFile::upload(const QString& /*filename*/)
 {
 }
@@ -130,4 +124,11 @@ void ctkXnatFile::reset()
 //----------------------------------------------------------------------------
 void ctkXnatFile::fetchImpl()
 {
+}
+
+//----------------------------------------------------------------------------
+void ctkXnatFile::downloadImpl(const QString& filename)
+{
+  QString query = this->resourceUri();
+  this->session()->download(filename, query);
 }

--- a/Libs/XNAT/Core/ctkXnatFile.h
+++ b/Libs/XNAT/Core/ctkXnatFile.h
@@ -57,6 +57,7 @@ public:
   QString fileContent() const;
 
   void download(const QString& filename);
+
   void upload(const QString& filename);
 
   void reset();
@@ -69,6 +70,8 @@ public:
 private:
 
   virtual void fetchImpl();
+
+  virtual void downloadImpl(const QString&);
 
   Q_DECLARE_PRIVATE(ctkXnatFile)
 };

--- a/Libs/XNAT/Core/ctkXnatObject.cpp
+++ b/Libs/XNAT/Core/ctkXnatObject.cpp
@@ -296,8 +296,9 @@ ctkXnatSession* ctkXnatObject::session() const
 }
 
 //----------------------------------------------------------------------------
-void ctkXnatObject::download(const QString& /*zipFilename*/)
+void ctkXnatObject::download(const QString& filename)
 {
+  this->downloadImpl(filename);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/XNAT/Core/ctkXnatObject.h
+++ b/Libs/XNAT/Core/ctkXnatObject.h
@@ -127,7 +127,7 @@ public:
   /// Deletes the object on the XNAT server and removes it from its parent.
   void erase();
 
-  virtual void download(const QString&);
+  void download(const QString&);
   virtual void upload(const QString&);
 
   //QObject* asyncObject() const;
@@ -177,6 +177,9 @@ private:
 
   /// The implementation of the fetch mechanism, called by the fetch() function.
   virtual void fetchImpl() = 0;
+
+  /// The implementation of the download mechanism, called by the download(const QString&) function.
+  virtual void downloadImpl(const QString&) = 0;
 
   Q_DECLARE_PRIVATE(ctkXnatObject)
 };

--- a/Libs/XNAT/Core/ctkXnatProject.cpp
+++ b/Libs/XNAT/Core/ctkXnatProject.cpp
@@ -27,6 +27,8 @@
 #include "ctkXnatSession.h"
 #include "ctkXnatSubject.h"
 
+#include <QDebug>
+
 const QString ctkXnatProject::SECONDARY_ID = "secondary_ID";
 const QString ctkXnatProject::DESCRIPTION = "description";
 const QString ctkXnatProject::PI_FIRSTNAME = "pi_firstname";
@@ -162,4 +164,10 @@ void ctkXnatProject::fetchImpl()
     this->add(subject);
   }
   this->fetchResources();
+}
+
+//----------------------------------------------------------------------------
+void ctkXnatProject::downloadImpl(const QString& filename)
+{
+  qDebug() << "ctkXnatProject::downloadImpl(const QString& filename) not yet implemented or not available by REST API";
 }

--- a/Libs/XNAT/Core/ctkXnatProject.h
+++ b/Libs/XNAT/Core/ctkXnatProject.h
@@ -69,6 +69,8 @@ private:
 
   virtual void fetchImpl();
 
+  virtual void downloadImpl(const QString&);
+
   Q_DECLARE_PRIVATE(ctkXnatProject)
 };
 

--- a/Libs/XNAT/Core/ctkXnatReconstruction.cpp
+++ b/Libs/XNAT/Core/ctkXnatReconstruction.cpp
@@ -27,6 +27,7 @@
 #include "ctkXnatReconstructionFolder.h"
 #include "ctkXnatSession.h"
 
+#include <QDebug>
 
 //----------------------------------------------------------------------------
 class ctkXnatReconstructionPrivate : public ctkXnatObjectPrivate
@@ -90,4 +91,14 @@ void ctkXnatReconstruction::fetchImpl()
 
     this->add(reconstructionResource);
   }
+}
+
+//----------------------------------------------------------------------------
+void ctkXnatReconstruction::downloadImpl(const QString& filename)
+{
+  qDebug() << "ctkXnatReconstruction::downloadImpl(const QString& filename) not yet tested";
+  QString query = this->resourceUri() + "/files";
+  ctkXnatSession::UrlParameters parameters;
+  parameters["format"] = "zip";
+  this->session()->download(filename, query, parameters);
 }

--- a/Libs/XNAT/Core/ctkXnatReconstruction.h
+++ b/Libs/XNAT/Core/ctkXnatReconstruction.h
@@ -51,6 +51,8 @@ private:
 
   virtual void fetchImpl();
 
+  virtual void downloadImpl(const QString&);
+
   Q_DECLARE_PRIVATE(ctkXnatReconstruction)
 };
 

--- a/Libs/XNAT/Core/ctkXnatReconstructionFolder.cpp
+++ b/Libs/XNAT/Core/ctkXnatReconstructionFolder.cpp
@@ -27,6 +27,7 @@
 #include "ctkXnatReconstruction.h"
 #include "ctkXnatSession.h"
 
+#include <QDebug>
 
 //----------------------------------------------------------------------------
 class ctkXnatReconstructionFolderPrivate : public ctkXnatObjectPrivate
@@ -86,4 +87,14 @@ void ctkXnatReconstructionFolder::fetchImpl()
     this->add(reconstruction);
   }
 
+}
+
+//----------------------------------------------------------------------------
+void ctkXnatReconstructionFolder::downloadImpl(const QString& filename)
+{
+  qDebug() << "ctkXnatReconstructionFolder::downloadImpl(const QString& filename) not yet tested";
+  QString query = this->resourceUri() + "/ALL/resources/files";
+  ctkXnatSession::UrlParameters parameters;
+  parameters["format"] = "zip";
+  this->session()->download(filename, query, parameters);
 }

--- a/Libs/XNAT/Core/ctkXnatReconstructionFolder.h
+++ b/Libs/XNAT/Core/ctkXnatReconstructionFolder.h
@@ -50,6 +50,8 @@ private:
 
   virtual void fetchImpl();
 
+  virtual void downloadImpl(const QString&);
+
   Q_DECLARE_PRIVATE(ctkXnatReconstructionFolder)
 };
 

--- a/Libs/XNAT/Core/ctkXnatResource.cpp
+++ b/Libs/XNAT/Core/ctkXnatResource.cpp
@@ -119,7 +119,10 @@ void ctkXnatResource::fetchImpl()
 }
 
 //----------------------------------------------------------------------------
-void ctkXnatResource::download(const QString& filename)
+void ctkXnatResource::downloadImpl(const QString& filename)
 {
-  this->session()->download(this, filename);
+  QString query = this->resourceUri() + "/files";
+  ctkXnatSession::UrlParameters parameters;
+  parameters["format"] = "zip";
+  this->session()->download(filename, query, parameters);
 }

--- a/Libs/XNAT/Core/ctkXnatResource.h
+++ b/Libs/XNAT/Core/ctkXnatResource.h
@@ -65,7 +65,10 @@ public:
 private:
 
   friend class qRestResult;
+
   virtual void fetchImpl();
+
+  virtual void downloadImpl(const QString&);
 
   Q_DECLARE_PRIVATE(ctkXnatResource)
 

--- a/Libs/XNAT/Core/ctkXnatScan.cpp
+++ b/Libs/XNAT/Core/ctkXnatScan.cpp
@@ -31,6 +31,8 @@ const QString ctkXnatScan::QUALITY = "quality";
 const QString ctkXnatScan::SERIES_DESCRIPTION = "series_description";
 const QString ctkXnatScan::TYPE = "type";
 
+#include <QDebug>
+
 //----------------------------------------------------------------------------
 class ctkXnatScanPrivate : public ctkXnatObjectPrivate
 {
@@ -113,4 +115,13 @@ void ctkXnatScan::reset()
 void ctkXnatScan::fetchImpl()
 {
   this->fetchResources();
+}
+
+//----------------------------------------------------------------------------
+void ctkXnatScan::downloadImpl(const QString& filename)
+{
+  QString query = this->resourceUri() + "/files";
+  ctkXnatSession::UrlParameters parameters;
+  parameters["format"] = "zip";
+  this->session()->download(filename, query, parameters);
 }

--- a/Libs/XNAT/Core/ctkXnatScan.cpp
+++ b/Libs/XNAT/Core/ctkXnatScan.cpp
@@ -31,8 +31,6 @@ const QString ctkXnatScan::QUALITY = "quality";
 const QString ctkXnatScan::SERIES_DESCRIPTION = "series_description";
 const QString ctkXnatScan::TYPE = "type";
 
-#include <QDebug>
-
 //----------------------------------------------------------------------------
 class ctkXnatScanPrivate : public ctkXnatObjectPrivate
 {

--- a/Libs/XNAT/Core/ctkXnatScan.h
+++ b/Libs/XNAT/Core/ctkXnatScan.h
@@ -63,7 +63,10 @@ public:
 private:
 
   friend class qRestResult;
+
   virtual void fetchImpl();
+
+  virtual void downloadImpl(const QString&);
 
   Q_DECLARE_PRIVATE(ctkXnatScan)
 };

--- a/Libs/XNAT/Core/ctkXnatScanFolder.cpp
+++ b/Libs/XNAT/Core/ctkXnatScanFolder.cpp
@@ -27,8 +27,6 @@
 #include "ctkXnatScan.h"
 #include "ctkXnatSession.h"
 
-#include <QDebug>
-
 //----------------------------------------------------------------------------
 class ctkXnatScanFolderPrivate : public ctkXnatObjectPrivate
 {

--- a/Libs/XNAT/Core/ctkXnatScanFolder.cpp
+++ b/Libs/XNAT/Core/ctkXnatScanFolder.cpp
@@ -27,6 +27,8 @@
 #include "ctkXnatScan.h"
 #include "ctkXnatSession.h"
 
+#include <QDebug>
+
 //----------------------------------------------------------------------------
 class ctkXnatScanFolderPrivate : public ctkXnatObjectPrivate
 {
@@ -90,4 +92,13 @@ void ctkXnatScanFolder::fetchImpl()
     
     this->add(scan);
   }
+}
+
+//----------------------------------------------------------------------------
+void ctkXnatScanFolder::downloadImpl(const QString& filename)
+{
+  QString query = this->resourceUri() + "/ALL/files";
+  ctkXnatSession::UrlParameters parameters;
+  parameters["format"] = "zip";
+  this->session()->download(filename, query, parameters);
 }

--- a/Libs/XNAT/Core/ctkXnatScanFolder.h
+++ b/Libs/XNAT/Core/ctkXnatScanFolder.h
@@ -50,6 +50,7 @@ private:
 
   friend class qRestResult;
   virtual void fetchImpl();
+  virtual void downloadImpl(const QString&);
 
   Q_DECLARE_PRIVATE(ctkXnatScanFolder)
 };

--- a/Libs/XNAT/Core/ctkXnatSession.cpp
+++ b/Libs/XNAT/Core/ctkXnatSession.cpp
@@ -591,24 +591,14 @@ void ctkXnatSession::remove(ctkXnatObject* object)
 }
 
 //----------------------------------------------------------------------------
-void ctkXnatSession::download(ctkXnatFile* file, const QString& fileName)
-{
-  Q_D(ctkXnatSession);
-  QString query = file->resourceUri();
-
-  QUuid queryId = d->xnat->download(fileName, query);
-  d->xnat->sync(queryId);
-}
-
-//----------------------------------------------------------------------------
-void ctkXnatSession::download(ctkXnatResource* resource, const QString& fileName)
+void ctkXnatSession::download(const QString& fileName,
+    const QString& resource,
+    const UrlParameters& parameters,
+    const HttpRawHeaders& rawHeaders)
 {
   Q_D(ctkXnatSession);
 
-  QString query = resource->resourceUri() + "/files";
-  qRestAPI::Parameters parameters;
-  parameters["format"] = "zip";
-  QUuid queryId = d->xnat->download(fileName, query, parameters);
+  QUuid queryId = d->xnat->download(fileName, resource, parameters, rawHeaders);
   d->xnat->sync(queryId);
 }
 

--- a/Libs/XNAT/Core/ctkXnatSession.h
+++ b/Libs/XNAT/Core/ctkXnatSession.h
@@ -187,14 +187,25 @@ public:
   void save(ctkXnatObject* object);
   void remove(ctkXnatObject* object);
 
-  void download(ctkXnatFile* file, const QString& fileName);
+  /// Downloads a file from the web service.
+  /// \a fileName is the name of the output file.
+  /// The \a resource and \parameters are used to compose the URL.
+  /// \a rawHeaders can be used to set the raw headers of the request to send.
+  /// These headers will be set additionally to those defined by the
+  /// \a defaultRawHeaders property.
+  void download(const QString& fileName,
+    const QString& resource,
+    const UrlParameters& parameters = UrlParameters(),
+    const HttpRawHeaders& rawHeaders = HttpRawHeaders());
+
+  //ivo void download(ctkXnatFile* file, const QString& fileName);
 
 //  void downloadScanFiles(ctkXnatExperiment* experiment, const QString& zipFileName);
 //  void downloadReconstructionFiles(ctkXnatExperiment* experiment, const QString& zipFileName);
 
 //  void download(ctkXnatScan* scan, const QString& zipFileName);
 
-  void download(ctkXnatResource* resource, const QString& zipFileName);
+//  void download(ctkXnatResource* resource, const QString& zipFileName);
 
   /**
    * @brief Sends a http HEAD request to the xnat instance

--- a/Libs/XNAT/Core/ctkXnatSession.h
+++ b/Libs/XNAT/Core/ctkXnatSession.h
@@ -198,27 +198,12 @@ public:
     const UrlParameters& parameters = UrlParameters(),
     const HttpRawHeaders& rawHeaders = HttpRawHeaders());
 
-  //ivo void download(ctkXnatFile* file, const QString& fileName);
-
-//  void downloadScanFiles(ctkXnatExperiment* experiment, const QString& zipFileName);
-//  void downloadReconstructionFiles(ctkXnatExperiment* experiment, const QString& zipFileName);
-
-//  void download(ctkXnatScan* scan, const QString& zipFileName);
-
-//  void download(ctkXnatResource* resource, const QString& zipFileName);
-
   /**
    * @brief Sends a http HEAD request to the xnat instance
    * @param resourceUri the URL to the server
    * @return the query uid
    */
   QUuid httpHead(const QString& resourceUri);
-
-//  void downloadReconstruction(ctkXnatReconstruction* reconstruction, const QString& zipFilename);
-
-//  void downloadReconstructionResourceFiles(ctkXnatReconstructionResource* reconstructionResource, const QString& zipFilename);
-
-//  void download(ctkXnatReconstructionResourceFile* reconstructionResourceFile, const QString& zipFileName);
 
   /**
    * @brief Signals that the session was re-newed.

--- a/Libs/XNAT/Core/ctkXnatSubject.cpp
+++ b/Libs/XNAT/Core/ctkXnatSubject.cpp
@@ -27,6 +27,8 @@
 #include "ctkXnatProject.h"
 #include "ctkXnatSession.h"
 
+#include <QDebug>
+
 const QString ctkXnatSubject::INSERT_DATE = "insert_date";
 const QString ctkXnatSubject::INSERT_USER = "insert_user";
 
@@ -152,4 +154,10 @@ void ctkXnatSubject::fetchImpl()
     this->add(experiment);
   }
   this->fetchResources();
+}
+
+//----------------------------------------------------------------------------
+void ctkXnatSubject::downloadImpl(const QString& filename)
+{
+  qDebug() << "ctkXnatSubject::downloadImpl(const QString& filename) not yet implemented or not available by REST API";
 }

--- a/Libs/XNAT/Core/ctkXnatSubject.h
+++ b/Libs/XNAT/Core/ctkXnatSubject.h
@@ -76,6 +76,8 @@ private:
 
   virtual void fetchImpl();
 
+  virtual void downloadImpl(const QString&);
+
   Q_DECLARE_PRIVATE(ctkXnatSubject)
 };
 


### PR DESCRIPTION
Ivo refactored the download code of the XNAT API during the last hackfest.
A quick overview about the changes: The code for downloading was moved into the different xnatObjects similar to the fetch() function. Each xnat object has now its own implementation for downloading and the ctkXnatSession no longer has to provide specific implementations for the different object types.