### PR TITLE
Update VTK to fix "garbage collection is no longer supported" error. See...

### DIFF
--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -25,7 +25,7 @@ endif()
 
 if(NOT DEFINED VTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
-  set(revision_tag d3b66526624ba8e55addcddb0ec28c40982473ac)
+  set(revision_tag f3f70ec0912cf836a3d5954a95cb04f0237fbdc4)
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()


### PR DESCRIPTION
... #534

Thanks to "towerbj" for reporting the problem and suggestion a fix.

$ git shortlog d3b6652..f3f70ec --no-merges
Dave DeMarle (3):
      backport a fix to 5.10 branch to fix vrml clang compilation
      fix the last fix
      bug 14180 silence icc and clang complaints about legacy

David Gobbi (1):
      BUG: Fix incorrect code detected by static analysis.

Sean McBride (1):
      Removed -fobjc-gc from VTK_REQUIRED_OBJCXX_FLAGS