### PR TITLE
Workaround refined macro warning when building CTKDICOMWidgetsPythonQt

### DIFF
--- a/CMake/ctkWrapPythonQt.py
+++ b/CMake/ctkWrapPythonQt.py
@@ -186,8 +186,16 @@ ${pythonqtWrappers}
 //
 
 #include <PythonQt.h>
-// XXX Avoid  warning: "HAVE_STAT" redefined
+// XXX Avoid  warning: "HAVE_XXXX" redefined
 #undef HAVE_STAT
+#undef HAVE_FTIME
+#undef HAVE_GETPID
+#undef HAVE_IO_H
+#undef HAVE_STRERROR
+#undef HAVE_SYS_UTIME_H
+#undef HAVE_TEMPNAM
+#undef HAVE_TMPNAM
+#undef HAVE_LONG_LONG
 #include "${namespace}_${target}.h"
 
 void PythonQt_init_${namespace}_${target}(PyObject* module)

--- a/CMake/ctkWrapPythonQt.py
+++ b/CMake/ctkWrapPythonQt.py
@@ -196,6 +196,7 @@ ${pythonqtWrappers}
 #undef HAVE_TEMPNAM
 #undef HAVE_TMPNAM
 #undef HAVE_LONG_LONG
+#undef HAVE_INT64_T
 #include "${namespace}_${target}.h"
 
 void PythonQt_init_${namespace}_${target}(PyObject* module)


### PR DESCRIPTION
This commit applies a patch similar to what was done in 09c2580. It basically
adds a workaround to avoid the warnings list below:

Warning	1	warning C4005: 'HAVE_FTIME' : macro redefinition	C:\D\N\Slicer-1-build\DCMTK-build\config\include\dcmtk\config\osconfig.h	175
Warning	2	warning C4005: 'HAVE_GETPID' : macro redefinition	C:\D\N\Slicer-1-build\DCMTK-build\config\include\dcmtk\config\osconfig.h	217
Warning	3	warning C4005: 'HAVE_IO_H' : macro redefinition	C:\D\N\Slicer-1-build\DCMTK-build\config\include\dcmtk\config\osconfig.h	274
Warning	4	warning C4005: 'HAVE_STRERROR' : macro redefinition	C:\D\N\Slicer-1-build\DCMTK-build\config\include\dcmtk\config\osconfig.h	622
Warning	5	warning C4005: 'HAVE_SYS_UTIME_H' : macro redefinition	C:\D\N\Slicer-1-build\DCMTK-build\config\include\dcmtk\config\osconfig.h	718
Warning	6	warning C4005: 'HAVE_TEMPNAM' : macro redefinition	C:\D\N\Slicer-1-build\DCMTK-build\config\include\dcmtk\config\osconfig.h	727
Warning	7	warning C4005: 'HAVE_TMPNAM' : macro redefinition	C:\D\N\Slicer-1-build\DCMTK-build\config\include\dcmtk\config\osconfig.h	736
Warning	8	warning C4005: 'HAVE_LONG_LONG' : macro redefinition	C:\D\N\Slicer-1-build\DCMTK-build\config\include\dcmtk\config\osconfig.h	974