### PR TITLE
QtTesting: Update Git repository URL to fix invalid cert issues.

### DIFF
--- a/CMakeExternals/QtTesting.cmake
+++ b/CMakeExternals/QtTesting.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED QtTesting_DIR)
     set(location_args GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
                       GIT_TAG ${revision_tag})
   else()
-    set(location_args GIT_REPOSITORY "${git_protocol}://paraview.org/QtTesting.git"
+    set(location_args GIT_REPOSITORY "${git_protocol}://github.com/Kitware/QtTesting.git"
                       GIT_TAG ${revision_tag})
   endif()
 


### PR DESCRIPTION
Since QtTesting development has been moved to Github, this commit
updates the URL accordingly.

The error occurred when using git protocol:

  git clone https://paraview.org/QtTesting.git
  Cloning into 'QtTesting'...
  fatal: unable to access 'https://paraview.org/QtTesting.git/': Unknown SSL protocol error in connection to paraview.org:443

  git clone https://paraview.org/QtTesting.git
  Cloning into 'QtTesting'...
  fatal: unable to access 'https://paraview.org/QtTesting.git/': SSL certificate problem: unable to get local issuer certificate

Reported-by: Sergey Aleshin <4memph@gmail.com>
Thanks: Sergey Aleshin <4memph@gmail.com>