### PR TITLE
BUG: Enable Ctrl-C shortcut in Python console in the history area

### DIFF
--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -296,7 +296,13 @@ void ctkConsolePrivate::keyPressEvent(QKeyEvent* e)
     }
 
   // Force the cursor back to the interactive area if anything else than copy/paste or page up/down is done
-  if(history_area)
+  // but only when a "real" key is pressed, not just a modifier (otherwise we could not press Control-c in the
+  // history area because the cursor would jump to the interactive area immediately when Control is pressed)
+  if(history_area
+       && e->key() != Qt::Key_Control
+       && e->key() != Qt::Key_Meta
+       && e->key() != Qt::Key_Alt
+       && e->key() != Qt::Key_Shift)
     {
     text_cursor.setPosition(this->documentEnd());
     this->setTextCursor(text_cursor);


### PR DESCRIPTION
Pressing Ctrl in the history area immediately jumped to the interactive area, essentially making Ctrl-C unavailable in the history area. Now we don't jump immediately to the interactive area if only a modifier key is pressed. This was the old behavior but factored out as part of the Python console simplification; but it has turned out it was actually necessary.