### PR TITLE
Expose option on ctkConsole to control the runFile() interface

### DIFF
--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -59,6 +59,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QKeyEvent>
 #include <QMimeData>
 #include <QPointer>
+#include <QPushButton>
 #include <QTextCursor>
 #include <QVBoxLayout>
 #include <QScrollBar>
@@ -94,7 +95,10 @@ ctkConsolePrivate::ctkConsolePrivate(ctkConsole& object) :
   InteractivePosition(documentEnd()),
   MultilineStatement(false), Ps1("$ "), Ps2("> "),
   EditorHints(ctkConsole::AutomaticIndentation | ctkConsole::RemoveTrailingSpaces),
-  ScrollbarAtBottom(false)
+  ScrollbarAtBottom(false),
+  RunFileOptions(ctkConsole::RunFileButton | ctkConsole::RunFileShortcut),
+  RunFileButton(NULL),
+  RunFileAction(NULL)
 {
 }
 
@@ -128,23 +132,29 @@ void ctkConsolePrivate::init()
   this->CommandHistory.append("");
   this->CommandPosition = 0;
 
-  QAction* runFileAction = new QAction(q->tr("&Run file"),q);
-  runFileAction->setShortcut(q->tr("Ctrl+r"));
-  connect(runFileAction, SIGNAL(triggered()), q, SLOT(runFile()));
-  q->addAction(runFileAction);
+  this->RunFileAction = new QAction(q->tr("&Run file"), q);
+  this->RunFileAction->setShortcut(q->tr("Ctrl+r"));
+  connect(this->RunFileAction, SIGNAL(triggered()), q, SLOT(runFile()));
+  q->addAction(this->RunFileAction);
 
   QAction* printHelpAction = new QAction(q->tr("Print &help"),q);
   printHelpAction->setShortcut(q->tr("Ctrl+h"));
   connect(printHelpAction, SIGNAL(triggered()), q, SLOT(printHelp()));
   q->addAction(printHelpAction);
 
+  this->RunFileButton = new QPushButton(q);
+  this->RunFileButton->setText(q->tr("&Run script from file"));
+
   QVBoxLayout * layout = new QVBoxLayout(q);
   layout->setMargin(0);
+  layout->setSpacing(0);
   layout->addWidget(this);
+  layout->addWidget(this->RunFileButton);
 
   connect(this->verticalScrollBar(), SIGNAL(valueChanged(int)),
           SLOT(onScrollBarValueChanged(int)));
   connect(this, SIGNAL(textChanged()), SLOT(onTextChanged()));
+  connect(this->RunFileButton, SIGNAL(clicked()), q, SLOT(runFile()));
 }
 
 //-----------------------------------------------------------------------------
