### PR TITLE
Remove superfluous test on fontconfig

### DIFF
--- a/Libs/Visualization/VTK/Core/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Core/CMakeLists.txt
@@ -90,12 +90,9 @@ if(${VTK_VERSION_MAJOR} GREATER 5)
     list(APPEND VTK_LIBRARIES vtkRenderingFreeTypeOpenGL)
   endif()
   if (TARGET vtkRenderingFreeTypeFontConfig AND UNIX AND NOT APPLE)
-    find_package(FontConfig QUIET)
-    if (FONTCONFIG_FOUND)
       list(APPEND VTK_LIBRARIES
         vtkRenderingFreeTypeFontConfig
         )
-    endif()
   endif()
 else()
   set(VTK_LIBRARIES


### PR DESCRIPTION
The test is run but only used to see if vtkRenderingFreeTypeFontConfig is
to be linked, but it is already tested whether the vtk target
vtkRenderingFreeTypeFontConfig actually exists.

In addition on Debian the FontConficConfig.cmake file doesn't extist, so the
test fails and linking as well, because the needed
vtkRenderingFreeTypeFontConfig is not added to the linker line.