### PR TITLE
Add a DICOM database query to retrieve SOPInstanceUIDs via a SeriesIn…

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -732,7 +732,7 @@ QStringList ctkDICOMDatabase::seriesForStudy(QString studyUID)
 }
 
 //------------------------------------------------------------------------------
-QStringList ctkDICOMDatabase::sopsForSeries(const QString seriesUID)
+QStringList ctkDICOMDatabase::instancesForSeries(const QString seriesUID)
 {
   Q_D(ctkDICOMDatabase);
   QSqlQuery query(d->Database);

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -732,6 +732,23 @@ QStringList ctkDICOMDatabase::seriesForStudy(QString studyUID)
 }
 
 //------------------------------------------------------------------------------
+QStringList ctkDICOMDatabase::sopsForSeries(const QString seriesUID)
+{
+  Q_D(ctkDICOMDatabase);
+  QSqlQuery query(d->Database);
+  query.prepare("SELECT SOPInstanceUID FROM Images WHERE SeriesInstanceUID= ?");
+  query.bindValue(0, seriesUID);
+  query.exec();
+  QStringList result;
+  if (query.next())
+  {
+    result << query.value(0).toString();
+  }
+
+  return result;
+}
+
+//------------------------------------------------------------------------------
 QStringList ctkDICOMDatabase::filesForSeries(QString seriesUID)
 {
   Q_D(ctkDICOMDatabase);

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -132,6 +132,7 @@ public:
   Q_INVOKABLE QStringList patients ();
   Q_INVOKABLE QStringList studiesForPatient (const QString patientUID);
   Q_INVOKABLE QStringList seriesForStudy (const QString studyUID);
+  Q_INVOKABLE QStringList sopsForSeries(const QString seriesUID);
   Q_INVOKABLE QString studyForSeries(QString seriesUID);
   Q_INVOKABLE QString patientForStudy(QString studyUID);
   Q_INVOKABLE QStringList filesForSeries (const QString seriesUID);

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -132,7 +132,7 @@ public:
   Q_INVOKABLE QStringList patients ();
   Q_INVOKABLE QStringList studiesForPatient (const QString patientUID);
   Q_INVOKABLE QStringList seriesForStudy (const QString studyUID);
-  Q_INVOKABLE QStringList sopsForSeries(const QString seriesUID);
+  Q_INVOKABLE QStringList instancesForSeries(const QString seriesUID);
   Q_INVOKABLE QString studyForSeries(QString seriesUID);
   Q_INVOKABLE QString patientForStudy(QString studyUID);
   Q_INVOKABLE QStringList filesForSeries (const QString seriesUID);


### PR DESCRIPTION
…stanceUID

A series, which is identified by the 'seriesUID' parameter, contains several images. To get a specific DICOM tag from these images (via the 'instanceValue'-function), a list of all the SOPInstanceUIDs, referred to by a SeriesInstanceUID, is needed.