@@ -950,6 +960,17 @@ void ctkConsole::setScrollBarPolicy(const Qt::ScrollBarPolicy& newScrollBarPolic
 {
   Q_D(ctkConsole);
   d->setVerticalScrollBarPolicy(newScrollBarPolicy);
+}
+
+//-----------------------------------------------------------------------------
+CTK_GET_CPP(ctkConsole, ctkConsole::RunFileOptions, runFileOptions, RunFileOptions);
+
+//-----------------------------------------------------------------------------
+void ctkConsole::setRunFileOptions(const RunFileOptions& newOptions)
+{
+  Q_D(ctkConsole);
+  d->RunFileButton->setVisible(newOptions.testFlag(ctkConsole::RunFileButton));
+  d->RunFileAction->setEnabled(newOptions.testFlag(ctkConsole::RunFileShortcut));
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -96,7 +96,7 @@ ctkConsolePrivate::ctkConsolePrivate(ctkConsole& object) :
   MultilineStatement(false), Ps1("$ "), Ps2("> "),
   EditorHints(ctkConsole::AutomaticIndentation | ctkConsole::RemoveTrailingSpaces),
   ScrollbarAtBottom(false),
-  RunFileOptions(ctkConsole::RunFileButton | ctkConsole::RunFileShortcut),
+  RunFileOptions(ctkConsole::RunFileShortcut),
   RunFileButton(NULL),
   RunFileAction(NULL)
 {
@@ -144,6 +144,7 @@ void ctkConsolePrivate::init()
 
   this->RunFileButton = new QPushButton(q);
   this->RunFileButton->setText(q->tr("&Run script from file"));
+  this->RunFileButton->setVisible(false);
 
   QVBoxLayout * layout = new QVBoxLayout(q);
   layout->setMargin(0);

--- a/Libs/Widgets/ctkConsole.h
+++ b/Libs/Widgets/ctkConsole.h
@@ -80,7 +80,9 @@ class CTK_WIDGETS_EXPORT ctkConsole : public QWidget
   Q_PROPERTY(EditorHints editorHints READ editorHints WRITE setEditorHints)
   Q_ENUMS(Qt::ScrollBarPolicy)
   Q_PROPERTY(Qt::ScrollBarPolicy scrollBarPolicy READ scrollBarPolicy WRITE setScrollBarPolicy)
-  
+  Q_FLAGS(RunFileOption RunFileOptions)
+  Q_PROPERTY(RunFileOptions runFileOptions READ runFileOptions WRITE setRunFileOptions)
+
 public:
 
   enum EditorHint
@@ -91,6 +93,14 @@ public:
     SplitCopiedTextByLine = 0x4  /*!< Copied text is split by lines and each one is executed (expected the last one) */
   };
   Q_DECLARE_FLAGS(EditorHints, EditorHint)
+
+  enum RunFileOption
+  {
+    NoRunFileUserInterface = 0x00,
+    RunFileButton = 0x01,   /*!< Show a button at the bottom of the console to run a file */
+    RunFileShortcut = 0x02, /*!< Add the shortcut CTRL+r to run a file */
+  };
+  Q_DECLARE_FLAGS(RunFileOptions, RunFileOption)
 
   ctkConsole(QWidget* parentObject = 0);
   typedef QWidget Superclass;
@@ -174,6 +184,13 @@ public:
   virtual void setPs2(const QString& newPs2);
 
   static QString stdInRedirectCallBack(void * callData);
+
+  RunFileOptions runFileOptions()const;
+
+  /// Set what options are visible to the user to run a file.
+  /// Default is RunFileButton | RunFileShortcut.
+  /// \sa runFileOptions()
+  void setRunFileOptions(const RunFileOptions& newOptions);
 
 Q_SIGNALS:
 

--- a/Libs/Widgets/ctkConsole.h
+++ b/Libs/Widgets/ctkConsole.h
@@ -187,8 +187,8 @@ public:
 
   RunFileOptions runFileOptions()const;
 
-  /// Set what options are visible to the user to run a file.
-  /// Default is RunFileButton | RunFileShortcut.
+  /// Set which options to run file are enabled.
+  /// Default is RunFileShortcut.
   /// \sa runFileOptions()
   void setRunFileOptions(const RunFileOptions& newOptions);
 

--- a/Libs/Widgets/ctkConsole_p.h
+++ b/Libs/Widgets/ctkConsole_p.h
@@ -30,6 +30,8 @@
 #include "ctkConsole.h"
 #include "ctkWidgetsExport.h"
 
+class QPushButton;
+
 /// \ingroup Widgets
 class CTK_WIDGETS_EXPORT ctkConsolePrivate : public QTextEdit
 {
@@ -185,6 +187,11 @@ public:
   bool ScrollbarAtBottom;
 
   QPointer<QEventLoop> InputEventLoop;
+
+  ctkConsole::RunFileOptions RunFileOptions;
+
+  QPushButton* RunFileButton;
+  QAction* RunFileAction;
 };
 
 


### PR DESCRIPTION
A shortcut to be able to run a file already existed. This commit adds a
button at the bottom of the console to do the same thing.
It also adds designable flags that control whether:
 - The button is visible
 - The shortcut is active
Default is shortcut active and the button is visible.