### PR TITLE
Make sure last is at least first when inserting rows

### DIFF
--- a/Libs/XNAT/Core/ctkXnatTreeModel.cpp
+++ b/Libs/XNAT/Core/ctkXnatTreeModel.cpp
@@ -291,7 +291,8 @@ void ctkXnatTreeModel::refresh(const QModelIndex& parent)
       // -> add it to the treeview
       if (addToTreeView)
       {
-        beginInsertRows(parent, 0, numChildren - 1);
+        int last = std::max(0, numChildren -1);
+        beginInsertRows(parent, 0, last);
         item->appendChild(new ctkXnatTreeItem(child, item));
         endInsertRows();
         ++numChildren;


### PR DESCRIPTION
Adding a item to a previously empty resource folder would result in first
being 0 and last being -1. This would trigger a Qt assert.