### PR TITLE
Make CTK compatible to Qt 5.8

### DIFF
--- a/Libs/CommandLineModules/Core/ctkCmdLineModuleParameterParsers_p.h
+++ b/Libs/CommandLineModules/Core/ctkCmdLineModuleParameterParsers_p.h
@@ -31,8 +31,8 @@ namespace {
 
 static bool parseBooleanAttribute(const QStringRef& attrValue)
 {
-  if (attrValue.compare("true", Qt::CaseInsensitive) == 0 ||
-      attrValue.compare("1") == 0)
+  if (attrValue.compare(QLatin1String("true"), Qt::CaseInsensitive) == 0 ||
+      attrValue.compare(QLatin1String("1")) == 0)
   {
     return true;
   }
@@ -79,23 +79,23 @@ protected:
 
     QStringRef name = xmlReader.name();
 
-    if (name.compare("name", Qt::CaseInsensitive) == 0)
+    if (name.compare(QLatin1String("name"), Qt::CaseInsensitive) == 0)
     {
       moduleParamPrivate->Name = xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("description", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("description"), Qt::CaseInsensitive) == 0)
     {
       moduleParamPrivate->Description = xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("label", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("label"), Qt::CaseInsensitive) == 0)
     {
       moduleParamPrivate->Label = xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("default", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("default"), Qt::CaseInsensitive) == 0)
     {
       moduleParamPrivate->Default = xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("flag", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("flag"), Qt::CaseInsensitive) == 0)
     {
       QString flag = xmlReader.readElementText().trimmed();
       if (flag.startsWith('-')) flag = flag.remove(0, 1);
@@ -103,7 +103,7 @@ protected:
       moduleParamPrivate->FlagAliasesAsString = xmlReader.attributes().value("alias").toString();
       moduleParamPrivate->DeprecatedFlagAliasesAsString = xmlReader.attributes().value("deprecatedalias").toString();
     }
-    else if (name.compare("longflag", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("longflag"), Qt::CaseInsensitive) == 0)
     {
       QString longFlag = xmlReader.readElementText().trimmed();
       if (longFlag.startsWith('-')) longFlag = longFlag.remove(0, 1);
@@ -111,11 +111,11 @@ protected:
       moduleParamPrivate->LongFlagAliasesAsString = xmlReader.attributes().value("alias").toString();
       moduleParamPrivate->DeprecatedLongFlagAliasesAsString = xmlReader.attributes().value("deprecatedalias").toString();
     }
-    else if (name.compare("index", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("index"), Qt::CaseInsensitive) == 0)
     {
       moduleParamPrivate->Index = xmlReader.readElementText().toInt();
     }
-    else if (name.compare("channel", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("channel"), Qt::CaseInsensitive) == 0)
     {
       moduleParamPrivate->Channel = xmlReader.readElementText().trimmed();
     }
@@ -134,15 +134,15 @@ protected:
     while(xmlReader.readNextStartElement())
     {
       QStringRef constraintElem = xmlReader.name();
-      if (constraintElem.compare("minimum", Qt::CaseInsensitive) == 0)
+      if (constraintElem.compare(QLatin1String("minimum"), Qt::CaseInsensitive) == 0)
       {
         moduleParamPrivate->Minimum = xmlReader.readElementText().trimmed();
       }
-      else if (constraintElem.compare("maximum", Qt::CaseInsensitive) == 0)
+      else if (constraintElem.compare(QLatin1String("maximum"), Qt::CaseInsensitive) == 0)
       {
         moduleParamPrivate->Maximum = xmlReader.readElementText().trimmed();
       }
-      else if (constraintElem.compare("step", Qt::CaseInsensitive) == 0)
+      else if (constraintElem.compare(QLatin1String("step"), Qt::CaseInsensitive) == 0)
       {
         moduleParamPrivate->Step = xmlReader.readElementText().trimmed();
       }
@@ -177,7 +177,7 @@ protected:
   {
     QStringRef name = xmlReader.name();
 
-    if (name.compare("constraints", Qt::CaseInsensitive) == 0)
+    if (name.compare(QLatin1String("constraints"), Qt::CaseInsensitive) == 0)
     {
       return handleConstraintsElement(moduleParamPrivate, xmlReader);
     }
@@ -197,7 +197,7 @@ protected:
   {
     QStringRef name = xmlReader.name();
 
-    if (name.compare("constraints", Qt::CaseInsensitive) == 0)
+    if (name.compare(QLatin1String("constraints"), Qt::CaseInsensitive) == 0)
     {
       return handleConstraintsElement(moduleParamPrivate, xmlReader);
     }
@@ -217,7 +217,7 @@ protected:
   {
     QStringRef name = xmlReader.name();
 
-    if (name.compare("element", Qt::CaseInsensitive) == 0)
+    if (name.compare(QLatin1String("element"), Qt::CaseInsensitive) == 0)
     {
       moduleParamPrivate->Elements.push_back(xmlReader.readElementText().trimmed());
       return true;

--- a/Libs/CommandLineModules/Core/ctkCmdLineModuleXmlParser.cpp
+++ b/Libs/CommandLineModules/Core/ctkCmdLineModuleXmlParser.cpp
@@ -103,39 +103,39 @@ void ctkCmdLineModuleXmlParser::handleExecutableElement()
   {
     QStringRef name = _xmlReader.name();
 
-    if (name.compare("category", Qt::CaseInsensitive) == 0)
+    if (name.compare(QLatin1String("category"), Qt::CaseInsensitive) == 0)
     {
       _md->d->Category = _xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("title", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("title"), Qt::CaseInsensitive) == 0)
     {
       _md->d->Title = _xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("version", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("version"), Qt::CaseInsensitive) == 0)
     {
       _md->d->Version = _xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("documentation-url", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("documentation-url"), Qt::CaseInsensitive) == 0)
     {
       _md->d->DocumentationURL = _xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("license", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("license"), Qt::CaseInsensitive) == 0)
     {
       _md->d->License = _xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("acknowledgements", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("acknowledgements"), Qt::CaseInsensitive) == 0)
     {
       _md->d->Acknowledgements = _xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("contributor", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("contributor"), Qt::CaseInsensitive) == 0)
     {
       _md->d->Contributor = _xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("description", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("description"), Qt::CaseInsensitive) == 0)
     {
       _md->d->Description = _xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("parameters", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("parameters"), Qt::CaseInsensitive) == 0)
     {
       this->handleParametersElement();
     }
@@ -159,11 +159,11 @@ void ctkCmdLineModuleXmlParser::handleParametersElement()
   {
     QStringRef name = _xmlReader.name();
 
-    if (name.compare("label", Qt::CaseInsensitive) == 0)
+    if (name.compare(QLatin1String("label"), Qt::CaseInsensitive) == 0)
     {
       group.d->Label = _xmlReader.readElementText().trimmed();
     }
-    else if (name.compare("description", Qt::CaseInsensitive) == 0)
+    else if (name.compare(QLatin1String("description"), Qt::CaseInsensitive) == 0)
     {
       group.d->Description = _xmlReader.readElementText().trimmed();
     }

--- a/Libs/CommandLineModules/Core/ctkCmdLineModuleXmlProgressWatcher.cpp
+++ b/Libs/CommandLineModules/Core/ctkCmdLineModuleXmlProgressWatcher.cpp
@@ -129,7 +129,8 @@ public:
         QString parent;
         if (!stack.empty()) parent = stack.back();
 
-        if (name.compare("module-root") != 0 && name.compare("module-snippet") != 0)
+        if (name.compare(QLatin1String("module-root")) != 0 &&
+            name.compare(QLatin1String("module-snippet")) != 0)
         {
           stack.push_back(name.toString());
         }
@@ -177,7 +178,7 @@ public:
           if (!stack.empty()) parent = stack.back();
         }
 
-        if (parent.isEmpty() && name.compare("module-snippet") != 0)
+        if (parent.isEmpty() && name.compare(QLatin1String("module-snippet")) != 0)
         {
           if (name.compare(FILTER_START, Qt::CaseInsensitive) == 0)
           {

--- a/Libs/PluginFramework/ctkBasicLocation_p.h
+++ b/Libs/PluginFramework/ctkBasicLocation_p.h
@@ -22,7 +22,7 @@
 #ifndef CTKBASICLOCATION_H
 #define CTKBASICLOCATION_H
 
-#include "service\datalocation\ctkLocation.h"
+#include "service/datalocation/ctkLocation.h"
 
 #include <QUrl>
 #include <QString>

--- a/Libs/PluginFramework/ctkBasicLocation_p.h
+++ b/Libs/PluginFramework/ctkBasicLocation_p.h
@@ -22,7 +22,7 @@
 #ifndef CTKBASICLOCATION_H
 #define CTKBASICLOCATION_H
 
-#include <service/datalocation/ctkLocation.h>
+#include "service\datalocation\ctkLocation.h"
 
 #include <QUrl>
 #include <QString>

--- a/Libs/PluginFramework/ctkDefaultApplicationLauncher_p.h
+++ b/Libs/PluginFramework/ctkDefaultApplicationLauncher_p.h
@@ -22,7 +22,7 @@
 #ifndef CTKDEFAULTAPPLICATIONLAUNCHER_H
 #define CTKDEFAULTAPPLICATIONLAUNCHER_H
 
-#include <service/application/ctkApplicationLauncher.h>
+#include "service/application/ctkApplicationLauncher.h"
 
 #include <QSemaphore>
 #include <QVariant>

--- a/Libs/PluginFramework/ctkPluginFrameworkDebugOptions_p.h
+++ b/Libs/PluginFramework/ctkPluginFrameworkDebugOptions_p.h
@@ -22,7 +22,7 @@
 #ifndef CTKPLUGINFRAMEWORKDEBUGOPTIONS_H
 #define CTKPLUGINFRAMEWORKDEBUGOPTIONS_H
 
-#include <service/debug/ctkDebugOptions.h>
+#include "service/debug/ctkDebugOptions.h"
 #include <service/debug/ctkDebugOptionsListener.h>
 
 #include <ctkServiceTracker.h>


### PR DESCRIPTION
Unfortunately, the Qt guys added another overload (QByteArray) of the compare method to QStringRef which results in ambiguities when calling this method with plain C strings. This can be fixed by explicitly using QLatin1String. According to the Qt documentation, this is even more efficient than using plain C strings.

Another issue is the inability of the MOC to find a few interface declarations, even though they are included right in front of the using classes. The trick was to switch from <>-includes to ""-includes to help the MOC along looking in the correct folders for the header files. Doesn't work for Snippet-EventAdmin-Intro, though. :/