### PR TITLE
Compile and link with vtk 6.2 and QT5 on Debian sid

### DIFF
--- a/Libs/Visualization/VTK/Core/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Core/CMakeLists.txt
@@ -90,12 +90,9 @@ if(${VTK_VERSION_MAJOR} GREATER 5)
     list(APPEND VTK_LIBRARIES vtkRenderingFreeTypeOpenGL)
   endif()
   if (TARGET vtkRenderingFreeTypeFontConfig AND UNIX AND NOT APPLE)
-    find_package(FontConfig QUIET)
-    if (FONTCONFIG_FOUND)
       list(APPEND VTK_LIBRARIES
         vtkRenderingFreeTypeFontConfig
         )
-    endif()
   endif()
 else()
   set(VTK_LIBRARIES

--- a/Libs/Visualization/VTK/Core/Testing/Cpp/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Core/Testing/Cpp/CMakeLists.txt
@@ -40,6 +40,7 @@ if(CTK_QT_VERSION VERSION_GREATER "4")
   QT5_GENERATE_MOCS(
     ctkVTKConnectionTestObjectDelete.cpp
     )
+  include_directories(${Qt5Widgets_INCLUDE_DIRS})
 else()
   QT4_WRAP_CPP(KIT_HELPER_SRCS ctkVTKObjectTestHelper.h)
   QT4_GENERATE_MOCS(

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/CMakeLists.txt
@@ -137,7 +137,13 @@ else()
   set(VTK_CHARTS_LIB vtkCharts)
 endif()
 
+
+
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME} ${VTK_CHARTS_LIB} ${CTK_BASE_LIBRARIES})
+
+if(CTK_QT_VERSION VERSION_GREATER "4")
+    target_link_libraries(${KIT}CppTests ${Qt5Test_LIBRARIES})
+endif()
 
 #
 # Add Tests


### PR DESCRIPTION
Hello, 

this pull request provides two small fixes to enable compilation with VTK6 and QT5 on the current Debian sid installation. The compile configuration is very close to the already existing experimental Debian package from 2013 ( see https://anonscm.debian.org/viewvc/debian-med/trunk/packages/ctk/trunk/debian/rules?view=markup ) 

Please see the commit messages for further details.