### PR TITLE
ctkCheckableComboBox: implemented missing method checkableModelHelper()

### DIFF
--- a/Libs/Widgets/ctkCheckableComboBox.cpp
+++ b/Libs/Widgets/ctkCheckableComboBox.cpp
@@ -345,6 +345,13 @@ Qt::CheckState ctkCheckableComboBox::checkState(const QModelIndex& index)const
 }
 
 //-----------------------------------------------------------------------------
+ctkCheckableModelHelper* ctkCheckableComboBox::checkableModelHelper()const
+{
+  Q_D(const ctkCheckableComboBox);
+  return d->CheckableModelHelper;
+}
+
+//-----------------------------------------------------------------------------
 void ctkCheckableComboBox::onDataChanged(const QModelIndex& start, const QModelIndex& end)
 {
   Q_D(ctkCheckableComboBox);


### PR DESCRIPTION
The method ctkCheckableComboBox::checkableModelHelper() is declared in
the header file but not implemented in the source file. This adds the
proper implementation.