### PR TITLE
Fixed build error on Mac OS X

### DIFF
--- a/Libs/Widgets/ctkColorPickerButton.cpp
+++ b/Libs/Widgets/ctkColorPickerButton.cpp
@@ -83,7 +83,7 @@ void ctkColorPickerButtonPrivate::computeIcon()
   QPainter p(&pix);
   p.setPen(QPen(Qt::gray));
   p.setBrush(this->Color.isValid() ?
-    this->Color : QBrush(Qt::BrushStyle::NoBrush));
+    this->Color : QBrush(Qt::NoBrush));
   p.drawRect(2, 2, pix.width() - 5, pix.height() - 5);
 
   this->Icon = QIcon(pix);


### PR DESCRIPTION
Qt::BrushStyle cannot be used as an scoped enumeration