### PR TITLE
upgraded PythonQt.cmake to use PythonQt3 in the superbuild with Qt5 and ...

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -42,7 +42,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
   endif()
 
   # Set desired qt version for PythonQt
-  list(APPEND ep_PythonQt_args -DDESIRED_QT_VERSION:STRING=${CTK_QT_VERSION})
+  list(APPEND ep_PythonQt_args -DPythonQt_QT_VERSION:STRING=${CTK_QT_VERSION})
 
   foreach(qtlib All ${qtlibs})
     string(TOUPPER ${qtlib} qtlib_uppercase)

--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -33,13 +33,6 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
 
   # Enable Qt libraries PythonQt wrapping if required
   if (CTK_QT_VERSION VERSION_GREATER "4")
-    message(FATAL_ERROR "To build CTK with Qt >= 5 and wrapping enabled, you "
-                        "are currently required to provide your own PythonQt "
-                        "by re-configuring CTK with option "
-                        "-DPYTHONQT_INSTALL_DIR:PATH=/path/to/PythonQt-30-install")
-    list(APPEND ep_PythonQt_args
-      -DPythonQt_QT_VERSION:STRING=${CTK_QT_VERSION}
-      )
     set(qtlibs Core Gui Widgets Network OpenGL PrintSupport Sql Svg UiTools WebKit WebKitWidgets Xml)
   else()
     list(APPEND ep_PythonQt_args
@@ -47,6 +40,10 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
       )
     set(qtlibs core gui network opengl sql svg uitools webkit xml)
   endif()
+
+  # Set desired qt version for PythonQt
+  list(APPEND ep_PythonQt_args -DDESIRED_QT_VERSION:STRING=${CTK_QT_VERSION})
+
   foreach(qtlib All ${qtlibs})
     string(TOUPPER ${qtlib} qtlib_uppercase)
     list(APPEND ep_PythonQt_args -DPythonQt_Wrap_Qt${qtlib}:BOOL=${CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QT${qtlib_uppercase}})


### PR DESCRIPTION
Upgraded CMake/PythonQt.cmake to work with the new PythonQt3 upgrade and Qt5 in the superbuild. TODOs: 
- Revision tag has to be upgraded to final version. 
- Everything needs to be tested on Windows/Mac. 
- Linker errors when building with testing. Qt5 libs need to be added to the testing (see output):
   
Linking CXX executable ../../../../../../bin/CTKScriptingPythonCoreCppTests
/media/Data/Bugsquashing/github/CTK-bin/CMakeExternals/Install/lib/libPythonQt.so: error: undefined reference to 'QColor::invalidate()'
/media/Data/Bugsquashing/github/CTK-bin/CMakeExternals/Install/lib/libPythonQt.so: error: undefined reference to 'QCursor::QCursor()'
/media/Data/Bugsquashing/github/CTK-bin/CMakeExternals/Install/lib/libPythonQt.so: error: undefined reference to 'QCursor::operator QVariant() const'
/media/Data/Bugsquashing/github/CTK-bin/CMakeExternals/Install/lib/libPythonQt.so: error: undefined reference to 'QCursor::~QCursor()'
/media/Data/Bugsquashing/github/CTK-bin/CMakeExternals/Install/lib/libPythonQt.so: error: undefined reference to 'QCursor::QCursor(Qt::CursorShape)'
/media/Data/Bugsquashing/github/CTK-bin/CMakeExternals/Install/lib/libPythonQt.so: error: undefined reference to 'QCursor::operator=(QCursor const&)'
/media/Data/Bugsquashing/github/CTK-bin/CMakeExternals/Install/lib/libPythonQt.so: error: undefined reference to 'QPen::QPen()'

