### PR TITLE
DICOM/Widgets: Fix "unused-but-set-variable" warning

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMThumbnailListWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMThumbnailListWidget.cpp
@@ -146,7 +146,6 @@ void ctkDICOMThumbnailListWidgetPrivate
 void ctkDICOMThumbnailListWidgetPrivate
 ::addSeriesThumbnails(const QModelIndex &index)
 {
-  QModelIndex studyIndex = index.parent();
   QModelIndex seriesIndex = index;
 
   ctkDICOMModel* model = const_cast<ctkDICOMModel*>(qobject_cast<const ctkDICOMModel*>(index.model()));


### PR DESCRIPTION
This commit fixes the following warning:

/path/to/CTK/Libs/DICOM/Widgets/ctkDICOMThumbnailListWidget.cpp: In member function ‘void ctkDICOMThumbnailListWidgetPrivate::addSeriesThumbnails(const QModelIndex&)’:
/path/to/CTK/Libs/DICOM/Widgets/ctkDICOMThumbnailListWidget.cpp:149:15: warning: variable ‘studyIndex’ set but not used [-Wunused-but-set-variable]
   QModelIndex studyIndex = index.parent();
               ^