### PR TITLE
BUG: Fixed VTK log message parsing regexp

### DIFF
--- a/Libs/Visualization/VTK/Core/ctkVTKErrorLogMessageHandler.cpp
+++ b/Libs/Visualization/VTK/Core/ctkVTKErrorLogMessageHandler.cpp
@@ -43,8 +43,10 @@ public:
   vtkTypeMacro(ctkVTKOutputWindow,vtkOutputWindow);
   void PrintSelf(ostream& os, vtkIndent indent);
 
-  ctkVTKOutputWindow():MessageHandler(0),
-    ContextRegExp("[a-zA-Z\\s]+: In (.+), line ([\\d]+)\\n(.+\\(0x[a-fA-F0-9]+\\))\\:\\s(.*)"){}
+  ctkVTKOutputWindow()
+    : MessageHandler(0)
+    , ContextRegExp("[a-zA-Z\\s]+: In (.+), line ([\\d]+)\\n(.+\\((?:0x)?[a-fA-F0-9]+\\))\\:\\s(.*)")
+  {}
   ~ctkVTKOutputWindow(){}
 
   virtual void DisplayText(const char*);
@@ -77,10 +79,14 @@ void ctkVTKOutputWindow::PrintSelf(ostream& os, vtkIndent indent)
 void ctkVTKOutputWindow::DisplayText(const char* text)
 {
   Q_ASSERT(this->MessageHandler);
+
+  ctkErrorLogContext context;
+  QString textOnly = this->parseText(text, context);
+
   this->MessageHandler->handleMessage(
         ctk::qtHandleToString(QThread::currentThreadId()),
         ctkErrorLogLevel::Info,
-        this->MessageHandler->handlerPrettyName(), ctkErrorLogContext(), text);
+        this->MessageHandler->handlerPrettyName(), context, textOnly);
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
0x prefix is not printed before object address on Windows, with latest VTK, therefore the 0x prefix is now optional before the address.

Added parsing of messages logged using DisplayText() to allow logging full context, such as file name, line number, etc. for informational messages.