### PR TITLE
1227 python console completer cursor between parentheses

### DIFF
--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
@@ -26,6 +26,9 @@
 #include <QList>
 #include <QStringList>
 
+// PythonQt includes
+#include <PythonQtPythonInclude.h> // For PyObject
+
 // CTK includes
 #include "ctkScriptingPythonCoreExport.h"
 
@@ -107,6 +110,13 @@ public:
   QStringList pythonAttributes(const QString& pythonVariableName,
                                const QString& module = QLatin1String("__main__"),
                                bool appendParenthesis = false) const;
+
+  /// Given a string of the form "<modulename1>[.<modulenameN>...]" containing modules, return the final module as a PyObject*
+  static PyObject* pythonModule(const QString &module);
+
+  /// Given a string of the form "<modulename1>[.<modulenameN>...].correspondingObject, return the final object as a PyObject*
+  /// \sa pythonModule
+  static PyObject* pythonObject(const QString& variableNameAndFunction);
 
   /// Returns True if python is initialized
   /// \sa pythonInitialized

--- a/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
+++ b/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
@@ -113,7 +113,21 @@ int ctkPythonConsoleCompleter::cursorOffset(const QString& completion)
   if (allTextFromShell.contains("()"))
     {
     allTextFromShell.replace("()", "");
-    QStringList lineSplit = allTextFromShell.split(".", QString::KeepEmptyParts);
+    // Search backward through the string for usable characters
+    QString currentCompletionText;
+    for (int i = allTextFromShell.length()-1; i >= 0; --i)
+      {
+      QChar c = allTextFromShell.at(i);
+      if (c.isLetterOrNumber() || c == '.' || c == '_')
+        {
+        currentCompletionText.prepend(c);
+        }
+      else
+        {
+        break;
+        }
+      }
+    QStringList lineSplit = currentCompletionText.split(".", QString::KeepEmptyParts);
     QString functionName = lineSplit.at(lineSplit.length()-1);
     QStringList builtinFunctionPath = QStringList() << "__main__" << "__builtins__";
     QStringList userDefinedFunctionPath = QStringList() << "__main__";
@@ -156,7 +170,6 @@ bool ctkPythonConsoleCompleter::isBuiltInFunction(const QString &pythonFunctionN
 int ctkPythonConsoleCompleter::parameterCountBuiltInFunction(const QString& pythonFunctionName)
 {
   int parameterCount = 0;
-  qDebug() << "In parameterCountBuiltInFunction";
   PyObject* pFunction = this->PythonManager.pythonModule(pythonFunctionName);
   if (pFunction && PyObject_HasAttrString(pFunction, "__doc__"))
     {

--- a/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
+++ b/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
@@ -82,117 +82,243 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 class ctkPythonConsoleCompleter : public ctkConsoleCompleter
 {
 public:
-  ctkPythonConsoleCompleter(ctkAbstractPythonManager& pythonManager)
-    : PythonManager(pythonManager)
-    {
-    this->setParent(&pythonManager);
-    }
+  ctkPythonConsoleCompleter(ctkAbstractPythonManager& pythonManager);
 
-  virtual void updateCompletionModel(const QString& completion)
-    {
-    // Start by clearing the model
-    this->setModel(0);
+  virtual int cursorOffset(const QString& completion);
+  virtual void updateCompletionModel(const QString& completion);
 
-    // Don't try to complete the empty string
-    if (completion.isEmpty())
-      {
-      return;
-      }
+protected:
+  bool isUserDefinedFunction(const QString &pythonFunctionName);
+  bool isBuiltInFunction(const QString &pythonFunctionName);
+  int parameterCountBuiltInFunction(const QString& pythonFunctionName);
+  int parameterCountUserDefinedFunction(const QString& pythonFunctionName);
+  int parameterCountFromDocumentation(const QString& pythonFunctionPath);
 
-    // Search backward through the string for usable characters
-    QString textToComplete;
-    for (int i = completion.length()-1; i >= 0; --i)
-      {
-      QChar c = completion.at(i);
-      if (c.isLetterOrNumber() || c == '.' || c == '_')
-        {
-        textToComplete.prepend(c);
-        }
-      else
-        {
-        break;
-        }
-      }
-
-    // Split the string at the last dot, if one exists
-    QString lookup;
-    QString compareText = textToComplete;
-    int dot = compareText.lastIndexOf('.');
-    if (dot != -1)
-      {
-      lookup = compareText.mid(0, dot);
-      compareText = compareText.mid(dot+1);
-      }
-
-    // Lookup python names
-    QStringList attrs;
-    if (!lookup.isEmpty() || !compareText.isEmpty())
-      {
-      bool appendParenthesis = true;
-      attrs = this->PythonManager.pythonAttributes(lookup, QLatin1String("__main__"), appendParenthesis);
-      attrs << this->PythonManager.pythonAttributes(lookup, QLatin1String("__main__.__builtins__"),
-                                                    appendParenthesis);
-      attrs.removeDuplicates();
-      }
-
-    // Initialize the completion model
-    if (!attrs.isEmpty())
-      {
-      this->setCompletionMode(QCompleter::PopupCompletion);
-      this->setModel(new QStringListModel(attrs, this));
-      this->setCaseSensitivity(Qt::CaseInsensitive);
-      this->setCompletionPrefix(compareText.toLower());
-      
-      //qDebug() << "completion" << completion;
-      // If a dot as been entered and if an item of possible
-      // choices matches one of the preference list, it will be selected.
-      QModelIndex preferredIndex = this->completionModel()->index(0, 0);
-      int dotCount = completion.count('.');
-      if (dotCount == 0 || completion.at(completion.count() - 1) == '.')
-        {
-        foreach(const QString& pref, this->AutocompletePreferenceList)
-          {
-          //qDebug() << "pref" << pref;
-          int dotPref = pref.count('.');
-          // Skip if there are dots in pref and if the completion has already more dots 
-          // than the pref
-          if ((dotPref != 0) && (dotCount > dotPref))
-            {
-            continue;
-            }
-          // Extract string before the last dot
-          int lastDot = pref.lastIndexOf('.');
-          QString prefBeforeLastDot;
-          if (lastDot != -1)
-            {
-            prefBeforeLastDot = pref.left(lastDot);
-            }
-          //qDebug() << "prefBeforeLastDot" << prefBeforeLastDot;
-          if (!prefBeforeLastDot.isEmpty() && QString::compare(prefBeforeLastDot, lookup) != 0)
-            {
-            continue;
-            }
-          QString prefAfterLastDot = pref;
-          if (lastDot != -1 )
-            {
-            prefAfterLastDot = pref.right(pref.size() - lastDot - 1);
-            }
-          //qDebug() << "prefAfterLastDot" << prefAfterLastDot;
-          QModelIndexList list = this->completionModel()->match(
-                this->completionModel()->index(0, 0), Qt::DisplayRole, QVariant(prefAfterLastDot));
-          if (list.count() > 0)
-            {
-            preferredIndex = list.first();
-            break;
-            }
-          }
-        }
-
-      this->popup()->setCurrentIndex(preferredIndex);
-      }
-    }
   ctkAbstractPythonManager& PythonManager;
 };
+
+//----------------------------------------------------------------------------
+ctkPythonConsoleCompleter::ctkPythonConsoleCompleter(ctkAbstractPythonManager& pythonManager)
+  : PythonManager(pythonManager)
+  {
+  this->setParent(&pythonManager);
+  }
+
+//----------------------------------------------------------------------------
+int ctkPythonConsoleCompleter::cursorOffset(const QString& completion)
+{
+  QString allTextFromShell = completion;
+  int parameterCount = 0;
+  int cursorOffset = 0;
+  if (allTextFromShell.contains("()"))
+    {
+    allTextFromShell.replace("()", "");
+    QStringList lineSplit = allTextFromShell.split(".", QString::KeepEmptyParts);
+    QString functionName = lineSplit.at(lineSplit.length()-1);
+    QStringList builtinFunctionPath = QStringList() << "__main__" << "__builtins__";
+    QStringList userDefinedFunctionPath = QStringList() << "__main__";
+    if (this->isBuiltInFunction(functionName))
+      {
+      parameterCount = this->parameterCountBuiltInFunction(QStringList(builtinFunctionPath+lineSplit).join("."));
+      }
+    else if (this->isUserDefinedFunction(functionName))
+      {
+      parameterCount = this->parameterCountUserDefinedFunction(QStringList(userDefinedFunctionPath+lineSplit).join("."));
+      }
+    else
+      {
+      QStringList variableNameAndFunctionList = userDefinedFunctionPath + lineSplit;
+      QString variableNameAndFunction = variableNameAndFunctionList.join(".");
+      parameterCount = this->parameterCountFromDocumentation(variableNameAndFunction);
+      }
+    }
+  if (parameterCount > 0)
+    {
+    cursorOffset = 1;
+    }
+  return cursorOffset;
+}
+
+
+//---------------------------------------------------------------------------
+bool ctkPythonConsoleCompleter::isUserDefinedFunction(const QString &pythonFunctionName)
+{
+  return this->PythonManager.pythonAttributes(pythonFunctionName).contains("__call__");
+}
+
+//---------------------------------------------------------------------------
+bool ctkPythonConsoleCompleter::isBuiltInFunction(const QString &pythonFunctionName)
+{
+  return this->PythonManager.pythonAttributes(pythonFunctionName, QLatin1String("__main__.__builtins__")).contains("__call__");
+}
+
+//---------------------------------------------------------------------------
+int ctkPythonConsoleCompleter::parameterCountBuiltInFunction(const QString& pythonFunctionName)
+{
+  int parameterCount = 0;
+  qDebug() << "In parameterCountBuiltInFunction";
+  PyObject* pFunction = this->PythonManager.pythonModule(pythonFunctionName);
+  if (pFunction && PyObject_HasAttrString(pFunction, "__doc__"))
+    {
+    PyObject* pDoc = PyObject_GetAttrString(pFunction, "__doc__");
+    QString docString = PyString_AsString(pDoc);
+    QString argumentExtract = docString.mid(docString.indexOf("(")+1, docString.indexOf(")") - docString.indexOf("(")-1);
+    QStringList arguments = argumentExtract.split(",", QString::SkipEmptyParts);
+    parameterCount = arguments.count();
+    Py_DECREF(pDoc);
+    Py_DECREF(pFunction);
+    }
+  return parameterCount;
+}
+
+//----------------------------------------------------------------------------
+int ctkPythonConsoleCompleter::parameterCountUserDefinedFunction(const QString& pythonFunctionName)
+{
+  int parameterCount = 0;
+  PyObject* pFunction = this->PythonManager.pythonModule(pythonFunctionName);
+  if (PyCallable_Check(pFunction))
+    {
+    PyObject* fc = PyObject_GetAttrString(pFunction, "func_code");
+    if (fc)
+       {
+      PyObject* ac = PyObject_GetAttrString(fc, "co_argcount");
+      if (ac)
+        {
+        parameterCount = PyInt_AsLong(ac);
+        Py_DECREF(ac);
+        }
+      Py_DECREF(fc);
+       }
+    }
+  return parameterCount;
+}
+
+//----------------------------------------------------------------------------
+int ctkPythonConsoleCompleter::parameterCountFromDocumentation(const QString& pythonFunctionPath)
+{
+  int parameterCount = 0;
+  PyObject* pFunction = this->PythonManager.pythonObject(pythonFunctionPath);
+  if (pFunction)
+    {
+    if (PyObject_HasAttrString(pFunction, "__call__"))
+      {
+      PyObject* pDoc = PyObject_GetAttrString(pFunction, "__doc__");
+      if (PyString_Check(pDoc))
+        {
+        QString docString = PyString_AsString(pDoc);
+        QString argumentExtract = docString.mid(docString.indexOf("(")+1, docString.indexOf(")") - docString.indexOf("(")-1);
+        QStringList arguments = argumentExtract.split(",", QString::SkipEmptyParts);
+        parameterCount = arguments.count();
+        }
+      }
+    Py_DECREF(pFunction);
+    }
+  return parameterCount;
+}
+
+void ctkPythonConsoleCompleter::updateCompletionModel(const QString& completion)
+{
+  // Start by clearing the model
+  this->setModel(0);
+
+  // Don't try to complete the empty string
+  if (completion.isEmpty())
+    {
+    return;
+    }
+
+  // Search backward through the string for usable characters
+  QString textToComplete;
+  for (int i = completion.length()-1; i >= 0; --i)
+    {
+    QChar c = completion.at(i);
+    if (c.isLetterOrNumber() || c == '.' || c == '_')
+      {
+      textToComplete.prepend(c);
+      }
+    else
+      {
+      break;
+      }
+   }
+
+  // Split the string at the last dot, if one exists
+  QString lookup;
+  QString compareText = textToComplete;
+  int dot = compareText.lastIndexOf('.');
+  if (dot != -1)
+    {
+    lookup = compareText.mid(0, dot);
+    compareText = compareText.mid(dot+1);
+    }
+
+  // Lookup python names
+  QStringList attrs;
+  if (!lookup.isEmpty() || !compareText.isEmpty())
+    {
+    bool appendParenthesis = true;
+    attrs = this->PythonManager.pythonAttributes(lookup, QLatin1String("__main__"), appendParenthesis);
+    attrs << this->PythonManager.pythonAttributes(lookup, QLatin1String("__main__.__builtins__"),
+                                                  appendParenthesis);
+    attrs.removeDuplicates();
+    }
+
+  // Initialize the completion model
+  if (!attrs.isEmpty())
+    {
+    this->setCompletionMode(QCompleter::PopupCompletion);
+    this->setModel(new QStringListModel(attrs, this));
+    this->setCaseSensitivity(Qt::CaseInsensitive);
+    this->setCompletionPrefix(compareText.toLower());
+
+    //qDebug() << "completion" << completion;
+    // If a dot as been entered and if an item of possible
+    // choices matches one of the preference list, it will be selected.
+    QModelIndex preferredIndex = this->completionModel()->index(0, 0);
+    int dotCount = completion.count('.');
+    if (dotCount == 0 || completion.at(completion.count() - 1) == '.')
+      {
+      foreach(const QString& pref, this->AutocompletePreferenceList)
+        {
+        //qDebug() << "pref" << pref;
+        int dotPref = pref.count('.');
+        // Skip if there are dots in pref and if the completion has already more dots
+        // than the pref
+        if ((dotPref != 0) && (dotCount > dotPref))
+          {
+          continue;
+          }
+        // Extract string before the last dot
+        int lastDot = pref.lastIndexOf('.');
+        QString prefBeforeLastDot;
+        if (lastDot != -1)
+          {
+          prefBeforeLastDot = pref.left(lastDot);
+          }
+        //qDebug() << "prefBeforeLastDot" << prefBeforeLastDot;
+        if (!prefBeforeLastDot.isEmpty() && QString::compare(prefBeforeLastDot, lookup) != 0)
+          {
+          continue;
+          }
+        QString prefAfterLastDot = pref;
+        if (lastDot != -1 )
+          {
+          prefAfterLastDot = pref.right(pref.size() - lastDot - 1);
+          }
+        //qDebug() << "prefAfterLastDot" << prefAfterLastDot;
+        QModelIndexList list = this->completionModel()->match(
+              this->completionModel()->index(0, 0), Qt::DisplayRole, QVariant(prefAfterLastDot));
+        if (list.count() > 0)
+          {
+          preferredIndex = list.first();
+          break;
+          }
+        }
+      }
+
+    this->popup()->setCurrentIndex(preferredIndex);
+    }
+}
 
 //----------------------------------------------------------------------------
 // ctkPythonConsolePrivate

--- a/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
+++ b/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
@@ -143,7 +143,8 @@ int ctkPythonConsoleCompleter::cursorOffset(const QString& completion)
       }
     else if (this->isInUserDefinedClass(currentCompletionText))
       {
-      parameterCount = this->parameterCountUserDefinedClassFunction(QStringList(userDefinedFunctionPath+lineSplit).join("."));
+      // "self" parameter can be ignored
+      parameterCount = this->parameterCountUserDefinedClassFunction(QStringList(userDefinedFunctionPath+lineSplit).join(".")) - 1;
       }
     else
       {

--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -756,6 +756,7 @@ void ctkConsolePrivate::insertCompletion(const QString& completion)
   tc.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
   QString shellLine = tc.selectedText();
   shellLine.replace(q->ps1(), "");
+  shellLine.replace(q->ps2(), "");
   tc.movePosition(QTextCursor::EndOfLine, QTextCursor::MoveAnchor);
   this->setTextCursor(tc);
   int cursorOffset = this->Completer->cursorOffset(shellLine);

--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -737,6 +737,7 @@ void ctkConsolePrivate::printWelcomeMessage()
 //-----------------------------------------------------------------------------
 void ctkConsolePrivate::insertCompletion(const QString& completion)
 {
+  Q_Q(ctkConsole);
   QTextCursor tc = this->textCursor();
   tc.movePosition(QTextCursor::Left, QTextCursor::KeepAnchor);
   if (tc.selectedText()==".")
@@ -751,6 +752,15 @@ void ctkConsolePrivate::insertCompletion(const QString& completion)
     tc.insertText(completion);
     this->setTextCursor(tc);
     }
+  tc.movePosition(QTextCursor::StartOfBlock);
+  tc.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
+  QString shellLine = tc.selectedText();
+  shellLine.replace(q->ps1(), "");
+  tc.movePosition(QTextCursor::EndOfLine, QTextCursor::MoveAnchor);
+  this->setTextCursor(tc);
+  int cursorOffset = this->Completer->cursorOffset(shellLine);
+  tc.movePosition(QTextCursor::Left, QTextCursor::MoveAnchor, cursorOffset);
+  this->setTextCursor(tc);
   this->updateCommandBuffer();
 }
 

--- a/Libs/Widgets/ctkConsole.h
+++ b/Libs/Widgets/ctkConsole.h
@@ -267,6 +267,10 @@ public:
   /// the line.
   virtual void updateCompletionModel(const QString& str) = 0;
 
+  /// Given the current completion, returns the number by which the
+  /// cursor should be shifted to the left.
+  virtual int cursorOffset(const QString& completion) = 0;
+
   /// Returns the autocomplete preference list
   QStringList autocompletePreferenceList();
 


### PR DESCRIPTION
Everything which was done by @chrismullins 4 years ago about autocompletion in the python console have been reviewed, updated and is now able to be merged.

Most of the code is  the same.
We can note that we updated the include library : `#include <dPython.h>` changed into `#include <PythonQt.h>`

For more details, you can see the issue linked on MantisBugTracker [#1227](http://na-mic.org/Mantis/view.php?id=1227) or the [older branch](https://github.com/chrismullins/CTK/commits/python-autocomplete-parameter-detection) that I used for doing the update