### PR TITLE
BUG: Fixed ctkFittedTextBrowser height computation for wide content

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkFittedTextBrowserTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkFittedTextBrowserTest1.cpp
@@ -20,6 +20,9 @@
 
 // Qt includes
 #include <QApplication>
+#include <QPushButton>
+#include <QTimer>
+#include <QVBoxLayout>
 
 // CTK includes
 #include "ctkFittedTextBrowser.h"
@@ -32,9 +35,34 @@ int ctkFittedTextBrowserTest1(int argc, char * argv [] )
 {
   QApplication app(argc, argv);
 
-  ctkFittedTextBrowser ctkObject;
+  QWidget widget;
+  QVBoxLayout* layout = new QVBoxLayout;
+  widget.setLayout(layout);
 
+  ctkFittedTextBrowser textBrowserWidget(&widget);
+  textBrowserWidget.setText(
+    "<pre>"
+    "This is a short line.\n"
+    "This is a very very, very very very, very very, very very very, very very, very very very long line\n"
+    "Some more lines 1."
+    "Some more lines 2."
+    "Some more, some more."
+    "</pre>");
+  layout->addWidget(&textBrowserWidget);
 
-  return EXIT_SUCCESS;
+  QPushButton expandingButton(&widget);
+  QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  sizePolicy.setHorizontalStretch(1);
+  sizePolicy.setVerticalStretch(1);
+  expandingButton.setSizePolicy(sizePolicy);
+  layout->addWidget(&expandingButton);
+
+  widget.show();
+
+  if (argc < 2 || QString(argv[1]) != "-I")
+  {
+    QTimer::singleShot(200, &app, SLOT(quit()));
+  }
+
+  return app.exec();
 }
-

--- a/Libs/Widgets/ctkFittedTextBrowser.cpp
+++ b/Libs/Widgets/ctkFittedTextBrowser.cpp
@@ -20,6 +20,7 @@
 
 // Qt includes
 #include <QDebug>
+#include <QScrollBar>
 #include <QTextBlock>
 #include <QAbstractTextDocumentLayout>
 
@@ -56,7 +57,13 @@ int ctkFittedTextBrowser::heightForWidth(int _width) const
   // Fudge factor. This is the difference between the frame and the 
   // viewport.
   int fudge = 2 * this->frameWidth();
-  
+
+  int horizontalScrollbarHeight = 0;
+  if (this->horizontalScrollBar()->isVisible())
+  {
+    horizontalScrollbarHeight = this->horizontalScrollBar()->height() + fudge;
+  }
+
   // Do the calculation assuming no scrollbars
   doc->setTextWidth(_width - fudge);
   int noScrollbarHeight =
@@ -69,7 +76,7 @@ int ctkFittedTextBrowser::heightForWidth(int _width) const
   
   // Get minimum height (even if string is empty): one line of text
   int _minimumHeight = QFontMetrics(doc->defaultFont()).lineSpacing() + fudge;
-  int ret = qMax(noScrollbarHeight, _minimumHeight);
+  int ret = qMax(noScrollbarHeight, _minimumHeight) + horizontalScrollbarHeight;
 
   doc->setTextWidth(savedWidth);
   return ret;


### PR DESCRIPTION
Height of horizontal scrollbar is taken into account now.