### PR TITLE
ENH: Improved ctkFittedTextBrowser API

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkFittedTextBrowserTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkFittedTextBrowserTest1.cpp
@@ -51,31 +51,28 @@ int ctkFittedTextBrowserTest1(int argc, char * argv [] )
   layout->addWidget(&textBrowserWidget);
 
   ctkFittedTextBrowser textBrowserWidgetCollapsibleText(&widget);
-  textBrowserWidgetCollapsibleText.setCollapsible(true);
-  textBrowserWidgetCollapsibleText.setText(
+  textBrowserWidgetCollapsibleText.setCollapsibleText(
     "This is the teaser for auto-text.\n More details are here.\n"
     "This is a very very, very very very, very very, very very very, very very, very very very long line\n"
     "Some more lines 1.\n"
     "Some more lines 2.\n"
     "Some more, some more.");
-  textBrowserWidgetCollapsibleText.setShowMoreText("&gt;&gt;&gt;");
-  textBrowserWidgetCollapsibleText.setShowLessText("&lt;&lt;&lt;");
+  textBrowserWidgetCollapsibleText.setShowDetailsText("&gt;&gt;&gt;");
+  textBrowserWidgetCollapsibleText.setHideDetailsText("&lt;&lt;&lt;");
   layout->addWidget(&textBrowserWidgetCollapsibleText);
 
   ctkFittedTextBrowser textBrowserWidgetCollapsibleHtml(&widget);
-  textBrowserWidgetCollapsibleHtml.setHtml(
+  textBrowserWidgetCollapsibleHtml.setCollapsibleHtml(
     "This is the teaser for html.<br>"
     "More details are here."
     "This is a very very, very very very, very very, very very very, very very, very very very long line\n"
     "Some more lines 1."
     "Some more lines 2."
     "Some more, some more.");
-  textBrowserWidgetCollapsibleHtml.setCollapsible(true);
   layout->addWidget(&textBrowserWidgetCollapsibleHtml);
 
   ctkFittedTextBrowser textBrowserWidgetCollapsibleComplexHtml(&widget);
-  textBrowserWidgetCollapsibleComplexHtml.setCollapsible(true);
-  textBrowserWidgetCollapsibleComplexHtml.setHtml(
+  textBrowserWidgetCollapsibleComplexHtml.setCollapsibleHtml(
     "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\"><html>"
     "<head><meta name=\"qrichtext\" content=\"1\" /> <style type=\"text/css\"> p, li { white-space: pre-wrap; } </style></head>"
     "<body style=\" font-family:'MS Shell Dlg 2'; font-size:12.25pt; font-weight:400; font-style:normal;\">"

--- a/Libs/Widgets/ctkFittedTextBrowser.h
+++ b/Libs/Widgets/ctkFittedTextBrowser.h
@@ -42,25 +42,14 @@ class ctkFittedTextBrowserPrivate;
 class CTK_WIDGETS_EXPORT ctkFittedTextBrowser : public QTextBrowser
 {
   Q_OBJECT
-  Q_PROPERTY(bool collapsible READ collapsible WRITE setCollapsible)
   Q_PROPERTY(bool collapsed READ collapsed WRITE setCollapsed)
-  Q_PROPERTY(QString showMoreText READ showMoreText WRITE setShowMoreText)
-  Q_PROPERTY(QString showLessText READ showLessText WRITE setShowLessText)
+  Q_PROPERTY(QString showDetailsText READ showDetailsText WRITE setShowDetailsText)
+  Q_PROPERTY(QString hideDetailsText READ hideDetailsText WRITE setHideDetailsText)
+
 
 public:
   ctkFittedTextBrowser(QWidget* parent = 0);
   virtual ~ctkFittedTextBrowser();
-
-  /// Show only first line with "More..." link to save space.
-  /// When the user clicks on the link then the full text is displayed
-  /// (and a "Less..." link).
-  /// The teaser is the beginning of the text up to the first newline character
-  /// (for plain text) or <br> tag (for html). The separator is removed when
-  /// the text is expanded so that the full text can continue on the same line
-  /// as the teaser.
-  void setCollapsible(bool collapsible);
-  /// Show only first line with "More..." link to save space.
-  bool collapsible() const;
 
   /// Show only first line/the full text.
   /// Only has effect if collapsible = true.
@@ -68,23 +57,20 @@ public:
   /// Show only first line/the full text.
   bool collapsed() const;
 
-  void setPlainText(const QString &text);
-#ifndef QT_NO_TEXTHTMLPARSER
-  void setHtml(const QString &text);
-#endif
-  void setText(const QString &text);
-
   /// Text that is displayed at the end of collapsed text.
   /// Clicking on the text expands the widget.
-  void setShowMoreText(const QString &text);
+  void setShowDetailsText(const QString &text);
   /// Text that is displayed at the end of collapsed text.
-  QString showMoreText()const;
+  QString showDetailsText()const;
 
   /// Text that is displayed at the end of non-collapsed text.
   /// Clicking on the text collapses the widget.
-  void setShowLessText(const QString &text);
+  void setHideDetailsText(const QString &text);
   /// Text that is displayed at the end of non-collapsed text.
-  QString showLessText()const;
+  QString hideDetailsText()const;
+
+  /// Return text set by setCollapsibleText.
+  Q_INVOKABLE QString collapsibleText() const;
 
   /// Reimplemented for internal reasons
   virtual QSize sizeHint() const;
@@ -92,6 +78,31 @@ public:
   virtual QSize minimumSizeHint() const;
   /// Reimplemented for internal reasons
   virtual int heightForWidth(int width) const;
+
+public Q_SLOTS:
+
+  /// Set text that can be displayed in a shortened form (collapsed) for saving space,
+  /// by only showing first line with "More..." link appended.
+  /// When the user clicks on the link then the full text is displayed
+  /// (and a "Less..." link).
+  /// The teaser is the beginning of the text up to the first newline character
+  /// (for plain text) or <br> tag (for html). The separator is removed when
+  /// the text is expanded so that the full text can continue on the same line
+  /// as the teaser.
+  /// 
+  /// The text can be plain text or HTML and the the right format will be guessed.
+  /// Use setCollapsedHtml() or setCollapsedPlainText() directly to avoid guessing.
+  void setCollapsibleText(const QString &text);
+
+#ifndef QT_NO_TEXTHTMLPARSER
+  /// Set text that can be displayed in a shortened form (collapsed) for saving space.
+  /// \sa setCollapsibleText
+  void setCollapsibleHtml(const QString &text);
+#endif
+
+  /// Set text that can be displayed in a shortened form (collapsed) for saving space.
+  /// \sa setCollapsibleText
+  void setCollapsiblePlainText(const QString &text);
 
 protected Q_SLOTS:
   void heightForWidthMayHaveChanged();

--- a/Libs/Widgets/ctkFittedTextBrowser_p.h
+++ b/Libs/Widgets/ctkFittedTextBrowser_p.h
@@ -1,22 +1,22 @@
 /*=========================================================================
 
-  Library:   CTK
+Library:   CTK
 
-  Copyright (c) Kitware Inc.
+Copyright (c) Kitware Inc.
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0.txt
+http://www.apache.org/licenses/LICENSE-2.0.txt
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
-  =========================================================================*/
+=========================================================================*/
 
 #ifndef __ctkFittedTextBrowser_p_h
 #define __ctkFittedTextBrowser_p_h
@@ -37,27 +37,26 @@ public:
   ctkFittedTextBrowserPrivate(ctkFittedTextBrowser& object);
   virtual ~ctkFittedTextBrowserPrivate();
 
-  // Get collapsed/expanded text in html format.
-  // Calls collapsiblePlainText or collapsibleHtml.
-  QString collapsibleText();
+  // Update collapsed/expanded text in the widget.
+  void updateCollapsedText();
+
   // Get collapsed/expanded text in html format from plain text.
-  QString collapsiblePlainText();
+  QString collapsedTextFromPlainText() const;
   // Get collapsed/expanded text in html format from html.
-  QString collapsibleHtml();
+  QString collapsedTextFromHtml() const;
 
   // Get more/less link in html format
-  QString collapseLinkText();
+  QString collapseLinkText() const;
 
-  bool Collapsible;
   bool Collapsed;
 
-  QString ShowMoreText;
-  QString ShowLessText;
+  QString ShowDetailsText;
+  QString HideDetailsText;
 
   // Stores the text that the user originally set.
-  QString FullText;
-  
-  enum FullTextSetMethod
+  QString CollapsibleText;
+
+  enum CollapsibleTextSetMethod
   {
     Text,
     PlainText,
@@ -65,7 +64,7 @@ public:
   };
 
   // Stores what method the user called to set text
-  FullTextSetMethod FullTextSetter;
+  CollapsibleTextSetMethod CollapsibleTextSetter;
 };
 
 #endif


### PR DESCRIPTION
setText methods were not virtual in base class, which made method calls from Python unpredictable.
Introduced new methods for setting collapsible text.

Also fixed const-correctness in ctkFittedTextBrowserPrivate class.