### PR TITLE
Qt 5.5 fixes

### DIFF
--- a/Libs/CommandLineModules/Core/ctkCmdLineModuleManager.h
+++ b/Libs/CommandLineModules/Core/ctkCmdLineModuleManager.h
@@ -24,8 +24,10 @@
 
 #include <ctkCommandLineModulesCoreExport.h>
 
-#include <QStringList>
+#include <QObject>
+#include <QScopedPointer>
 #include <QString>
+#include <QStringList>
 #include "ctkCmdLineModuleReference.h"
 
 struct ctkCmdLineModuleBackend;

--- a/Libs/PluginFramework/ctkPluginArchiveSQL_p.h
+++ b/Libs/PluginFramework/ctkPluginArchiveSQL_p.h
@@ -22,10 +22,11 @@
 #ifndef CTKPLUGINARCHIVESQL_P_H
 #define CTKPLUGINARCHIVESQL_P_H
 
-#include <QString>
-#include <QHash>
-#include <QUrl>
 #include <QDateTime>
+#include <QHash>
+#include <QSharedPointer>
+#include <QString>
+#include <QUrl>
 
 #include "ctkPluginArchive_p.h"
 #include "ctkPluginManifest_p.h"


### PR DESCRIPTION
There are some build errors if you build CTK with the new Qt 5.5, which are related to some missing includes.
I was not able to use the BUILD_ALL configuration since both, ITK and VTK as well as Python did not work on my Mac OS X 10.10 with apple clang 6.1.0