### PR TITLE
BUG: Fixed multiple view display in layouts

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkLayoutManagerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkLayoutManagerTest1.cpp
@@ -49,6 +49,10 @@ QString tabLayout(
 " <item><view name=\"tab2\"/></item>"
 " <item><view name=\"tab3\"/></item>"
 "</layout>");
+QString tabMultipleLayout(
+  "<layout type=\"tab\">"
+  " <item multiple=\"true\"><view name=\"tab1\"/></item>"
+  "</layout>");
 QString nestedLayout(
 "<layout type=\"tab\">"
 " <item>"
@@ -107,6 +111,9 @@ int ctkLayoutManagerTest1(int argc, char * argv [] )
   Q_ASSERT(res);
   QDomDocument tabLayoutDoc("tablayout");
   res = tabLayoutDoc.setContent(tabLayout);
+  Q_ASSERT(res);
+  QDomDocument tabMultipleLayoutDoc("tabMultiplelayout");
+  res = tabMultipleLayoutDoc.setContent(tabMultipleLayout);
   Q_ASSERT(res);
   QDomDocument nestedLayoutDoc("nestedlayout");
   res = nestedLayoutDoc.setContent(nestedLayout);
@@ -254,6 +261,30 @@ int ctkLayoutManagerTest1(int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
+  // Switch back to nested layout
+  nestedToTabLayoutManager.setLayout(nestedLayoutDoc);
+  QTimer::singleShot(200, &app, SLOT(quit()));
+  app.exec();
+
+  // Test that multiple="true" makes all cached views shown,
+  // even if cached views are disabled.
+  nestedToTabInstanciator->setUseCachedViews(false);
+  nestedToTabLayoutManager.setLayout(tabMultipleLayoutDoc);
+  if (nestedToTabInstanciator->registeredViews().count() != 2 * 4 ||
+    nestedToTabInstanciator->registeredViews()[0]->isHidden() ||
+    !nestedToTabInstanciator->registeredViews()[1]->isHidden() ||
+    !nestedToTabInstanciator->registeredViews()[2]->isHidden())
+    {
+    std::cout << __LINE__ << " tabMultiple: "
+      << "ctkLayoutManager::setupLayout() failed to show/hide widgets "
+      << nestedToTabInstanciator->registeredViews().count();
+    for (int i = 0; i < nestedToTabInstanciator->registeredViews().count(); i++)
+      {
+      std::cout << " " << nestedToTabInstanciator->registeredViews()[i]->isHidden();
+      }
+    std::cout << std::endl;
+    return EXIT_FAILURE;
+    }
 
   if (argc < 2 || QString(argv[1]) != "-I" )
     {

--- a/Libs/Widgets/ctkLayoutViewFactory.cpp
+++ b/Libs/Widgets/ctkLayoutViewFactory.cpp
@@ -167,8 +167,10 @@ QList<QWidget*> ctkLayoutViewFactory::viewsFromXML(QDomElement layoutElement)
     }
   // The layout element does not match any existing one, however we can just reuse
   // one that was registered for a different layout element.
-  if (this->useCachedViews() &&
-      d->NumberOfViewsInCurrentLayout >= 0 && 
+  // We use cached views (regardless of useCachedViews settings)
+  // as this is required for showing all compatible views when multiple="true"
+  // attribute is set.
+  if (d->NumberOfViewsInCurrentLayout >= 0 && 
       d->NumberOfViewsInCurrentLayout < d->Views.count())
     {
     for (int i = d->NumberOfViewsInCurrentLayout; i < d->Views.count(); ++i)


### PR DESCRIPTION
When multiple="true" specified in a view item then it means that all compatible views should be shown.
However, this only worked when cached views were enabled.

This caused in 3D Slicer "Tabbed slice" and "Tabbed 3D" layouts show only one view instead of all.