### PR TITLE
XNAT/Core: Fix unused warning in ctkXnatObject::fetchResources

### DIFF
--- a/Libs/XNAT/Core/ctkXnatObject.cpp
+++ b/Libs/XNAT/Core/ctkXnatObject.cpp
@@ -431,6 +431,7 @@ void ctkXnatObject::saveImpl(bool /*overwrite*/)
 //----------------------------------------------------------------------------
 void ctkXnatObject::fetchResources(const QString& path)
 {
+  Q_UNUSED(path);
   ctkXnatResourceFolder* resFolder = new ctkXnatResourceFolder();
   this->add(resFolder);
 }


### PR DESCRIPTION
This commit fixes the following warning:

```
/path/to/CTK/Libs/XNAT/Core/ctkXnatObject.cpp: At global scope:
/path/to/CTK/Libs/XNAT/Core/ctkXnatObject.cpp:432:51: warning: unused parameter ‘path’ [-Wunused-parameter]
 void ctkXnatObject::fetchResources(const QString& path)
                                                   ^
```