### PR TITLE
Xnat api fixes and improvements

### DIFF
--- a/Libs/XNAT/Core/ctkXnatDataModel.h
+++ b/Libs/XNAT/Core/ctkXnatDataModel.h
@@ -36,7 +36,7 @@ class ctkXnatSession;
  * @brief The ctkXnatDataModel class reprents the root object in a
  * XNAT data hierarchy.
  */
-class ctkXnatDataModel : public ctkXnatObject
+class CTK_XNAT_CORE_EXPORT ctkXnatDataModel : public ctkXnatObject
 {
 
 public:

--- a/Libs/XNAT/Core/ctkXnatFile.cpp
+++ b/Libs/XNAT/Core/ctkXnatFile.cpp
@@ -151,7 +151,7 @@ void ctkXnatFile::saveImpl(bool overwrite)
   Q_D(ctkXnatFile);
 
   ctkXnatSession::UrlParameters urlParams;
-  urlParams["xsi:type"] = this->schemaType();
+  urlParams["xsiType"] = this->schemaType();
   // Flag needed for file upload
   urlParams["inbody"] = "true";
 
@@ -165,7 +165,7 @@ void ctkXnatFile::saveImpl(bool overwrite)
     // Do not append these file specific properties since they require a slightly
     // different key for uploading a file (e.g. instead of "file_format" only "format")
     if (itProperties.key() == FILE_TAGS || itProperties.key() == FILE_FORMAT ||
-        itProperties.key() == FILE_CONTENT)
+        itProperties.key() == FILE_CONTENT || itProperties.key() == "xsiType")
       continue;
 
     urlParams[itProperties.key()] = itProperties.value();

--- a/Libs/XNAT/Core/ctkXnatObject.cpp
+++ b/Libs/XNAT/Core/ctkXnatObject.cpp
@@ -377,7 +377,7 @@ void ctkXnatObject::saveImpl(bool /*overwrite*/)
 {
   Q_D(ctkXnatObject);
   ctkXnatSession::UrlParameters urlParams;
-  urlParams["xsi:type"] = this->schemaType();
+  urlParams["xsiType"] = this->schemaType();
 
   // Just do this if there is already a valid last-modification-time,
   // otherwise the object is not yet on the server!
@@ -401,7 +401,7 @@ void ctkXnatObject::saveImpl(bool /*overwrite*/)
   while (itProperties.hasNext())
   {
     itProperties.next();
-    if (itProperties.key() == "ID")
+    if (itProperties.key() == "ID" || itProperties.key() == "xsiType")
       continue;
 
     urlParams[itProperties.key()] = itProperties.value();

--- a/Libs/XNAT/Core/ctkXnatResource.cpp
+++ b/Libs/XNAT/Core/ctkXnatResource.cpp
@@ -173,7 +173,7 @@ void ctkXnatResource::downloadImpl(const QString& filename)
 void ctkXnatResource::saveImpl(bool /*overwrite*/)
 {
   ctkXnatSession::UrlParameters urlParams;
-  urlParams["xsi:type"] = this->schemaType();
+  urlParams["xsiType"] = this->schemaType();
 
   const QMap<QString, QString>& properties = this->properties();
   QMapIterator<QString, QString> itProperties(properties);

--- a/Libs/XNAT/Core/ctkXnatScan.cpp
+++ b/Libs/XNAT/Core/ctkXnatScan.cpp
@@ -100,7 +100,7 @@ QString ctkXnatScan::type() const
 //----------------------------------------------------------------------------
 QString ctkXnatScan::resourceUri() const
 {
-  return QString("%1/%2").arg(parent()->resourceUri(), this->id());
+  return QString("%1/%2/resources").arg(parent()->resourceUri(), this->id());
 }
 
 //----------------------------------------------------------------------------
@@ -112,7 +112,24 @@ void ctkXnatScan::reset()
 //----------------------------------------------------------------------------
 void ctkXnatScan::fetchImpl()
 {
-  this->fetchResources();
+  QString query = this->resourceUri();
+  ctkXnatSession* const session = this->session();
+  QUuid queryId = session->httpGet(query);
+
+  QList<ctkXnatObject*> resources = session->httpResults(queryId,
+                                                           ctkXnatDefaultSchemaTypes::XSI_RESOURCE);
+
+  foreach (ctkXnatObject* resource, resources)
+  {
+    QString label = resource->name();
+    if (label.isEmpty())
+    {
+      label = "NO NAME";
+    }
+
+    resource->setName(label);
+    this->add(resource);
+  }
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
* Fixed misnamed named url parameter: "xsi:type" is wrong and may lead to query errors. Correct is "xsiType"
* Fixed a linker error that occurred on linux due to a missing export macro.
* Changed the way a ctkXnatScan is fetched by removing the ctkXnatResourceFolder from its hierarchy.
This prevents that a "Resource" folder is shown e.g. in the tree view between the scan and its resources