### PR TITLE
Add /usr/local/include for FreeBSD (QtOpengl)

### DIFF
--- a/Libs/Widgets/CMakeLists.txt
+++ b/Libs/Widgets/CMakeLists.txt
@@ -6,6 +6,13 @@ project(CTKWidgets)
 
 set(KIT_export_directive "CTK_WIDGETS_EXPORT")
 
+# add local include directory for FreeBSD
+# (QtOpengl can't find GL/gl.h)
+# actual bug: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=195105
+if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+  include_directories("/usr/local/include")
+endif()
+
 #
 # Add the libraries QtTesting
 #


### PR DESCRIPTION
fix alike that in other project: https://github.com/dotnet/coreclr/pull/550/files
fixes building CTKWidgets on FreeBSD 10