### PR TITLE
XNAT API: Refactor upload and implement file upload

### DIFF
--- a/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
+++ b/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
@@ -147,6 +147,8 @@ void ctkXnatTreeBrowserMainWindow::addResourceClicked()
 {
   const QModelIndex index = ui->treeView->selectionModel()->currentIndex();
   ctkXnatObject* parentObject = m_TreeModel->xnatObject(index);
+  parentObject->addResourceFolder("data");
+  m_TreeModel->refresh(index);
 }
 
 void ctkXnatTreeBrowserMainWindow::uploadFileClicked()

--- a/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
+++ b/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
@@ -147,7 +147,7 @@ void ctkXnatTreeBrowserMainWindow::addResourceClicked()
 {
   const QModelIndex index = ui->treeView->selectionModel()->currentIndex();
   ctkXnatObject* parentObject = m_TreeModel->xnatObject(index);
-  parentObject->addResource("data", "ctk format", "custom content", "tag1, tag2");
+  parentObject->addResourceFolder("data", "ctk format", "custom content", "tag1, tag2");
 }
 
 void ctkXnatTreeBrowserMainWindow::uploadFileClicked()

--- a/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
+++ b/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
@@ -147,7 +147,6 @@ void ctkXnatTreeBrowserMainWindow::addResourceClicked()
 {
   const QModelIndex index = ui->treeView->selectionModel()->currentIndex();
   ctkXnatObject* parentObject = m_TreeModel->xnatObject(index);
-  parentObject->addResourceFolder("data", "ctk format", "custom content", "tag1, tag2");
 }
 
 void ctkXnatTreeBrowserMainWindow::uploadFileClicked()
@@ -161,9 +160,6 @@ void ctkXnatTreeBrowserMainWindow::uploadFileClicked()
     file->setLocalFilePath(filename);
     QFileInfo fileInfo (filename);
     file->setName(fileInfo.fileName());
-    file->setFileFormat("some format");
-    file->setFileContent("some content");
-    file->setFileTags("some, tags");
     resource->add(file);
     try
     {

--- a/CMakeExternals/CTKData.cmake
+++ b/CMakeExternals/CTKData.cmake
@@ -59,5 +59,4 @@ endif()
 
 mark_as_superbuild(
   VARS CTKData_DIR:PATH
-  LABELS "FIND_PACKAGE"
   )

--- a/Libs/Widgets/Testing/Cpp/ctkSearchBoxTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSearchBoxTest1.cpp
@@ -38,8 +38,8 @@ int ctkSearchBoxTest1(int argc, char* argv[])
   QApplication app(argc, argv);
 
   QPalette p;
-  p.setColor(QPalette::ColorRole::Window, Qt::gray);
-  p.setColor(QPalette::ColorRole::Base, Qt::gray);
+  p.setColor(QPalette::Window, Qt::gray);
+  p.setColor(QPalette::Base, Qt::gray);
 
   ctkSearchBox search;
   search.setShowSearchIcon(true);

--- a/Libs/XNAT/Core/Testing/ctkXnatSessionTest.h
+++ b/Libs/XNAT/Core/Testing/ctkXnatSessionTest.h
@@ -60,6 +60,10 @@ private slots:
 
   void testCreateSubject();
 
+  void testAddResourceFolder();
+
+  void testUploadAndDownloadFile();
+
 private:
   QScopedPointer<ctkXnatSessionTestCasePrivate> d_ptr;
 

--- a/Libs/XNAT/Core/ctkXnatAPI.cpp
+++ b/Libs/XNAT/Core/ctkXnatAPI.cpp
@@ -32,9 +32,6 @@
 #if (QT_VERSION >= QT_VERSION_CHECK(5,0,0))
 #include <QUrlQuery>
 #endif
-#include <QXmlDefaultHandler>
-#include <QXmlInputSource>
-#include <QXmlSimpleReader>
 
 // --------------------------------------------------------------------------
 // ctkXnatAPI methods
@@ -117,18 +114,13 @@ void ctkXnatAPI::parseResponse(qRestResult* restResult, const QByteArray& respon
 // --------------------------------------------------------------------------
 QList<QVariantMap> ctkXnatAPI::parseXmlResponse(qRestResult* /*restResult*/, const QByteArray& response)
 {
-  QXmlInputSource xmlInput;
-  xmlInput.setData(response);
-  QXmlSimpleReader xmlReader;
-
   QList<QVariantMap> result;
   // In this case a resource catalog xml was requested
   if (response.contains("<cat:Catalog"))
   {
     ctkXnatResourceCatalogXmlParser parser;
-    xmlReader.setContentHandler(&parser);
-    xmlReader.parse(&xmlInput, true);
-    result = parser.md5Hashes();
+    parser.setData(response);
+    parser.parseXml(result);
   }
   return result;
 }

--- a/Libs/XNAT/Core/ctkXnatAssessorFolder.cpp
+++ b/Libs/XNAT/Core/ctkXnatAssessorFolder.cpp
@@ -66,6 +66,18 @@ QString ctkXnatAssessorFolder::resourceUri() const
 }
 
 //----------------------------------------------------------------------------
+QString ctkXnatAssessorFolder::name() const
+{
+  return this->label();
+}
+
+//----------------------------------------------------------------------------
+QString ctkXnatAssessorFolder::label() const
+{
+  return this->property(LABEL);
+}
+
+//----------------------------------------------------------------------------
 void ctkXnatAssessorFolder::reset()
 {
   ctkXnatObject::reset();

--- a/Libs/XNAT/Core/ctkXnatAssessorFolder.h
+++ b/Libs/XNAT/Core/ctkXnatAssessorFolder.h
@@ -42,6 +42,9 @@ public:
 
   virtual QString resourceUri() const;
 
+  virtual QString name() const;
+  virtual QString label()const;
+
   void reset();
 
 private:

--- a/Libs/XNAT/Core/ctkXnatFile.cpp
+++ b/Libs/XNAT/Core/ctkXnatFile.cpp
@@ -21,11 +21,8 @@
 
 #include "ctkXnatFile.h"
 
-#include "ctkXnatException.h"
 #include "ctkXnatObjectPrivate.h"
 #include "ctkXnatSession.h"
-
-#include <QDebug>
 
 const QString ctkXnatFile::FILE_NAME = "Name";
 const QString ctkXnatFile::FILE_TAGS = "file_tags";

--- a/Libs/XNAT/Core/ctkXnatFile.h
+++ b/Libs/XNAT/Core/ctkXnatFile.h
@@ -75,9 +75,8 @@ private:
   /**
     * @brief Uploads the file to the server
     * Before calling save() the localFilePath has to be set
-    * @throws ctkXnatException it the specified file does not exists
     */
-  virtual void saveImpl();
+  virtual void saveImpl(bool overwrite);
 
   Q_DECLARE_PRIVATE(ctkXnatFile)
 };

--- a/Libs/XNAT/Core/ctkXnatObject.cpp
+++ b/Libs/XNAT/Core/ctkXnatObject.cpp
@@ -229,15 +229,18 @@ void ctkXnatObject::add(ctkXnatObject* child)
   }
 
   bool childExists (false);
