### PR TITLE
Do not override widget visibility if already set in a layout view factory

### DIFF
--- a/Libs/Widgets/ctkLayoutFactory.cpp
+++ b/Libs/Widgets/ctkLayoutFactory.cpp
@@ -160,8 +160,12 @@ void ctkLayoutFactory::setupView(QDomElement viewElement, QWidget* view)
   if (factory)
     {
     factory->setupView(viewElement, view);
+    d->Views.insert(view);
     }
-  this->ctkLayoutManager::setupView(viewElement, view);
+  else
+    {
+    this->ctkLayoutManager::setupView(viewElement, view);
+    }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This is particularly useful for custom layoutViewFactory setting the
widget visibility property to either true or false in a specialized
"ctkLayoutViewFactory::setupView" function. This commit will avoid
the widget visibility to be systematically forced to true by
"ctkLayoutManager::setupView".