### PR TITLE
Add possibility to set proxy for xnat

### DIFF
--- a/Libs/XNAT/Core/ctkXnatSession.cpp
+++ b/Libs/XNAT/Core/ctkXnatSession.cpp
@@ -44,7 +44,6 @@
 #include <QStringBuilder>
 #include <QNetworkCookie>
 
-
 #include <ctkXnatAPI_p.h>
 #include <qRestResult.h>
 

--- a/Libs/XNAT/Core/ctkXnatSession.cpp
+++ b/Libs/XNAT/Core/ctkXnatSession.cpp
@@ -44,6 +44,7 @@
 #include <QStringBuilder>
 #include <QNetworkCookie>
 
+
 #include <ctkXnatAPI_p.h>
 #include <qRestResult.h>
 
@@ -734,4 +735,12 @@ void ctkXnatSession::emitTimeOut()
     d->timer->stop();
     emit timedOut();
   }
+}
+
+//----------------------------------------------------------------------------
+void ctkXnatSession::setHttpNetworkProxy(const QNetworkProxy& proxy)
+{
+  Q_D(ctkXnatSession);
+
+  d->xnat->setHttpNetworkProxy(proxy);
 }

--- a/Libs/XNAT/Core/ctkXnatSession.h
+++ b/Libs/XNAT/Core/ctkXnatSession.h
@@ -32,6 +32,7 @@
 #include <QUuid>
 
 class QDateTime;
+class QNetworkProxy;
 
 class ctkXnatSessionPrivate;
 
@@ -158,6 +159,15 @@ public:
     * @param path the path to the download location
     */
   void setDefaultDownloadDir(const QString& path);
+
+  /**
+    * @brief Sets a network proxy that will be used to connect with XNAT
+    *
+    * Tells the qRestAPI to use a network proxy for the connection to XNAT
+    *
+    * @param proxy the network proxy that will be set
+    */
+  void setHttpNetworkProxy(const QNetworkProxy& proxy);
 
   /**
     * @brief returns the default download location


### PR DESCRIPTION
This is sometimes necessary if the computer from which you want to connect to XNAT is behind a proxy.
Otherwise the connection to XNAT might not be possible.