-  foreach (ctkXnatObject* existingChild, d->children)
+
+  QList<ctkXnatObject*>::iterator iter;
+  for (iter = d->children.begin(); iter != d->children.end(); ++iter)
   {
-    if ((existingChild->id().length() != 0 && existingChild->id() == child->id()) ||
-        (existingChild->id().length() == 0 && existingChild->name() == child->name()))
+    if (((*iter)->id().length() != 0 && (*iter)->id() == child->id()) ||
+        ((*iter)->id().length() == 0 && (*iter)->name() == child->name()))
     {
-      d->children.replace(d->children.indexOf(existingChild), child);
+      *iter = child;
       childExists = true;
     }
   }
+
   if (!childExists)
   {
     d->children.push_back(child);

--- a/Libs/XNAT/Core/ctkXnatObject.cpp
+++ b/Libs/XNAT/Core/ctkXnatObject.cpp
@@ -357,7 +357,11 @@ ctkXnatResource* ctkXnatObject::addResourceFolder(QString foldername, QString fo
     resource->setTags(tags);
 
   resFolder->add(resource);
-  resource->save();
+
+  if (!resource->exists())
+    resource->save();
+  else
+    qDebug()<<"Not adding resource folder. Folder already exists!";
 
   return resource;
 }

--- a/Libs/XNAT/Core/ctkXnatObject.cpp
+++ b/Libs/XNAT/Core/ctkXnatObject.cpp
@@ -322,7 +322,7 @@ void ctkXnatObject::save()
 }
 
 //----------------------------------------------------------------------------
