### PR TITLE
Xnat session timeout handling

### DIFF
--- a/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
+++ b/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.cpp
@@ -101,8 +101,8 @@ void ctkXnatTreeBrowserMainWindow::loginButtonPushed()
       {
         ui->loginButton->setText("Logout");
         ui->loginLabel->setText(QString("Connected: %1").arg(m_Session->url().toString()));
-        this->connect(m_Session, SIGNAL(sessionTimedOut()), this, SLOT(sessionTimedOutMsg()));
-        this->connect(m_Session, SIGNAL(sessionAboutToBeTimedOut()), this, SLOT(sessionTimesOutSoonMsg()));
+        this->connect(m_Session, SIGNAL(timedOut()), this, SLOT(sessionTimedOutMsg()));
+        this->connect(m_Session, SIGNAL(aboutToTimeOut()), this, SLOT(sessionAboutToTimeOutMsg()));
 
         ctkXnatDataModel* dataModel = m_Session->dataModel();
         m_TreeModel->addDataModel(dataModel);
@@ -198,7 +198,7 @@ void ctkXnatTreeBrowserMainWindow::sessionTimedOutMsg()
   QMessageBox::warning(this, "Session Timeout", "The session timed out.");
 }
 
-void ctkXnatTreeBrowserMainWindow::sessionTimesOutSoonMsg()
+void ctkXnatTreeBrowserMainWindow::sessionAboutToTimeOutMsg()
 {
   QMessageBox msgBox;
   msgBox.setIcon(QMessageBox::Warning);

--- a/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.h
+++ b/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.h
@@ -49,7 +49,7 @@ private Q_SLOTS:
   void addResourceClicked();
   void uploadFileClicked();
   void sessionTimedOutMsg();
-  void sessionTimesOutSoonMsg();
+  void sessionAboutToTimeOutMsg();
 
 private:
   Ui::ctkXnatTreeBrowserMainWindow* ui;

--- a/Libs/XNAT/Core/ctkXnatSession.h
+++ b/Libs/XNAT/Core/ctkXnatSession.h
@@ -273,14 +273,14 @@ public:
   Q_SIGNAL void progress(QUuid, double);
 
   /**
-   * @brief Signals that the session is timed out.
+   * @brief Signals that the session has timed out.
    */
-  Q_SIGNAL void sessionTimedOut();
+  Q_SIGNAL void timedOut();
 
   /**
    * @brief Signals that the session will time out in one minute.
    */
-  Q_SIGNAL void sessionAboutToBeTimedOut();
+  Q_SIGNAL void aboutToTimeOut();
 
 public slots:
   void processResult(QUuid queryId, QList<QVariantMap> parameters);
@@ -292,7 +292,7 @@ protected:
 private:
   Q_DECLARE_PRIVATE(ctkXnatSession)
   Q_DISABLE_COPY(ctkXnatSession)
-  Q_SLOT void emitSessionTimeOut();
+  Q_SLOT void emitTimeOut();
 };
 
 #endif


### PR DESCRIPTION
Currently the CTK XNAT API does not notice when the XNAT session times out.
Accessing XNAT via the CTK XNAT API after a session timeout leads currently to a crash.

With this pullrequest we added the handling of session timeouts to the ctkXnatSession and also to the ctkXnatTreeBrowser application. 