### PR TITLE
Adding the xsiType=xnat:resource query parameter leads to an error when upload ing resources to XNAT

### DIFF
--- a/Libs/XNAT/Core/ctkXnatResource.cpp
+++ b/Libs/XNAT/Core/ctkXnatResource.cpp
@@ -173,6 +173,7 @@ void ctkXnatResource::downloadImpl(const QString& filename)
 void ctkXnatResource::saveImpl(bool /*overwrite*/)
 {
   ctkXnatSession::UrlParameters urlParams;
+  urlParams["xsi:type"] = this->schemaType();
 
   const QMap<QString, QString>& properties = this->properties();
   QMapIterator<QString, QString> itProperties(properties);

--- a/Libs/XNAT/Core/ctkXnatResource.cpp
+++ b/Libs/XNAT/Core/ctkXnatResource.cpp
@@ -173,7 +173,6 @@ void ctkXnatResource::downloadImpl(const QString& filename)
 void ctkXnatResource::saveImpl(bool /*overwrite*/)
 {
   ctkXnatSession::UrlParameters urlParams;
-  urlParams["xsiType"] = this->schemaType();
 
   const QMap<QString, QString>& properties = this->properties();
   QMapIterator<QString, QString> itProperties(properties);


### PR DESCRIPTION
error 422: Unprocessable entity

This can be reproduced with curl.
Omitting this query parameter solve the issue