### PR TITLE
fix build on platforms where qreal is not equivalent of double

### DIFF
--- a/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp
+++ b/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp
@@ -295,16 +295,16 @@ void ctkMaterialPropertyPreviewLabel::draw(QImage& image)
         ref.setZ( 2.*normal.z()*dot - light.z());
         ref.normalize();
 
-        qreal diffuseComp = qMax(diffuse * dot, 0.);
+        qreal diffuseComp = qMax(diffuse * dot, static_cast<qreal>(0.));
 
         qreal specularDot = qMax(static_cast<qreal>(QVector3D::dotProduct(ref, view)), static_cast<qreal>(0));
 
         qreal specularComp = specular*pow(specularDot, specular_power);
 
         QVector3D intensity;
-        intensity.setX( qMin((ambient + diffuseComp)*d->Color.redF() + specularComp, static_cast<qreal>(1.)));
-        intensity.setY( qMin((ambient + diffuseComp)*d->Color.greenF() + specularComp, static_cast<qreal>(1.)));
-        intensity.setZ( qMin((ambient + diffuseComp)*d->Color.blueF() + specularComp, static_cast<qreal>(1.)));
+        intensity.setX( qMin(static_cast<qreal>((ambient + diffuseComp)*d->Color.redF() + specularComp), static_cast<qreal>(1.)));
+        intensity.setY( qMin(static_cast<qreal>((ambient + diffuseComp)*d->Color.greenF() + specularComp), static_cast<qreal>(1.)));
+        intensity.setZ( qMin(static_cast<qreal>((ambient + diffuseComp)*d->Color.blueF() + specularComp), static_cast<qreal>(1.)));
 
         if (opacity == 1.)
           {

--- a/Libs/Widgets/ctkTransferFunctionBarsItem.cpp
+++ b/Libs/Widgets/ctkTransferFunctionBarsItem.cpp
@@ -92,7 +92,7 @@ ctkTransferFunctionBarsItem::~ctkTransferFunctionBarsItem()
 void ctkTransferFunctionBarsItem::setBarWidth(qreal newBarWidthRatio)
 {
   Q_D(ctkTransferFunctionBarsItem);
-  newBarWidthRatio = qBound(0., newBarWidthRatio, 1.);
+  newBarWidthRatio = qBound(static_cast<qreal>(0.), newBarWidthRatio, static_cast<qreal>(1.));
   if (d->BarWidthRatio == newBarWidthRatio)
     {
     return;


### PR DESCRIPTION
On some platforms, e. g. Fedora armv7hl, CTK fails to build with the following errors:

~~~
[ 30%] Building CXX object Libs/Widgets/CMakeFiles/CTKWidgets.dir/ctkMaterialPropertyPreviewLabel.cpp.o
cd /builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/build/Libs/Widgets && /usr/bin/c++   -DCTKWidgets_EXPORTS -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_OPENGL_LIB -DQT_SQL_LIB -DQT_TEST_LIB -DQT_XMLPATTERNS_LIB -DQT_XML_LIB -isystem /usr/include/QtOpenGL -isystem /usr/include/QtXmlPatterns -isystem /usr/include/QtGui -isystem /usr/include/QtTest -isystem /usr/include/QtXml -isystem /usr/include/QtSql -isystem /usr/include/QtNetwork -isystem /usr/include/QtCore -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/build/Libs/Widgets -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/build/Libs/Widgets/Resources/UI -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/build -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Core -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/build/Libs/Core  -Wall -Wextra -Wpointer-arith -Winvalid-pch -Wcast-align -Wwrite-strings -fdiagnostics-show-option -Wl,--no-undefined -fstack-protector-all -Woverloaded-virtual -Wold-style-cast -Wstrict-null-sentinel -Wsign-promo -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -march=armv7-a -mfpu=vfpv3-d16  -mfloat-abi=hard    -fvisibility=hidden -fvisibility-inlines-hidden   -g -fPIC   -o CMakeFiles/CTKWidgets.dir/ctkMaterialPropertyPreviewLabel.cpp.o -c /builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp: In member function 'void ctkMaterialPropertyPreviewLabel::draw(QImage&)':
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:298:51: error: no matching function for call to 'qMax(qreal, double)'
         qreal diffuseComp = qMax(diffuse * dot, 0.);
                                                   ^
In file included from /usr/include/QtGui/qrgb.h:45:0,
                 from /usr/include/QtGui/qcolor.h:45,
                 from /usr/include/QtGui/QColor:1,
                 from /builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:22:
/usr/include/QtCore/qglobal.h:1328:34: note: candidate: template<class T> constexpr const T& qMax(const T&, const T&)
 Q_DECL_CONSTEXPR inline const T &qMax(const T &a, const T &b) { return (a < b) ? b : a; }
                                  ^~~~
/usr/include/QtCore/qglobal.h:1328:34: note:   template argument deduction/substitution failed:
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:298:51: note:   deduced conflicting types for parameter 'const T' ('float' and 'double')
         qreal diffuseComp = qMax(diffuse * dot, 0.);
                                                   ^
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:318:140: error: no matching function for call to 'qMin(double, qreal)'
           rgba = qRgba(static_cast<unsigned char>(qMin(255. * intensity.x() * opacity + qRed(rgba)*(1. - opacity), static_cast<qreal>(255.))),
                                                                                                                                            ^
In file included from /usr/include/QtGui/qrgb.h:45:0,
                 from /usr/include/QtGui/qcolor.h:45,
                 from /usr/include/QtGui/QColor:1,
                 from /builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:22:
/usr/include/QtCore/qglobal.h:1326:34: note: candidate: template<class T> constexpr const T& qMin(const T&, const T&)
 Q_DECL_CONSTEXPR inline const T &qMin(const T &a, const T &b) { return (a < b) ? a : b; }
                                  ^~~~
/usr/include/QtCore/qglobal.h:1326:34: note:   template argument deduction/substitution failed:
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:318:140: note:   deduced conflicting types for parameter 'const T' ('double' and 'qreal {aka float}')
           rgba = qRgba(static_cast<unsigned char>(qMin(255. * intensity.x() * opacity + qRed(rgba)*(1. - opacity), static_cast<qreal>(255.))),
                                                                                                                                            ^
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:319:142: error: no matching function for call to 'qMin(double, qreal)'
                        static_cast<unsigned char>(qMin(255. * intensity.y() * opacity + qGreen(rgba)*(1. - opacity), static_cast<qreal>(255.))),
                                                                                                                                              ^
In file included from /usr/include/QtGui/qrgb.h:45:0,
                 from /usr/include/QtGui/qcolor.h:45,
                 from /usr/include/QtGui/QColor:1,
                 from /builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:22:
/usr/include/QtCore/qglobal.h:1326:34: note: candidate: template<class T> constexpr const T& qMin(const T&, const T&)
 Q_DECL_CONSTEXPR inline const T &qMin(const T &a, const T &b) { return (a < b) ? a : b; }
                                  ^~~~
/usr/include/QtCore/qglobal.h:1326:34: note:   template argument deduction/substitution failed:
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:319:142: note:   deduced conflicting types for parameter 'const T' ('double' and 'qreal {aka float}')
                        static_cast<unsigned char>(qMin(255. * intensity.y() * opacity + qGreen(rgba)*(1. - opacity), static_cast<qreal>(255.))),
                                                                                                                                              ^
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:320:141: error: no matching function for call to 'qMin(double, qreal)'
                        static_cast<unsigned char>(qMin(255. * intensity.z() * opacity + qBlue(rgba)*(1. - opacity), static_cast<qreal>(255.))),
                                                                                                                                             ^
In file included from /usr/include/QtGui/qrgb.h:45:0,
                 from /usr/include/QtGui/qcolor.h:45,
                 from /usr/include/QtGui/QColor:1,
                 from /builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:22:
/usr/include/QtCore/qglobal.h:1326:34: note: candidate: template<class T> constexpr const T& qMin(const T&, const T&)
 Q_DECL_CONSTEXPR inline const T &qMin(const T &a, const T &b) { return (a < b) ? a : b; }
                                  ^~~~
/usr/include/QtCore/qglobal.h:1326:34: note:   template argument deduction/substitution failed:
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:320:141: note:   deduced conflicting types for parameter 'const T' ('double' and 'qreal {aka float}')
                        static_cast<unsigned char>(qMin(255. * intensity.z() * opacity + qBlue(rgba)*(1. - opacity), static_cast<qreal>(255.))),
                                                                                                                                             ^
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:321:126: error: no matching function for call to 'qMin(double, qreal)'
                        static_cast<unsigned char>(qMin(255. * opacity + qAlpha(rgba)*(1. - opacity), static_cast<qreal>(255.))));
                                                                                                                              ^
In file included from /usr/include/QtGui/qrgb.h:45:0,
                 from /usr/include/QtGui/qcolor.h:45,
                 from /usr/include/QtGui/QColor:1,
                 from /builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:22:
/usr/include/QtCore/qglobal.h:1326:34: note: candidate: template<class T> constexpr const T& qMin(const T&, const T&)
 Q_DECL_CONSTEXPR inline const T &qMin(const T &a, const T &b) { return (a < b) ? a : b; }
                                  ^~~~
/usr/include/QtCore/qglobal.h:1326:34: note:   template argument deduction/substitution failed:
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkMaterialPropertyPreviewLabel.cpp:321:126: note:   deduced conflicting types for parameter 'const T' ('double' and 'qreal {aka float}')
                        static_cast<unsigned char>(qMin(255. * opacity + qAlpha(rgba)*(1. - opacity), static_cast<qreal>(255.))));
                                                                                                                              ^
Libs/Widgets/CMakeFiles/CTKWidgets.dir/build.make:1859: recipe for target 'Libs/Widgets/CMakeFiles/CTKWidgets.dir/ctkMaterialPropertyPreviewLabel.cpp.o' failed
make[2]: *** [Libs/Widgets/CMakeFiles/CTKWidgets.dir/ctkMaterialPropertyPreviewLabel.cpp.o] Error 1
~~~

~~~
[ 38%] Building CXX object Libs/Widgets/CMakeFiles/CTKWidgets.dir/ctkTransferFunctionItem.cpp.o
cd /builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/build/Libs/Widgets && /usr/bin/c++   -DCTKWidgets_EXPORTS -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_OPENGL_LIB -DQT_SQL_LIB -DQT_TEST_LIB -DQT_XMLPATTERNS_LIB -DQT_XML_LIB -isystem /usr/include/QtOpenGL -isystem /usr/include/QtXmlPatterns -isystem /usr/include/QtGui -isystem /usr/include/QtTest -isystem /usr/include/QtXml -isystem /usr/include/QtSql -isystem /usr/include/QtNetwork -isystem /usr/include/QtCore -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/build/Libs/Widgets -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/build/Libs/Widgets/Resources/UI -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/build -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Core -I/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/build/Libs/Core  -Wall -Wextra -Wpointer-arith -Winvalid-pch -Wcast-align -Wwrite-strings -fdiagnostics-show-option -Wl,--no-undefined -fstack-protector-all -Woverloaded-virtual -Wold-style-cast -Wstrict-null-sentinel -Wsign-promo -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -march=armv7-a -mfpu=vfpv3-d16  -mfloat-abi=hard    -fvisibility=hidden -fvisibility-inlines-hidden   -g -fPIC   -o CMakeFiles/CTKWidgets.dir/ctkTransferFunctionItem.cpp.o -c /builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkTransferFunctionItem.cpp
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkTransferFunctionBarsItem.cpp: In member function 'void ctkTransferFunctionBarsItem::setBarWidth(qreal)':
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkTransferFunctionBarsItem.cpp:95:53: error: no matching function for call to 'qBound(double, qreal&, double)'
   newBarWidthRatio = qBound(0., newBarWidthRatio, 1.);
                                                     ^
In file included from /usr/include/QtCore/qnamespace.h:45:0,
                 from /usr/include/QtCore/qobjectdefs.h:45,
                 from /usr/include/QtCore/qobject.h:47,
                 from /usr/include/QtCore/qcoreapplication.h:45,
                 from /usr/include/QtGui/qapplication.h:45,
                 from /usr/include/QtGui/QApplication:1,
                 from /builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkTransferFunctionBarsItem.cpp:22:
/usr/include/QtCore/qglobal.h:1330:34: note: candidate: template<class T> constexpr const T& qBound(const T&, const T&, const T&)
 Q_DECL_CONSTEXPR inline const T &qBound(const T &min, const T &val, const T &max)
                                  ^~~~~~
/usr/include/QtCore/qglobal.h:1330:34: note:   template argument deduction/substitution failed:
/builddir/build/BUILD/CTK-bdc8caca0458759e1672a94ca2857595d40f17b0/Libs/Widgets/ctkTransferFunctionBarsItem.cpp:95:53: note:   deduced conflicting types for parameter 'const T' ('double' and 'qreal {aka float}')
   newBarWidthRatio = qBound(0., newBarWidthRatio, 1.);
                                                     ^
~~~