### PR TITLE
Extend the ctkPluginFrameworkLauncher convenience run method to accept cl args

### DIFF
--- a/Libs/PluginFramework/ctkPluginFrameworkLauncher.cpp
+++ b/Libs/PluginFramework/ctkPluginFrameworkLauncher.cpp
@@ -388,7 +388,7 @@ void ctkPluginFrameworkLauncher::setFrameworkProperties(const ctkProperties& pro
 }
 
 //----------------------------------------------------------------------------
-QVariant ctkPluginFrameworkLauncher::run(QRunnable* endSplashHandler)
+QVariant ctkPluginFrameworkLauncher::run(QRunnable* endSplashHandler, const QVariant& argument)
 {
   if (d->running)
   {
@@ -424,9 +424,9 @@ QVariant ctkPluginFrameworkLauncher::run(QRunnable* endSplashHandler)
       startup(d->endSplashHandler);
       if (ctkPluginFrameworkProperties::getProperty(PROP_IGNOREAPP).toBool() || d->isForcedRestart())
       {
-        return QVariant();
+        return argument;
       }
-      return run(QVariant());
+      return run(argument);
     }
     catch (const std::exception& e)
     {

--- a/Libs/PluginFramework/ctkPluginFrameworkLauncher.h
+++ b/Libs/PluginFramework/ctkPluginFrameworkLauncher.h
@@ -107,10 +107,11 @@ public:
    *
    * @param endSplashHandler the block of code to run to tear down the splash
    * 	screen or <code>null</code> if no tear down is required
+   * @param argument the argument passed to the application. Default is QVariant().
    * @return the result of running the application
    * @throws Exception if anything goes wrong
    */
-  static QVariant run(QRunnable* endSplashHandler = NULL);
+  static QVariant run(QRunnable* endSplashHandler = NULL, const QVariant& argument = QVariant());
 
   /**
    * Runs the application for which the platform was started. The platform


### PR DESCRIPTION
Previously one either had the choice of using the convenience run method,
without having the option of handling command line arguments, or handling
startup etc oneself. This change will add an additional parameter to the
convenience run method which takes the command line arguments and hands
them through.

cc: @saschazelzer