### PR TITLE
resource uri with label

### DIFF
--- a/Libs/XNAT/Core/Testing/ctkXnatSessionTest.cpp
+++ b/Libs/XNAT/Core/Testing/ctkXnatSessionTest.cpp
@@ -257,7 +257,6 @@ void ctkXnatSessionTestCase::testCreateSubject()
   ctkXnatSubject* subject = new ctkXnatSubject(project);
 
   QString subjectName = QString("CTK_S") + QUuid::createUuid().toString().mid(1, 8);
-  subject->setId(subjectName);
   subject->setName(subjectName);
 
   subject->save();

--- a/Libs/XNAT/Core/ctkXnatExperiment.cpp
+++ b/Libs/XNAT/Core/ctkXnatExperiment.cpp
@@ -67,6 +67,10 @@ ctkXnatExperiment::~ctkXnatExperiment()
 //----------------------------------------------------------------------------
 QString ctkXnatExperiment::resourceUri() const
 {
+  if (this->id().isEmpty())
+  {
+    return QString("%1/experiments/%2").arg(parent()->resourceUri(), this->label());
+  }
   return QString("%1/experiments/%2").arg(parent()->resourceUri(), this->id());
 }
 

--- a/Libs/XNAT/Core/ctkXnatSession.cpp
+++ b/Libs/XNAT/Core/ctkXnatSession.cpp
@@ -576,7 +576,7 @@ void ctkXnatSession::save(ctkXnatObject* object)
   if (maps.size() == 1 && maps[0].size() == 1)
   {
     QVariant id = maps[0][ctkXnatObject::ID];
-    if (!id.isNull())
+    if (id.isNull())
     {
       object->setId(id.toString());
     }

--- a/Libs/XNAT/Core/ctkXnatSession.cpp
+++ b/Libs/XNAT/Core/ctkXnatSession.cpp
@@ -573,10 +573,10 @@ void ctkXnatSession::save(ctkXnatObject* object)
   }
 
   const QList<QVariantMap>& maps = result->results();
-  if (maps.size() == 1 && maps[0].size() == 1)
+  if (maps.size() == 1 && maps[0].size() == 2)
   {
     QVariant id = maps[0][ctkXnatObject::ID];
-    if (id.isNull())
+    if (!id.isNull())
     {
       object->setId(id.toString());
     }

--- a/Libs/XNAT/Core/ctkXnatSubject.cpp
+++ b/Libs/XNAT/Core/ctkXnatSubject.cpp
@@ -124,6 +124,10 @@ void ctkXnatSubject::setInsertUser(const QString& insertUser)
 //----------------------------------------------------------------------------
 QString ctkXnatSubject::resourceUri() const
 {
+  if (this->id().isEmpty())
+  {
+    return QString("%1/subjects/%2").arg(parent()->resourceUri(), this->label());
+  }
   return QString("%1/subjects/%2").arg(parent()->resourceUri(), this->id());
 }
 


### PR DESCRIPTION
To Create a subject or an experiment with a XNAT generated ID, the ID should not be used.
Therefore the resourceUri() method also can return the URI with the label of an Object.
Adjusted the TestCase to this change.