### PR TITLE
Do not require QWidget in decorator generated by ctkWrapPythonQt

### DIFF
--- a/CMake/ctkWrapPythonQt.py
+++ b/CMake/ctkWrapPythonQt.py
@@ -168,7 +168,7 @@ def ctk_wrap_pythonqt(target, namespace, output_dir, input_files, extra_verbose)
 #ifndef __${namespace}_${target}_h
 #define __${namespace}_${target}_h
 
-#include <QWidget>
+#include <QObject>
 ${includes}
 ${pythonqtWrappers}
 #endif


### PR DESCRIPTION
Including QObject is sufficient, this was an oversight of the initial
implementation added in d3f81f4 (Move all PythonQt wrapping code into
one script. See #449)

Inspired-by: Eric Heim <e.heim@dkfz-heidelberg.de>