### PR TITLE
Add FOLDER parameter to ctkMacroBuildQtPlugin

### DIFF
--- a/CMake/ctkMacroBuildQtPlugin.cmake
+++ b/CMake/ctkMacroBuildQtPlugin.cmake
@@ -27,7 +27,7 @@
 macro(ctkMacroBuildQtPlugin)
   cmake_parse_arguments(MY
     "" # no options
-    "NAME;EXPORT_DIRECTIVE;PLUGIN_DIR" # one value args
+    "NAME;EXPORT_DIRECTIVE;FOLDER;PLUGIN_DIR" # one value args
     "SRCS;MOC_SRCS;UI_FORMS;INCLUDE_DIRECTORIES;TARGET_LIBRARIES;RESOURCES" # multi value args
     ${ARGN}
     )
@@ -142,6 +142,10 @@ macro(ctkMacroBuildQtPlugin)
     ${QT_QTDESIGNER_LIBRARY}
     )
   target_link_libraries(${lib_name} ${my_libs})
+
+  if(NOT "${MY_FOLDER}" STREQUAL "")
+    set_target_properties(${lib_name} PROPERTIES FOLDER ${MY_FOLDER})
+  endif()
 
   # Install the library
   # CTK_INSTALL_QTPLUGIN_DIR:STRING can be passed when configuring CTK


### PR DESCRIPTION
If specified, the target(s) associated with designer, icon engine and
style plugins will be added into the specified folder when the project is
configured for an IDE supporting it.

For more details, see http://www.cmake.org/cmake/help/v2.8.9/cmake.html#prop_tgt:FOLDER