### PR TITLE
ctkSearchBoxTest1: Fix build error

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkSearchBoxTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSearchBoxTest1.cpp
@@ -38,8 +38,8 @@ int ctkSearchBoxTest1(int argc, char* argv[])
   QApplication app(argc, argv);
 
   QPalette p;
-  p.setColor(QPalette::ColorRole::Window, Qt::gray);
-  p.setColor(QPalette::ColorRole::Base, Qt::gray);
+  p.setColor(QPalette::Window, Qt::gray);
+  p.setColor(QPalette::Base, Qt::gray);
 
   ctkSearchBox search;
   search.setShowSearchIcon(true);


### PR DESCRIPTION
This commit fixes a regression introduced in 400eb23 (Add white border to
clear icon)

The build error was happening on Ubuntu 14.04.2 using gcc 4.8.2:

```
/path/to/CTK/Libs/Widgets/Testing/Cpp/ctkSearchBoxTest1.cpp: In function ‘int ctkSearchBoxTest1(int, char**)’:
/path/to/CTK/Libs/Widgets/Testing/Cpp/ctkSearchBoxTest1.cpp:41:24: error: ‘QPalette::ColorRole’ is not a class or namespace
   p.setColor(QPalette::ColorRole::Window, Qt::gray);
                        ^
/path/to/CTK/Libs/Widgets/Testing/Cpp/ctkSearchBoxTest1.cpp:42:24: error: ‘QPalette::ColorRole’ is not a class or namespace
   p.setColor(QPalette::ColorRole::Base, Qt::gray);
```