-void ctkXnatObject::addResource(QString foldername, QString format,
+ctkXnatResource* ctkXnatObject::addResourceFolder(QString foldername, QString format,
                                    QString content, QString tags)
 {
   if (foldername.size() == 0)
@@ -358,6 +358,8 @@ void ctkXnatObject::addResource(QString foldername, QString format,
 
   resFolder->add(resource);
   resource->save();
+
+  return resource;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/XNAT/Core/ctkXnatObject.cpp
+++ b/Libs/XNAT/Core/ctkXnatObject.cpp
@@ -178,7 +178,6 @@ void ctkXnatObject::setProperty(const QString& name, const QVariant& value)
   if (d->properties[name] != value)
   {
     d->properties.insert(name, value.toString());
-    d->modified = true; //TODO some internal method for e.g. setting the ID for the first time
   }
 }
 
@@ -318,7 +317,6 @@ void ctkXnatObject::save(bool overwrite)
 {
   Q_D(ctkXnatObject);
   this->saveImpl(overwrite);
-  d->modified = false;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/XNAT/Core/ctkXnatObject.cpp
+++ b/Libs/XNAT/Core/ctkXnatObject.cpp
@@ -314,10 +314,10 @@ void ctkXnatObject::download(const QString& filename)
 }
 
 //----------------------------------------------------------------------------
-void ctkXnatObject::save()
+void ctkXnatObject::save(bool overwrite)
 {
   Q_D(ctkXnatObject);
-  this->saveImpl();
+  this->saveImpl(overwrite);
   d->modified = false;
 }
 
@@ -369,7 +369,7 @@ bool ctkXnatObject::exists() const
 }
 
 //----------------------------------------------------------------------------
-void ctkXnatObject::saveImpl()
+void ctkXnatObject::saveImpl(bool /*overwrite*/)
 {
   Q_D(ctkXnatObject);
   QString query = this->resourceUri();

--- a/Libs/XNAT/Core/ctkXnatObject.cpp
+++ b/Libs/XNAT/Core/ctkXnatObject.cpp
@@ -286,10 +286,10 @@ void ctkXnatObject::setSchemaType(const QString& schemaType)
 }
 
 //----------------------------------------------------------------------------
-void ctkXnatObject::fetch()
+void ctkXnatObject::fetch(bool forceFetch)
 {
   Q_D(ctkXnatObject);
-  if (!d->fetched)
+  if (!d->fetched || forceFetch)
   {
     this->fetchImpl();
     d->fetched = true;

--- a/Libs/XNAT/Core/ctkXnatObject.cpp
+++ b/Libs/XNAT/Core/ctkXnatObject.cpp
@@ -236,7 +236,6 @@ void ctkXnatObject::add(ctkXnatObject* child)
     {
       d->children.replace(d->children.indexOf(existingChild), child);
       childExists = true;
-      qWarning() << "ctkXnatObject::add(): Child already exists -> Replaced child!";
     }
   }
   if (!childExists)
@@ -383,7 +382,7 @@ void ctkXnatObject::saveImpl(bool /*overwrite*/)
     // If the object has been modified on the server, perform an update
     if (d->lastModifiedTime < remoteModTime)
     {
-      qDebug()<<"Object maybe overwritten on server!";
+      qWarning()<<"Uploaded object maybe overwritten on server!";
       // TODO update from server, since modification time is not really supported
       // by xnat right now this is not of high priority
       // something like this->updateImpl + setLastModifiedTime()

--- a/Libs/XNAT/Core/ctkXnatObject.h
+++ b/Libs/XNAT/Core/ctkXnatObject.h
@@ -31,6 +31,7 @@
 #include <QString>
 #include <QMetaType>
 
+class ctkXnatResource;
 class ctkXnatSession;
 class ctkXnatObjectPrivate;
 
@@ -130,7 +131,7 @@ public:
   void download(const QString&);
 
   /// Creates the object on the XNAT server and sets the new ID.
-  virtual void addResource(QString foldername,
+  virtual ctkXnatResource* addResourceFolder(QString foldername,
                            QString format = "", QString content = "", QString tags = "");
 
   //QObject* asyncObject() const;

--- a/Libs/XNAT/Core/ctkXnatObject.h
+++ b/Libs/XNAT/Core/ctkXnatObject.h
@@ -132,7 +132,13 @@ public:
 
   void download(const QString&);
 
-  /// Creates the object on the XNAT server and sets the new ID.
+  /// Creates a new resource folder with the given foldername, format, content and tags
+  /// for this ctkXnatObject on the server.
+  /// @param foldername the name of the resource folder on the server (mandatory)
+  /// @param format the text of the format field of a resource (optional)
+  /// @param content the text of the content field of a resource (optional)
+  /// @param tags the content of the tags field of a resource (optional)
+  /// @returns ctkXnatResource the created resource
   virtual ctkXnatResource* addResourceFolder(QString foldername,
                            QString format = "", QString content = "", QString tags = "");
 

--- a/Libs/XNAT/Core/ctkXnatObject.h
+++ b/Libs/XNAT/Core/ctkXnatObject.h
@@ -117,7 +117,7 @@ public:
   virtual void reset();
 
   /// Fetches the children and the properties of the object.
-  void fetch();
+  void fetch(bool forceFetch = false);
 
   /// Checks if the object exists on the XNAT server.
   bool exists() const;

--- a/Libs/XNAT/Core/ctkXnatObject.h
+++ b/Libs/XNAT/Core/ctkXnatObject.h
@@ -123,7 +123,9 @@ public:
   bool exists() const;
 
   /// Creates the object on the XNAT server and sets the new ID.
-  void save();
+  /// @param overwrite, if true and the object already exists on the server
+  ///                   it will be overwritten by the changes
+  void save(bool overwrite = true);
 
   /// Deletes the object on the XNAT server and removes it from its parent.
   void erase();
@@ -187,7 +189,9 @@ private:
 
   /// The implementation of the upload mechanism, called by the save() function.
   /// Subclasses of ctkXnatObject can overwrite this function if needed
-  virtual void saveImpl();
+  /// @param overwrite, if true and the object already exists on the server
+  ///                   it will be overwritten by the changes
+  virtual void saveImpl(bool overwrite = true);
 
   Q_DECLARE_PRIVATE(ctkXnatObject)
 };

--- a/Libs/XNAT/Core/ctkXnatObjectPrivate.h
+++ b/Libs/XNAT/Core/ctkXnatObjectPrivate.h
@@ -56,10 +56,6 @@ private:
 
   bool fetched;
 
-  // Indicates whether a xnatObject is locally modified and not yet
-  // synchronized with its instance on the server
-  bool modified;
-
   ctkXnatObject* parent;
 };
 

--- a/Libs/XNAT/Core/ctkXnatReconstructionFolder.cpp
+++ b/Libs/XNAT/Core/ctkXnatReconstructionFolder.cpp
@@ -53,6 +53,7 @@ ctkXnatReconstructionFolder::ctkXnatReconstructionFolder(ctkXnatObject* parent)
   : ctkXnatObject(*new ctkXnatReconstructionFolderPrivate(), parent, QString::null)
 {
   this->setProperty(ID, "reconstructions");
+  this->setProperty(LABEL, "Reconstructions");
 }
 
 //----------------------------------------------------------------------------
@@ -64,6 +65,18 @@ ctkXnatReconstructionFolder::~ctkXnatReconstructionFolder()
 QString ctkXnatReconstructionFolder::resourceUri() const
 {
   return QString("%1/%2").arg(parent()->resourceUri(), this->id());
+}
+
+//----------------------------------------------------------------------------
+QString ctkXnatReconstructionFolder::name() const
+{
+  return this->label();
+}
+
+//----------------------------------------------------------------------------
+QString ctkXnatReconstructionFolder::label() const
+{
+  return this->property(LABEL);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/XNAT/Core/ctkXnatReconstructionFolder.h
+++ b/Libs/XNAT/Core/ctkXnatReconstructionFolder.h
@@ -44,6 +44,9 @@ public:
 
   virtual QString resourceUri() const;
 
+  virtual QString name() const;
+  virtual QString label()const;
+
   void reset();
 
 private:

--- a/Libs/XNAT/Core/ctkXnatResource.cpp
+++ b/Libs/XNAT/Core/ctkXnatResource.cpp
@@ -167,7 +167,7 @@ void ctkXnatResource::downloadImpl(const QString& filename)
 }
 
 //----------------------------------------------------------------------------
-void ctkXnatResource::saveImpl()
+void ctkXnatResource::saveImpl(bool /*overwrite*/)
 {
   QString query = this->resourceUri();
 

--- a/Libs/XNAT/Core/ctkXnatResource.cpp
+++ b/Libs/XNAT/Core/ctkXnatResource.cpp
@@ -169,9 +169,9 @@ void ctkXnatResource::downloadImpl(const QString& filename)
 //----------------------------------------------------------------------------
 void ctkXnatResource::saveImpl(bool /*overwrite*/)
 {
-  QString query = this->resourceUri();
+  ctkXnatSession::UrlParameters urlParams;
+  urlParams["xsi:type"] = this->schemaType();
 
-  query.append(QString("?%1=%2").arg("xsi:type", this->schemaType()));
   const QMap<QString, QString>& properties = this->properties();
   QMapIterator<QString, QString> itProperties(properties);
   while (itProperties.hasNext())
@@ -179,8 +179,9 @@ void ctkXnatResource::saveImpl(bool /*overwrite*/)
     itProperties.next();
     if (itProperties.key() == ID || itProperties.key() == "xsiType")
       continue;
-    query.append(QString("&%1=%2").arg(itProperties.key(), itProperties.value()));
+
+    urlParams[itProperties.key()] = itProperties.value();
   }
-  QUuid queryId = this->session()->httpPut(query);
+  QUuid queryId = this->session()->httpPut(this->resourceUri(), urlParams);
   session()->httpResults(queryId, ctkXnatDefaultSchemaTypes::XSI_RESOURCE);
 }

--- a/Libs/XNAT/Core/ctkXnatResource.cpp
+++ b/Libs/XNAT/Core/ctkXnatResource.cpp
@@ -27,8 +27,8 @@
 const QString ctkXnatResource::TAGS = "tags";
 const QString ctkXnatResource::FORMAT = "format";
 const QString ctkXnatResource::CONTENT = "content";
-
 const QString ctkXnatResource::ID = "xnat_abstractresource_id";
+
 //----------------------------------------------------------------------------
 class ctkXnatResourcePrivate : public ctkXnatObjectPrivate
 {

--- a/Libs/XNAT/Core/ctkXnatResource.h
+++ b/Libs/XNAT/Core/ctkXnatResource.h
@@ -67,7 +67,7 @@ public:
 
   void reset();
 
-  void saveImpl();
+  void saveImpl(bool overwrite);
 
   static const QString ID;
   static const QString TAGS;

--- a/Libs/XNAT/Core/ctkXnatResourceCatalogXmlParser.cpp
+++ b/Libs/XNAT/Core/ctkXnatResourceCatalogXmlParser.cpp
@@ -33,7 +33,6 @@ public:
   {
   }
 
-  QList<QVariantMap> result;
   QXmlStreamReader xmlReader;
 };
 
@@ -79,10 +78,4 @@ void ctkXnatResourceCatalogXmlParser::parseXml(QList<QVariantMap>& result)
   {
     qWarning()<<"Error parsing XNAT resource catalog xml!";
   }
-}
-
-const QList<QVariantMap>& ctkXnatResourceCatalogXmlParser::md5Hashes()
-{
-  Q_D(ctkXnatResourceCatalogXmlParser);
-  return d->result;
 }

--- a/Libs/XNAT/Core/ctkXnatResourceCatalogXmlParser.h
+++ b/Libs/XNAT/Core/ctkXnatResourceCatalogXmlParser.h
@@ -24,7 +24,8 @@
 
 #include "ctkXNATCoreExport.h"
 
-#include <QXmlDefaultHandler>
+#include <QList>
+#include <QVariantMap>
 
 class ctkXnatResourceCatalogXmlParserPrivate;
 
@@ -40,7 +41,7 @@ class ctkXnatResourceCatalogXmlParserPrivate;
  *
  * @ingroup XNAT_Core
  */
-class CTK_XNAT_CORE_EXPORT ctkXnatResourceCatalogXmlParser : public QXmlDefaultHandler
+class CTK_XNAT_CORE_EXPORT ctkXnatResourceCatalogXmlParser
 {
 
 public:
@@ -48,10 +49,10 @@ public:
   ~ctkXnatResourceCatalogXmlParser();
 
   /**
-   * Overwrites QXmlDefaultHandler::startElement()
+   * @brief Set the xml input for the parser
+   * @param xmlInput as QByteArray
    */
-  bool startElement(const QString &namespaceURI, const QString &localName,
-                    const QString &qName, const QXmlAttributes &atts);
+  void setData(const QByteArray& xmlInput);
 
   /**
    * @brief Returns the md5 hashes of the resource files
@@ -59,6 +60,11 @@ public:
    */
   const QList<QVariantMap>& md5Hashes();
 
+  /**
+   * @brief Parses the xml input and extracts the md5 hashes of the resource catalog
+   * @param result the QList in which the md5 hashes will be stored
+   */
+  void parseXml(QList<QVariantMap> &result);
 private:
 
   ctkXnatResourceCatalogXmlParser(const ctkXnatResourceCatalogXmlParser& );

--- a/Libs/XNAT/Core/ctkXnatResourceCatalogXmlParser.h
+++ b/Libs/XNAT/Core/ctkXnatResourceCatalogXmlParser.h
@@ -55,12 +55,6 @@ public:
   void setData(const QByteArray& xmlInput);
 
   /**
-   * @brief Returns the md5 hashes of the resource files
-   * @return A list of QVariantMaps, which contain the md5 hashes
-   */
-  const QList<QVariantMap>& md5Hashes();
-
-  /**
    * @brief Parses the xml input and extracts the md5 hashes of the resource catalog
    * @param result the QList in which the md5 hashes will be stored
    */

--- a/Libs/XNAT/Core/ctkXnatResourceFolder.cpp
+++ b/Libs/XNAT/Core/ctkXnatResourceFolder.cpp
@@ -63,6 +63,18 @@ QString ctkXnatResourceFolder::resourceUri() const
 }
 
 //----------------------------------------------------------------------------
+QString ctkXnatResourceFolder::name() const
+{
+  return this->label();
+}
+
+//----------------------------------------------------------------------------
+QString ctkXnatResourceFolder::label() const
+{
+  return this->property(LABEL);
+}
+
+//----------------------------------------------------------------------------
 void ctkXnatResourceFolder::reset()
 {
   ctkXnatObject::reset();

--- a/Libs/XNAT/Core/ctkXnatResourceFolder.cpp
+++ b/Libs/XNAT/Core/ctkXnatResourceFolder.cpp
@@ -101,7 +101,7 @@ void ctkXnatResourceFolder::downloadImpl(const QString& filename)
 }
 
 //----------------------------------------------------------------------------
-void ctkXnatResourceFolder::saveImpl()
+void ctkXnatResourceFolder::saveImpl(bool /*overwrite*/)
 {
   // Not implemented since a resource folder is automatically created when
   // a resource is uploaded

--- a/Libs/XNAT/Core/ctkXnatResourceFolder.h
+++ b/Libs/XNAT/Core/ctkXnatResourceFolder.h
@@ -42,6 +42,9 @@ public:
 
   virtual QString resourceUri() const;
 
+  virtual QString name() const;
+  virtual QString label()const;
+
   void reset();
 
 private:

--- a/Libs/XNAT/Core/ctkXnatResourceFolder.h
+++ b/Libs/XNAT/Core/ctkXnatResourceFolder.h
@@ -49,7 +49,7 @@ private:
   friend class qRestResult;
   virtual void fetchImpl();
   virtual void downloadImpl(const QString&);
-  virtual void saveImpl();
+  virtual void saveImpl(bool overwrite);
 
   Q_DECLARE_PRIVATE(ctkXnatResourceFolder)
 };

--- a/Libs/XNAT/Core/ctkXnatScanFolder.cpp
+++ b/Libs/XNAT/Core/ctkXnatScanFolder.cpp
@@ -66,6 +66,18 @@ QString ctkXnatScanFolder::resourceUri() const
 }
 
 //----------------------------------------------------------------------------
