### PR TITLE
RFC: LibraryFactory: allow setting LoadHints for symbol resolution

### DIFF
--- a/Libs/Core/ctkAbstractLibraryFactory.h
+++ b/Libs/Core/ctkAbstractLibraryFactory.h
@@ -56,13 +56,16 @@ public:
   /// Set list of required symbols
   void setSymbols(const QStringList& symbols);
 
-  /// 
+  /// Set lookup hints for symbol resolution. See QLibrary documentation.
+  void setLoadHints(QLibrary::LoadHints hints);
+
+  ///
   /// \brief Resolve symbols
   /// \note The function will return False if it fails to resolve one
   /// of the required symbols set using setSymbols(const QStringList&)
   bool resolve();
-  
-  /// 
+
+  ///
   /// Get symbol address
   SymbolAddressType symbolAddress(const QString& symbol)const;
 

--- a/Libs/Core/ctkAbstractLibraryFactory.tpp
+++ b/Libs/Core/ctkAbstractLibraryFactory.tpp
@@ -65,6 +65,14 @@ void ctkFactoryLibraryItem<BaseClassType>::setSymbols(const QStringList& symbols
 
 //-----------------------------------------------------------------------------
 template<typename BaseClassType>
+void ctkFactoryLibraryItem<BaseClassType>
+::setLoadHints(QLibrary::LoadHints hints)
+{
+  this->Library.setLoadHints(hints);
+}
+
+//-----------------------------------------------------------------------------
+template<typename BaseClassType>
 bool ctkFactoryLibraryItem<BaseClassType>::resolve()
 {
   foreach(const QString& symbol, this->Symbols)
@@ -129,8 +137,8 @@ bool ctkAbstractLibraryFactory<BaseClassType>
 
 //-----------------------------------------------------------------------------
 template<typename BaseClassType>
-void ctkAbstractLibraryFactory<BaseClassType>::
-initItem(ctkAbstractFactoryItem<BaseClassType>* item)
+void ctkAbstractLibraryFactory<BaseClassType>
+::initItem(ctkAbstractFactoryItem<BaseClassType>* item)
 {
   this->ctkAbstractFileBasedFactory<BaseClassType>::initItem(item);
   dynamic_cast<ctkFactoryLibraryItem<BaseClassType>*>(item)->setSymbols(this->Symbols);


### PR DESCRIPTION
This does not seem to currently be exposed, and is important for controlling shared library symbol resolution behavior.

(See related comment at https://github.com/commontk/CTK/blob/b721b7caf80f994c1830b8b77d120bed5d47a865/Libs/PluginFramework/ctkPluginConstants.h#L98-L107)