### PR TITLE
ctkAbstractPythonManager: Clean up PythonQt before finalizing the Python interpreter

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -66,7 +66,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
     message(FATAL_ERROR "error: Python is required to build ${PROJECT_NAME}")
   endif()
 
-  set(revision_tag 503597ba3274f59cd68347f11926340ec4f33471)
+  set(revision_tag f9c7e6a8e7c9ca7953b7128e820a81c93ed2cc56)
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
@@ -86,11 +86,12 @@ ctkAbstractPythonManager::ctkAbstractPythonManager(QObject* _parent) : Superclas
 //-----------------------------------------------------------------------------
 ctkAbstractPythonManager::~ctkAbstractPythonManager()
 {
+  PythonQt::cleanup();
+
   if (Py_IsInitialized())
     {
     Py_Finalize();
     }
-  PythonQt::cleanup();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This commit moves the call to PythonQt's cleanup function to be before the call that finalizes the Python interpreter. The interpreter should still be running during PythonQt::cleanup() so that calls to Py_DECREF succeed.

Applying this change exposes problems in PythonQt, so the following PythonQt PRs should be applied before this:
https://github.com/commontk/PythonQt/pull/25
https://github.com/commontk/PythonQt/pull/26
