### PR TITLE
STYLE ensure that the current selection in the tableView isn't cleared

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
@@ -108,6 +108,8 @@ void ctkDICOMTableViewPrivate::setUpTableView()
       this->tblDicomDatabaseView->setModel(this->dicomSQLFilterModel);
       this->tblDicomDatabaseView->setColumnHidden(0, true);
       this->tblDicomDatabaseView->setSortingEnabled(true);
+      // ensure that the current selection isn't cleared by clicking outside the existing rows of this tableView
+      this->tblDicomDatabaseView->setSelectionMode(QAbstractItemView::MultiSelection);
 #if QT_VERSION < QT_VERSION_CHECK(5,0,0)
       this->tblDicomDatabaseView->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
 #else


### PR DESCRIPTION
Current fix ensures that the clicking outside the rows of this tableView doesn't clear the existing selection