### PR TITLE
ENH: set method for AxisLabels in the ctkWidgetAxes

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkAxesWidgetTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkAxesWidgetTest1.cpp
@@ -22,9 +22,11 @@
 #include <QApplication>
 #include <QSignalSpy>
 #include <QTimer>
+#include <QStringList>
 
 // CTK includes
 #include "ctkAxesWidget.h"
+#include "ctkCoreTestingMacros.h"
 
 // STD includes
 #include <cstdlib>
@@ -84,6 +86,12 @@ int ctkAxesWidgetTest1(int argc, char * argv [] )
             << spy[0].at(0).toInt() << " " << spy[1].at(0).toInt() << std::endl;
     return EXIT_FAILURE;
     }
+
+
+  QStringList axesLabels = QStringList() << "W" << "E" << "S" << "N" << "Z" << "z";
+  CHECK_BOOL(axes.setAxesLabels(axesLabels), true)
+  CHECK_QSTRINGLIST(axesLabels, axes.axesLabels());
+
   axes.setAutoReset(false);
   axes.setAutoReset(true);
   axes.setWindowTitle("AutoReset=On");

--- a/Libs/Widgets/ctkAxesWidget.cpp
+++ b/Libs/Widgets/ctkAxesWidget.cpp
@@ -293,6 +293,27 @@ void ctkAxesWidget::paintEvent(QPaintEvent *)
 }
 
 // ----------------------------------------------------------------------------------
+bool ctkAxesWidget::setAxesLabels(const QStringList& labels)
+{
+  Q_D(ctkAxesWidget);
+  if (labels.size() != 6)
+    {
+    qWarning("ctkAxesWidget::setAxesLabels() failed: Exactly 6 labels are expected.");
+    return false;
+    }
+
+  d->AxesLabels = labels;
+  return true;
+}
+
+// ----------------------------------------------------------------------------------
+QStringList ctkAxesWidget::axesLabels() const
+{
+  Q_D(const ctkAxesWidget);
+  return d->AxesLabels;
+}
+
+// ----------------------------------------------------------------------------------
 void ctkAxesWidget::mousePressEvent(QMouseEvent *mouseEvent)
 {
   Q_D(ctkAxesWidget);

--- a/Libs/Widgets/ctkAxesWidget.h
+++ b/Libs/Widgets/ctkAxesWidget.h
@@ -37,6 +37,7 @@ class CTK_WIDGETS_EXPORT ctkAxesWidget : public QWidget
   Q_ENUMS(Axis)
   Q_PROPERTY(Axis currentAxis READ currentAxis WRITE setCurrentAxis NOTIFY currentAxisChanged)
   Q_PROPERTY(bool autoReset READ autoReset WRITE setAutoReset)
+  Q_PROPERTY(QStringList axesLabels READ axesLabels WRITE setAxesLabels)
 public : 
 
   enum Axis
@@ -80,6 +81,12 @@ public slots :
   ///
   /// Set the autoReset property to None anytime the currentAxis is changed.
   void setAutoReset(bool reset);
+
+  /// Set the AxesLabels
+  bool setAxesLabels(const QStringList& labels);
+
+  /// Get the AxesLabels
+  QStringList axesLabels() const;
 
   /// Size hints
   virtual QSize minimumSizeHint()const;


### PR DESCRIPTION
The aim is to enable the customization of the ctkAxesWidget in Slicer. 