### PR TITLE
Add an option to the ctkConsole to add/set the completion shortcuts

### DIFF
--- a/Libs/Scripting/Python/Widgets/Testing/Cpp/ctkPythonConsoleTest1.cpp
+++ b/Libs/Scripting/Python/Widgets/Testing/Cpp/ctkPythonConsoleTest1.cpp
@@ -26,6 +26,7 @@
 // CTK includes
 #include "ctkPythonConsole.h"
 #include "ctkAbstractPythonManager.h"
+#include "ctkCompleter.h"
 
 // STD includes
 #include <cstdlib>
@@ -41,6 +42,12 @@ int ctkPythonConsoleTest1(int argc, char * argv [] )
   ctkPythonConsole pythonConsole;
   ctkAbstractPythonManager pythonManager;
   pythonConsole.initialize(&pythonManager);
+
+  QList<QKeySequence> otherShortcuts;
+  otherShortcuts << QKeySequence(Qt::CTRL + Qt::Key_Space);
+  otherShortcuts << Qt::Key_F1;
+  pythonConsole.setCompleterShortcuts(otherShortcuts);
+  pythonConsole.addCompleterShortcut(Qt::Key_Tab);
 
   QObject::connect(&button, SIGNAL(clicked()), &pythonConsole, SLOT(show()));
 

--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -94,7 +94,8 @@ ctkConsolePrivate::ctkConsolePrivate(ctkConsole& object) :
   InteractivePosition(documentEnd()),
   MultilineStatement(false), Ps1("$ "), Ps2("> "),
   EditorHints(ctkConsole::AutomaticIndentation | ctkConsole::RemoveTrailingSpaces),
-  ScrollbarAtBottom(false)
+  ScrollbarAtBottom(false),
+  CompleterShortcuts(QList<QKeySequence>() << Qt::Key_Tab)
 {
 }
 
@@ -402,7 +403,7 @@ void ctkConsolePrivate::keyPressEvent(QKeyEvent* e)
     return;
     }
 
-  if (e->key() == Qt::Key_Tab)
+  if (this->CompleterShortcuts.contains(e->key() + e->modifiers()))
     {
     e->accept();
     this->updateCompleter();
@@ -950,6 +951,26 @@ void ctkConsole::setScrollBarPolicy(const Qt::ScrollBarPolicy& newScrollBarPolic
 {
   Q_D(ctkConsole);
   d->setVerticalScrollBarPolicy(newScrollBarPolicy);
+}
+
+//-----------------------------------------------------------------------------
+CTK_GET_CPP(ctkConsole, QList<QKeySequence>, completerShortcuts, CompleterShortcuts);
+
+//-----------------------------------------------------------------------------
+void ctkConsole::setCompleterShortcuts(const QList<QKeySequence>& keys)
+{
+  Q_D(ctkConsole);
+  d->CompleterShortcuts = keys;
+}
+
+//-----------------------------------------------------------------------------
+void ctkConsole::addCompleterShortcut(const QKeySequence& key)
+{
+  Q_D(ctkConsole);
+  if (!d->CompleterShortcuts.contains(key))
+    {
+    d->CompleterShortcuts.append(key);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Widgets/ctkConsole.h
+++ b/Libs/Widgets/ctkConsole.h
@@ -80,7 +80,8 @@ class CTK_WIDGETS_EXPORT ctkConsole : public QWidget
   Q_PROPERTY(EditorHints editorHints READ editorHints WRITE setEditorHints)
   Q_ENUMS(Qt::ScrollBarPolicy)
   Q_PROPERTY(Qt::ScrollBarPolicy scrollBarPolicy READ scrollBarPolicy WRITE setScrollBarPolicy)
-  
+  Q_PROPERTY(QList<QKeySequence> completerShortcuts READ completerShortcuts WRITE setCompleterShortcuts)
+
 public:
 
   enum EditorHint
@@ -174,6 +175,20 @@ public:
   virtual void setPs2(const QString& newPs2);
 
   static QString stdInRedirectCallBack(void * callData);
+
+  /// Get the list of shortcuts that trigger the completion options.
+  /// \sa setCompleterShortcuts(), addCompleterShortcut()
+  QList<QKeySequence> completerShortcuts()const;
+
+  /// Set the list of shortcuts showing the completion options.
+  /// Default is simply Qt::Key_Tab.
+  /// \sa completerShortcuts(), addCompleterShortcut()
+  void setCompleterShortcuts(const QList<QKeySequence>& keys);
+
+  /// Convenience method to add a key sequence to the list of shortcuts that
+  /// show the completion options.
+  /// \sa completerShortcuts(), setCompleterShortcuts()
+  void addCompleterShortcut(const QKeySequence& key);
 
 Q_SIGNALS:
 

--- a/Libs/Widgets/ctkConsole_p.h
+++ b/Libs/Widgets/ctkConsole_p.h
@@ -185,6 +185,8 @@ public:
   bool ScrollbarAtBottom;
 
   QPointer<QEventLoop> InputEventLoop;
+
+  QList<QKeySequence> CompleterShortcuts;
 };
 
 


### PR DESCRIPTION
As of now, the user can add shortcuts to the console to trigger the
completion.
Default key (tab) is the same as before to preserve backward compatibility.