### PR TITLE
ENH: Preserve actor order in vtkLightBoxRendererManager

### DIFF
--- a/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
+++ b/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
@@ -415,16 +415,14 @@ void vtkLightBoxRendererManager::vtkInternal
 #else
   item->ImageMapper->SetInputConnection(this->ImageDataConnection);
   bool hasViewProp = item->Renderer->HasViewProp(item->ImageActor);
-  if (!this->ImageDataConnection && hasViewProp)
+  if (!hasViewProp)
     {
-    item->Renderer->RemoveViewProp(item->ImageActor);
-    item->Renderer->RemoveViewProp(item->HighlightedBoxActor);
-    }
-  else if (this->ImageDataConnection && !hasViewProp)
-    {
+    item->ImageActor->SetVisibility(false);
+    item->HighlightedBoxActor->SetVisibility(false);
     item->Renderer->AddActor2D(item->ImageActor);
     item->Renderer->AddActor2D(item->HighlightedBoxActor);
     }
+  item->ImageActor->SetVisibility(this->ImageDataConnection != NULL);
 #endif
 }
 


### PR DESCRIPTION
The order of how 2D actors are added to the renderer greatly influences the rendering result. Therefore, for consistent rendering results actor ordering in slice viewer has to be preserved when just changing the input image data.

Old behavior: When input to slice viewer was set to NULL (no image is selected for display), the image actor was removed from the renderer. When an image was selected again, the image actor was added again. This changed the actor order.

Implemented fix: Modified the behavior to only hide the image actor when input is set to NULL. This way when image input is later set to non-NULL, the image actor does not get promoted to the top of the actor list (but keeps its original position).

Fixes this problem in 3D Slicer:
https://app.assembla.com/spaces/slicerrt/tickets/823-segmentation-disappears-after-deselecting-volume-in-slice-view