### PR TITLE
Update ctk user password for central.xnat.org, which was expired

### DIFF
--- a/Libs/XNAT/Core/Testing/ctkXnatSessionTest.cpp
+++ b/Libs/XNAT/Core/Testing/ctkXnatSessionTest.cpp
@@ -71,7 +71,7 @@ void ctkXnatSessionTestCase::initTestCase()
   d->LoginProfile.setName("ctk");
   d->LoginProfile.setServerUrl(QString("https://central.xnat.org"));
   d->LoginProfile.setUserName("ctk");
-  d->LoginProfile.setPassword("ctk-xnat");
+  d->LoginProfile.setPassword("ctk-xnat2015");
 }
 
 void ctkXnatSessionTestCase::init()


### PR DESCRIPTION
The password for central.xnat.org for the ctk user, which is used within the ctkXnatSessionTest was expired, which lead to an immediate exception if executing the test.
i updated the password for the user