### PR TITLE
Support Qt 5.5 compilation

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKCompositeFunction.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKCompositeFunction.cpp
@@ -168,7 +168,8 @@ ctkControlPoint* ctkVTKCompositeFunction::controlPoint(int index)const
   rangeY[1] = this->maxValue();
 
   // test piecewise
-  Q_ASSERT(valuesPWF[0] >= rangePWF[0] && valuesPWF[0] <= rangePWF [1] &&  // X
+#ifndef QT_NO_DEBUG
+  Q_ASSERT(valuesPWF[0] >= rangePWF[0] && valuesPWF[0] <= rangePWF[1] &&  // X
     valuesPWF[1] >= rangeY[0].toDouble() && valuesPWF[1] <= rangeY[1].toDouble()  &&  // Y
     valuesPWF[2] >= 0. && valuesPWF[2] <= 1. &&                // Midpoint
     valuesPWF[3] >= 0. && valuesPWF[3] <= 1. );                // Sharpness
@@ -181,7 +182,7 @@ ctkControlPoint* ctkVTKCompositeFunction::controlPoint(int index)const
     valuesCTF[3] >= 0. && valuesCTF[3] <= 1. &&  // Blue
     valuesCTF[4] >= 0. && valuesCTF[4] <= 1. &&  // MidPoint
     valuesCTF[5] >= 0. && valuesCTF[5] <= 1.);   // Sharpness
-
+#endif
   // if only 2 points -> linear
   if (index + 1 >= this->count())
     {
@@ -204,6 +205,7 @@ ctkControlPoint* ctkVTKCompositeFunction::controlPoint(int index)const
   d->PiecewiseFunction->GetNodeValue(index + 1, nextValuesPWF);
   d->ColorTransferFunction->GetNodeValue(index + 1, nextValuesCTF);
 
+#ifndef QT_NO_DEBUG
   Q_ASSERT(nextValuesPWF[0] >= rangePWF[0] && nextValuesPWF[0] <= rangePWF[1]  &&  // X
     nextValuesPWF[1] >= rangeY[0].toDouble() && nextValuesPWF[1] <= rangeY[1].toDouble()  &&  // Y
     nextValuesPWF[2] >= 0. && nextValuesPWF[2] <= 1. &&                // Midpoint
@@ -216,7 +218,7 @@ ctkControlPoint* ctkVTKCompositeFunction::controlPoint(int index)const
     nextValuesCTF[3] >= 0. && nextValuesCTF[3] <= 1. &&  // Blue
     nextValuesCTF[4] >= 0. && nextValuesCTF[4] <= 1. &&  // MidPoint
     nextValuesCTF[5] >= 0. && nextValuesCTF[5] <= 1.);   // Sharpness
-
+#endif
   // Optimization: don't use subPoints if the ramp is linear (sharpness == 0)
   if (valuesPWF[3] == 0. && valuesCTF[5] == 0.)
     {
@@ -324,7 +326,9 @@ int ctkVTKCompositeFunction::insertControlPoint(qreal pos)
       d->PiecewiseFunction->AddPoint( pos, 0);
 
   // check index
+#ifndef QT_NO_DEBUG
   Q_ASSERT(indexColor == indexPiecewise);
+#endif
 
   index = indexColor;
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKPiecewiseFunction.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKPiecewiseFunction.cpp
@@ -149,12 +149,12 @@ ctkControlPoint* ctkVTKPiecewiseFunction::controlPoint(int index)const
   rangeY[1] = this->maxValue();
   //    rangeYDiff /= rangeY[1].toReal() - rangeY[0].toReal();
 
-
+#ifndef QT_NO_DEBUG
   Q_ASSERT(values[0] >= range[0] && values[0] <= range [1] &&  // X
            values[1] >= rangeY[0].toDouble() && values[1] <= rangeY[1].toDouble()  &&  // Y
            values[2] >= 0. && values[2] <= 1. &&                // Midpoint
            values[3] >= 0. && values[3] <= 1. );                // Sharpness
-
+#endif
   if (index + 1 >= this->count())
     {
     ctkControlPoint* cp = new ctkControlPoint();
@@ -173,10 +173,12 @@ ctkControlPoint* ctkVTKPiecewiseFunction::controlPoint(int index)const
   double nextValues[4];
   d->PiecewiseFunction->GetNodeValue(index + 1, nextValues);
 
-  Q_ASSERT(nextValues[0] >= range[0] && nextValues[0] <= range[1]  &&  // X
+#ifndef QT_NO_DEBUG
+  Q_ASSERT(nextValues[0] >= range[0] && nextValues[0] <= range[1] &&  // X
            nextValues[1] >= rangeY[0].toDouble() && nextValues[1] <= rangeY[1].toDouble()  &&  // Y
            nextValues[2] >= 0. && nextValues[2] <= 1. &&                // Midpoint
            nextValues[3] >= 0. && nextValues[3] <= 1. );                // Sharpness
+#endif
   // Optimization: Don't use Subpoints if sharpness == 0
   if (values[3] == 0.)
     {


### PR DESCRIPTION
In Qt 5.5:
  Q_ASSERT will now expand the condition even in release mode when
  asserts are disabled, albeit in an unreachable code path. This
  solves compiler warnings about variables and functions that were
  unused in release mode because they were only used in assertions.
  Unfortunately, codebases that hid those functions and variables
  via #ifndef will need to remove the conditionals to compile with
  Qt 5.5.
  http://code.qt.io/cgit/qt/qtbase.git/tree/dist/changes-5.5.0