### PR TITLE
Added double click support for patients and studies table

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMTableManager.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMTableManager.cpp
@@ -98,6 +98,10 @@ void ctkDICOMTableManagerPrivate::init()
   QObject::connect(this->seriesTable, SIGNAL(selectionChanged(const QStringList&)),
                    q, SIGNAL(seriesSelectionChanged(const QStringList&)));
 
+  QObject::connect( this->patientsTable, SIGNAL( doubleClicked( const QModelIndex& ) ),
+                    q, SIGNAL( patientsDoubleClicked( const QModelIndex& ) ) );
+  QObject::connect( this->studiesTable, SIGNAL( doubleClicked( const QModelIndex& ) ),
+                    q, SIGNAL( studiesDoubleClicked( const QModelIndex& ) ) );
   QObject::connect(this->seriesTable, SIGNAL(doubleClicked(const QModelIndex&)),
                    q, SIGNAL(seriesDoubleClicked(const QModelIndex&)));
 

--- a/Libs/DICOM/Widgets/ctkDICOMTableManager.h
+++ b/Libs/DICOM/Widgets/ctkDICOMTableManager.h
@@ -114,6 +114,8 @@ Q_SIGNALS:
   void studiesSelectionChanged(const QStringList &uids);
   void seriesSelectionChanged(const QStringList &uids);
 
+  void patientsDoubleClicked( const QModelIndex&);
+  void studiesDoubleClicked( const QModelIndex&);
   void seriesDoubleClicked(const QModelIndex&);
 
   // signals to propagate the context menu requests from


### PR DESCRIPTION
This commit simply adds a redirection of the 'double click' signal
from patients and studies table, as it exists for series.

 On branch dicom-tablemanager-doubleclick
 Changes to be committed:
	modified:   Libs/DICOM/Widgets/ctkDICOMTableManager.cpp
	modified:   Libs/DICOM/Widgets/ctkDICOMTableManager.h