### PR TITLE
ctkAbstractPythonManager: revert change to clean up PythonQt before f…

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -66,7 +66,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
     message(FATAL_ERROR "error: Python is required to build ${PROJECT_NAME}")
   endif()
 
-  set(revision_tag b0194d0ce4a98a21c76344685c6bf7d77f870c7e)
+  set(revision_tag d1b0cacf96d20513cd68cdfbdf9dc686b104c477)
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
@@ -86,12 +86,11 @@ ctkAbstractPythonManager::ctkAbstractPythonManager(QObject* _parent) : Superclas
 //-----------------------------------------------------------------------------
 ctkAbstractPythonManager::~ctkAbstractPythonManager()
 {
-  PythonQt::cleanup();
-
   if (Py_IsInitialized())
     {
     Py_Finalize();
     }
+  PythonQt::cleanup();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
…inalizing the Python interpreter

This commit reverts 77a24f217d3ef65586107dded4d1df76e36049bf.

The original change worked in conjunction with fixes in PythonQt to avoid
various crashes while destroying the ctkAbstractPythonManager, for example by
calling Py_DECREF after the Python interpreter was finalized.

Further testing shows that a better fix is indeed to finalize first to ensure
clean destruction of PythonQt objects, and to make PythonQt's clean up step more
robust by handling a finalized interpreter.

An example of code which necessitates this change is creating an instance of
class Foo:

```
    class Foo(object):

      def __init__(self):
	    self.timer = qt.QTimer()

      def __del__(self):
	    self.timer.setSingleShot(True)
```

During Py_Finalize(), the Foo instance's __del__ method is called, which in turn
calls a method on a Qt object. For this to succeed, PythonQt's data must still
be in place.

This depends on https://github.com/commontk/PythonQt/pull/31