### PR TITLE
BUG: Fixed Console Shift+Home behavior

### DIFF
--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -268,8 +268,19 @@ void ctkConsolePrivate::keyPressEvent(QKeyEvent* e)
         break;
 
       case Qt::Key_Home:
+        // Need to override the default behavior because we want to jump to right after the prompt and
+        // not to the first character in the line (beginning of the prompt).
         e->accept();
-        text_cursor.setPosition(this->InteractivePosition);
+        if (e->modifiers() & Qt::ShiftModifier)
+          {
+          // Shift+Home - SelectStartOfLine: select from the first character to the current position
+          text_cursor.setPosition(this->InteractivePosition, QTextCursor::KeepAnchor);
+          }
+        else
+          {
+          // Home - MoveToStartOfLine: jump to first character
+          text_cursor.setPosition(this->InteractivePosition);
+          }
         this->setTextCursor(text_cursor);
         break;
 

--- a/Libs/Widgets/ctkConsole_p.h
+++ b/Libs/Widgets/ctkConsole_p.h
@@ -44,6 +44,8 @@ public:
 
   void init();
 
+  static bool isMoveLeftWithinLine(QKeyEvent* e, QTextCursor::MoveOperation &moveOperation, QTextCursor::MoveMode &moveMode);
+
   virtual void keyPressEvent(QKeyEvent* e);
 
   void switchToUserInputTextColor(QTextCursor* textCursorToUpdate = 0);


### PR DESCRIPTION
The console had an annoying bug: Shift+Home did not select text up to the start of line, just jumped to the start of line
(while Shift+End already properly selected text up to the end of line).

The problem was that Home key handling was overridden (to jump to the end of the prompt instead of start of line) but the Shift modifier was ignored.