### PR TITLE
ctkRangeSlider: always set clip rect when drawing slider handle

### DIFF
--- a/Libs/Widgets/ctkRangeSlider.cpp
+++ b/Libs/Widgets/ctkRangeSlider.cpp
@@ -280,12 +280,10 @@ void ctkRangeSliderPrivate::drawMinimumSlider( QStylePainter* painter ) const
     option.activeSubControls = QStyle::SC_SliderHandle;
     option.state |= QStyle::State_Sunken;
     }
-#ifdef Q_OS_MAC
   // On mac style, drawing just the handle actually draws also the groove.
   QRect clip = q->style()->subControlRect(QStyle::CC_Slider, &option,
                                           QStyle::SC_SliderHandle, q);
   painter->setClipRect(clip);
-#endif
   painter->drawComplexControl(QStyle::CC_Slider, option);
 }
 
@@ -305,12 +303,10 @@ void ctkRangeSliderPrivate::drawMaximumSlider( QStylePainter* painter ) const
     option.activeSubControls = QStyle::SC_SliderHandle;
     option.state |= QStyle::State_Sunken;
     }
-#ifdef Q_OS_MAC
   // On mac style, drawing just the handle actually draws also the groove.
   QRect clip = q->style()->subControlRect(QStyle::CC_Slider, &option,
                                           QStyle::SC_SliderHandle, q);
   painter->setClipRect(clip);
-#endif
   painter->drawComplexControl(QStyle::CC_Slider, option);
 }
 


### PR DESCRIPTION
In Qt 5 the drawComplexControl method always draws the complete slider
and thus drawing the maximum slider causes the minimum slider being
painted over.