+QString ctkXnatScanFolder::name() const
+{
+  return this->label();
+}
+
+//----------------------------------------------------------------------------
+QString ctkXnatScanFolder::label() const
+{
+  return this->property(LABEL);
+}
+
+//----------------------------------------------------------------------------
 void ctkXnatScanFolder::reset()
 {
   ctkXnatObject::reset();

--- a/Libs/XNAT/Core/ctkXnatScanFolder.h
+++ b/Libs/XNAT/Core/ctkXnatScanFolder.h
@@ -44,6 +44,9 @@ public:
 
   virtual QString resourceUri() const;
 
+  virtual QString name() const;
+  virtual QString label()const;
+
   void reset();
 
 private:

--- a/Libs/XNAT/Core/ctkXnatSession.cpp
+++ b/Libs/XNAT/Core/ctkXnatSession.cpp
@@ -90,7 +90,7 @@ ctkXnatSessionPrivate::ctkXnatSessionPrivate(const ctkXnatLoginProfile& loginPro
                                              ctkXnatSession* q)
   : loginProfile(loginProfile)
   , xnat(new ctkXnatAPI())
-  , defaultDownloadDir("")
+  , defaultDownloadDir(".")
   , q(q)
 {
   // TODO This is a workaround for connecting to sites with self-signed

--- a/Libs/XNAT/Core/ctkXnatSession.cpp
+++ b/Libs/XNAT/Core/ctkXnatSession.cpp
@@ -531,12 +531,12 @@ QList<ctkXnatObject*> ctkXnatSession::httpResults(const QUuid& uuid, const QStri
   return d->results(restResult.data(), schemaType);
 }
 
-QUuid ctkXnatSession::httpPut(const QString& resource, const ctkXnatSession::UrlParameters& /*parameters*/,
+QUuid ctkXnatSession::httpPut(const QString& resource, const ctkXnatSession::UrlParameters& parameters,
                               const ctkXnatSession::HttpRawHeaders& /*rawHeaders*/)
 {
   Q_D(ctkXnatSession);
   d->checkSession();
-  return d->xnat->put(resource);
+  return d->xnat->put(resource, parameters);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/XNAT/Core/ctkXnatSession.cpp
+++ b/Libs/XNAT/Core/ctkXnatSession.cpp
@@ -652,9 +652,13 @@ void ctkXnatSession::upload(ctkXnatFile *file,
   if (localFile.open(QFile::ReadOnly) && md5ChecksumRemote != "0")
   {
     QCryptographicHash hash(QCryptographicHash::Md5);
-    // TODO Do this in case of Qt5
-    //if (hash.addData(&file))
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+    hash.addData(&localFile);
+#else
     hash.addData(localFile.readAll());
+#endif
+
     QString md5ChecksumLocal(hash.result().toHex());
     // Retrieving the md5 checksum on the server and comparing
     // it with the local file md5 sum
@@ -662,7 +666,6 @@ void ctkXnatSession::upload(ctkXnatFile *file,
     {
       // Remove corrupted file from server
       file->erase();
-      // TODO qError! Exception im Pythonwrapping nicht auswertbar?
       throw ctkXnatException("Upload failed! An error occurred during file upload.");
     }
   }

--- a/Libs/XNAT/Core/ctkXnatSession.cpp
+++ b/Libs/XNAT/Core/ctkXnatSession.cpp
@@ -63,7 +63,7 @@ public:
   QScopedPointer<ctkXnatAPI> xnat;
   QScopedPointer<ctkXnatDataModel> dataModel;
   QString sessionId;
-  QString defaultFilePath;
+  QString defaultDownloadDir;
 
   QMap<QString, QString> sessionProperties;
 
@@ -90,7 +90,7 @@ ctkXnatSessionPrivate::ctkXnatSessionPrivate(const ctkXnatLoginProfile& loginPro
                                              ctkXnatSession* q)
   : loginProfile(loginProfile)
   , xnat(new ctkXnatAPI())
-  , defaultFilePath("")
+  , defaultDownloadDir("")
   , q(q)
 {
   // TODO This is a workaround for connecting to sites with self-signed
@@ -478,27 +478,27 @@ QString ctkXnatSession::sessionId() const
 }
 
 //----------------------------------------------------------------------------
-void ctkXnatSession::setDefaultFilePath(const QString &path)
+void ctkXnatSession::setDefaultDownloadDir(const QString &path)
 {
   Q_D(ctkXnatSession);
 
   QDir directory(path);
   if (directory.exists() && path.size() != 0)
   {
-    d->defaultFilePath = path;
+    d->defaultDownloadDir = path;
   }
   else
   {
-    d->defaultFilePath = QDir::currentPath();
-    qWarning() << "Specified directory: ["<<path<<"] does not exists! Setting default filepath to :"<<d->defaultFilePath;
+    d->defaultDownloadDir = QDir::currentPath();
+    qWarning() << "Specified directory: ["<<path<<"] does not exists! Setting default filepath to :"<<d->defaultDownloadDir;
   }
 }
 
 //----------------------------------------------------------------------------
-QString ctkXnatSession::defaultFilePath() const
+QString ctkXnatSession::defaultDownloadDir() const
 {
   Q_D(const ctkXnatSession);
-  return d->defaultFilePath;
+  return d->defaultDownloadDir;
 }
 
 //----------------------------------------------------------------------------
@@ -639,13 +639,13 @@ void ctkXnatSession::upload(ctkXnatFile *xnatFile,
   // of the parent resource. Unfortunately for XNAT versions <= 1.6.4
   // this is the only way to get the file's MD5 hash form the server.
   QString md5Query = xnatFile->parent()->resourceUri();
-  QUuid md5ID = this->httpGet(md5Query);
-  QList<QVariantMap> result = this->httpSync(md5ID);
+  QUuid md5QueryID = this->httpGet(md5Query);
+  QList<QVariantMap> result = this->httpSync(md5QueryID);
 
   QString md5ChecksumRemote ("0");
   // Newly added files are usually at the end of the catalog
-  // and hence at the end of the result list. So iterating backwards
-  // is for performance reasons.
+  // and hence at the end of the result list.
+  // So iterating backward is for performance reasons.
   QList<QVariantMap>::const_iterator it = result.constEnd()-1;
   while (it != result.constBegin()-1)
   {
@@ -683,7 +683,6 @@ void ctkXnatSession::upload(ctkXnatFile *xnatFile,
   {
     qWarning()<<"Could not validate file upload! Remote MD5: "<<md5ChecksumRemote;
   }
-  // End file validation
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/XNAT/Core/ctkXnatSession.cpp
+++ b/Libs/XNAT/Core/ctkXnatSession.cpp
@@ -483,7 +483,7 @@ void ctkXnatSession::setDefaultDownloadDir(const QString &path)
   Q_D(ctkXnatSession);
 
   QDir directory(path);
-  if (directory.exists() && path.size() != 0)
+  if (directory.exists())
   {
     d->defaultDownloadDir = path;
   }

--- a/Libs/XNAT/Core/ctkXnatSession.h
+++ b/Libs/XNAT/Core/ctkXnatSession.h
@@ -241,8 +241,7 @@ public:
   /// \a rawHeaders can be used to set the raw headers of the request to send.
   /// These headers will be set additionally to those defined by the
   /// \a defaultRawHeaders property.
-  void upload(const QString& fileName,
-    const QString& resource,
+  void upload(ctkXnatFile *,
     const UrlParameters& parameters = UrlParameters(),
     const HttpRawHeaders& rawHeaders = HttpRawHeaders());
 

--- a/Libs/XNAT/Core/ctkXnatSession.h
+++ b/Libs/XNAT/Core/ctkXnatSession.h
@@ -235,13 +235,13 @@ public:
     const UrlParameters& parameters = UrlParameters(),
     const HttpRawHeaders& rawHeaders = HttpRawHeaders());
 
-  /// Uploads a file to the web service.
+  /// Uploads a file to the server.
   /// \a fileName is the name of the file.
   /// The \a resource and \parameters are used to compose the URL.
   /// \a rawHeaders can be used to set the raw headers of the request to send.
   /// These headers will be set additionally to those defined by the
   /// \a defaultRawHeaders property.
-  void upload(ctkXnatFile *,
+  void upload(ctkXnatFile *xnatFile,
     const UrlParameters& parameters = UrlParameters(),
     const HttpRawHeaders& rawHeaders = HttpRawHeaders());
 

--- a/Libs/XNAT/Core/ctkXnatSession.h
+++ b/Libs/XNAT/Core/ctkXnatSession.h
@@ -147,23 +147,23 @@ public:
   QString sessionId() const;
 
   /**
-    * @brief Sets the default location where files will be save after being downloaded
+    * @brief Sets the default location where files will be saved after being downloaded
     *
     * Sets the default directory into which file downloads will be saved.
-    * By default this value is empty and files will be stored into the directory
-    * of the executable.
+    * By default this value is empty and files will be stored into the current
+    * working directory.
     * If the path does not exists a warning will be printed and the path will be
-    * set to the current working directory
+    * set to the current working directory.
     *
     * @param path the path to the download location
     */
-  void setDefaultFilePath(const QString& path);
+  void setDefaultDownloadDir(const QString& path);
 
   /**
     * @brief returns the default download location
     * @return the default download directory as string
     */
-  QString defaultFilePath() const;
+  QString defaultDownloadDir() const;
 
   ctkXnatDataModel* dataModel() const;
 
@@ -268,7 +268,7 @@ public:
    */
   Q_SIGNAL void sessionAboutToBeClosed();
 
-  Q_SIGNAL void uploadFinished();
+//  Q_SIGNAL void uploadFinished();
 
   Q_SIGNAL void progress(QUuid, double);
 

--- a/Libs/XNAT/Core/ctkXnatTreeModel.cpp
+++ b/Libs/XNAT/Core/ctkXnatTreeModel.cpp
@@ -182,7 +182,7 @@ bool ctkXnatTreeModel::hasChildren(const QModelIndex& index) const
   }
 
   ctkXnatTreeItem* item = d->itemAt(index);
-  return !item->xnatObject()->isFetched() || !item->xnatObject()->children().isEmpty();
+  return item->xnatObject() || !item->xnatObject()->isFetched() || !item->xnatObject()->children().isEmpty();
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/XNAT/Core/ctkXnatTreeModel.h
+++ b/Libs/XNAT/Core/ctkXnatTreeModel.h
@@ -50,6 +50,12 @@ public:
   virtual bool canFetchMore(const QModelIndex& parent) const;
   virtual void fetchMore(const QModelIndex& parent);
 
+  /**
+   * @brief Convenience method for refreshing an entry of the tree model
+   * @param The parent item, whose children will be refreshed
+   */
+  virtual void refresh(const QModelIndex& parent = QModelIndex());
+
   ctkXnatObject* xnatObject(const QModelIndex& index) const;
 
   void addDataModel(ctkXnatDataModel* dataModel);

--- a/Libs/XNAT/Widgets/ctkXnatLoginDialog.cpp
+++ b/Libs/XNAT/Widgets/ctkXnatLoginDialog.cpp
@@ -212,7 +212,7 @@ void ctkXnatLoginDialog::accept()
     return;
     }
   d->Session = session.take();
-  d->Session->setDefaultFilePath(ui->edtDownloadDir->text());
+  d->Session->setDefaultDownloadDir(ui->edtDownloadDir->text());
 
   QDialog::accept();
 }

--- a/Plugins/org.commontk.configadmin/Testing/Cpp/CMakeLists.txt
+++ b/Plugins/org.commontk.configadmin/Testing/Cpp/CMakeLists.txt
@@ -10,10 +10,15 @@ set(MY_MOC_CXX )
 
 set(test_executable ${PROJECT_NAME}CppTests)
 
+set(${test_executable}_DEPENDENCIES ${fw_lib} ${fwtestutil_lib})
+
+set(my_includes)
+ctkFunctionGetIncludeDirs(my_includes ${test_executable})
+include_directories(${my_includes})
+
 add_executable(${test_executable} ${SRCS} ${MY_MOC_CXX})
 target_link_libraries(${test_executable}
-  ${fw_lib}
-  ${fwtestutil_lib}
+  ${${test_executable}_DEPENDENCIES}
 )
 
 add_dependencies(${test_executable} ${PROJECT_NAME} ${configadmin_test})

--- a/Plugins/org.commontk.eventadmin/Testing/Cpp/CMakeLists.txt
+++ b/Plugins/org.commontk.eventadmin/Testing/Cpp/CMakeLists.txt
@@ -12,10 +12,15 @@ set(MY_MOC_CXX )
 
 set(test_executable ${PROJECT_NAME}CppTests)
 
+set(${test_executable}_DEPENDENCIES ${fw_lib} ${fwtestutil_lib})
+
+set(my_includes)
+ctkFunctionGetIncludeDirs(my_includes ${test_executable})
+include_directories(${my_includes})
+
 add_executable(${test_executable} ctkEventAdminImplTestMain.cpp)
 target_link_libraries(${test_executable}
-  ${fw_lib}
-  ${fwtestutil_lib}
+  ${${test_executable}_DEPENDENCIES}
 )
 
 add_dependencies(${test_executable} ${PROJECT_NAME} ${eventadmin_test})
@@ -27,10 +32,15 @@ set_property(TEST ${PROJECT_NAME}Tests PROPERTY LABELS ${PROJECT_NAME})
 
 set(test_executable ${PROJECT_NAME}PerfTests)
 
+set(${test_executable}_DEPENDENCIES ${fw_lib} ${fwtestutil_lib})
+
+#set(my_includes)
+#ctkFunctionGetIncludeDirs(my_includes ${test_executable})
+#include_directories(${my_includes})
+
 add_executable(${test_executable} ctkEventAdminImplPerfTestMain.cpp)
 target_link_libraries(${test_executable}
-  ${fw_lib}
-  ${fwtestutil_lib}
+  ${${test_executable}_DEPENDENCIES}
 )
 
 add_dependencies(${test_executable} ${PROJECT_NAME} ${eventadmin_perftest})

--- a/Plugins/org.commontk.metatype/Testing/Cpp/CMakeLists.txt
+++ b/Plugins/org.commontk.metatype/Testing/Cpp/CMakeLists.txt
@@ -10,10 +10,15 @@ set(MY_MOC_CXX )
 
 set(test_executable ${PROJECT_NAME}CppTests)
 
+set(${test_executable}_DEPENDENCIES ${fw_lib} ${fwtestutil_lib})
+
+set(my_includes)
+ctkFunctionGetIncludeDirs(my_includes ${test_executable})
+include_directories(${my_includes})
+
 add_executable(${test_executable} ${SRCS} ${MY_MOC_CXX})
 target_link_libraries(${test_executable}
-  ${fw_lib}
-  ${fwtestutil_lib}
+  ${${test_executable}_DEPENDENCIES}
 )
 
 add_dependencies(${test_executable} ${PROJECT_NAME} ${metatype_test})


### PR DESCRIPTION
Here is a short overview about what is changed within this pull request

- Refactored existing upload / save functionality: save() method was moved to ctkXnatObject. Each subclass has now a saveImpl() which is called by save() (similar to the fetch / download functionality)
- Implemented file upload via the CTK XNAT API
- Validation of the upload is done via the XNAT resource catalog xml which is parsed by a new class (ctkXnatResourceCatalogXmlParser)
- Added new class ctkXnatResourceFolder, which is consistent to ctkXnatScanFolder, ctkXnatreconstructionFolder and ctkXnatAssessorFolder
- Implemented resource creation via CTK XNAT API
- Added defaultDownloadDir location to ctkXnatSession
- Updated qRestAPI to latest revision, which supports the file upload
- Enhanced ctkXnatTreeModel so that new children can be added to existing objects
- Enhanced ctkXnatTreeBrowser for resource creation and file upload possibility