### PR TITLE
Allow user to set/reset the range in ctkVTKHistogram

### DIFF
--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKHistogramTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKHistogramTest2.cpp
@@ -32,6 +32,9 @@ int ctkVTKHistogramTest2( int argc, char * argv [])
   rgbDataArray->InsertNextTuple3(1000, 143, -1412);
   rgbDataArray->InsertNextTuple3(-543, 210,   151);
   rgbDataArray->InsertNextTuple3(  -1, 210,    10);
+
+  // Generate histogram on the Green values
+  rgbHistogram.setComponent(1);
   rgbHistogram.setDataArray(rgbDataArray);
   if (rgbHistogram.dataArray() != rgbDataArray)
     {
@@ -41,8 +44,15 @@ int ctkVTKHistogramTest2( int argc, char * argv [])
     return EXIT_FAILURE;
     }
 
-  // Generate histogram on the Green values
-  rgbHistogram.setComponent(1);
+  double range[2], expectedRange[2] = {50.0, 211.0};
+  rgbHistogram.range(range[0], range[1]);
+  if (range[0] != expectedRange[0] && range[1] != expectedRange[1])
+    {
+    std::cerr << "Bad range: " << range[0] << " " << range[1] << std::endl
+              << " expected: " << expectedRange[0] << " " << expectedRange[1]
+              << std::endl;
+    return EXIT_FAILURE;
+    }
 
   //------Test build---------------------------------
   rgbHistogram.build();

--- a/Libs/Visualization/VTK/Widgets/ctkVTKHistogram.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKHistogram.h
@@ -52,8 +52,15 @@ public:
   /// Returns the number of bins. Returns 0 until build() is called.
   virtual int count()const;
 
-  /// Please note that range only works if you have at least set an array.
+  // Set/Get the range of the histogram.
+  // Please note that after an array is set, the range will be reset.
+  // \sa resetRange()
+  virtual void setRange(qreal minRang, qreal maxRange);
   virtual void range(qreal& minRange, qreal& maxRange)const;
+
+  // Reset the range to the array's range.
+  virtual void resetRange();
+
   virtual QVariant minValue()const;
   virtual QVariant maxValue()const;
 
@@ -63,6 +70,8 @@ public:
   void setComponent(int component);
   int component()const;
 
+  // Set the number of bins to use in the histogram. If this is set,
+  // the range will be ignored.
   int numberOfBins()const;
   void setNumberOfBins(int number);
 


### PR DESCRIPTION
Previously, the range was tied to the data array range. Now with the new
method, the user can change the range of the histogram easily.
When the range is changed, the histogram will be recomputed if the number
of bins changes.