### PR TITLE
fix Core linking: FreeBSD does not have a libdl

### DIFF
--- a/Libs/Core/CMakeLists.txt
+++ b/Libs/Core/CMakeLists.txt
@@ -142,7 +142,7 @@ ctkMacroBuildLib(
   )
 
 # Needed for ctkBackTrace
-if(UNIX)
+if(UNIX AND NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   target_link_libraries(${PROJECT_NAME} dl)
 elseif(WIN32 AND NOT MINGW)
   target_link_libraries(${PROJECT_NAME} dbghelp)


### PR DESCRIPTION
The same functionality that is in linux's libdl is provided in FreeBSD's libc