### PR TITLE
Update PythonQt to fix crash during PythonQt::cleanup()

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -66,7 +66,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
     message(FATAL_ERROR "error: Python is required to build ${PROJECT_NAME}")
   endif()
 
-  set(revision_tag d1b0cacf96d20513cd68cdfbdf9dc686b104c477)
+  set(revision_tag cbf890f8eda122b8dca8e67d2bf75e85640ab297)
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()


### PR DESCRIPTION
Update PythonQt to commontk/PythonQt@cbf890f8eda122b8dca8e67d2bf75e85640ab297:

// -------------------------
    commit cbf890f8eda122b8dca8e67d2bf75e85640ab297
    Author: Max Smolens <max.smolens@kitware.com>
    Date:   Tue Sep 15 15:45:30 2015 -0400

	Fix PythonQtSignalReceiver crash during cleanup

	This commit fixes a crash during PythonQt::cleanup(). While destroying the
	PythonQtPrivate instance, any remaining PythonQtSignalReceivers that are kept
	alive only by their parent object will be destroyed. The crash occurs when
	PythonQtSignalReceiver's destructor calls back into
	PythonQtPrivate::removeSignalEmitter() when the PythonQtPrivate instance is
	mostly destroyed.

	Includes test case that crashes without the fix.
// -------------------------