### PR TITLE
Don't through exception from ctkDICOMDatabase

### DIFF
--- a/Libs/DICOM/Core/Testing/Cpp/CMakeLists.txt
+++ b/Libs/DICOM/Core/Testing/Cpp/CMakeLists.txt
@@ -8,6 +8,7 @@ create_test_sourcelist(Tests ${KIT}CppTests.cpp
   ctkDICOMDatabaseTest4.cpp
   ctkDICOMDatabaseTest5.cpp
   ctkDICOMDatabaseTest6.cpp
+  ctkDICOMDatabaseTest7.cpp
   ctkDICOMItemTest1.cpp
   ctkDICOMIndexerTest1.cpp
   ctkDICOMModelTest1.cpp
@@ -41,6 +42,7 @@ SIMPLE_TEST(ctkDICOMDatabaseTest3
 SIMPLE_TEST(ctkDICOMDatabaseTest4 ${CTKData_DIR}/Data/DICOM/MRHEAD/000055.IMA)
 SIMPLE_TEST(ctkDICOMDatabaseTest5 ${CTKData_DIR}/Data/DICOM/MRHEAD/000055.IMA)
 SIMPLE_TEST(ctkDICOMDatabaseTest6 ${CTKData_DIR}/Data/DICOM/MRHEAD/000055.IMA)
+SIMPLE_TEST(ctkDICOMDatabaseTest7)
 SIMPLE_TEST(ctkDICOMItemTest1)
 SIMPLE_TEST(ctkDICOMIndexerTest1 )
 

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest7.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest7.cpp
@@ -1,0 +1,65 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+// Qt includes
+#include <QCoreApplication>
+#include <QDir>
+
+// ctkDICOMCore includes
+#include "ctkDICOMDatabase.h"
+
+// STD includes
+#include <iostream>
+#include <cstdlib>
+
+
+int ctkDICOMDatabaseTest7( int argc, char * argv [] )
+{
+  QCoreApplication app(argc, argv);
+
+  ctkDICOMDatabase database;
+  QDir databaseDirectory = QDir::temp();
+  databaseDirectory.remove("ctkDICOMDatabase.sql");
+  databaseDirectory.remove("ctkDICOMTagCache.sql");
+
+  QFileInfo databaseFile(databaseDirectory, QString("database.test"));
+  database.openDatabase(databaseFile.absoluteFilePath());
+
+  bool res = database.initializeDatabase();
+
+  if (!res)
+    {
+    std::cerr << "ctkDICOMDatabase::initializeDatabase() failed." << std::endl;
+    return EXIT_FAILURE;
+    }
+  std::cerr << "Database is in " << databaseDirectory.path().toStdString() << std::endl;
+
+  // try to call fileValue with bogus data - should not trigger and exception
+  // (see https://github.com/commontk/CTK/issues/706)
+
+  database.fileValue("/tmp/file-that-does-not-exist", "00ff,eeee");
+
+  //
+  // Close and clean up
+  //
+  database.closeDatabase();
+
+  return EXIT_SUCCESS;
+}

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -994,11 +994,18 @@ QString ctkDICOMDatabase::fileValue(const QString fileName, const unsigned short
   ctkDICOMItem dataset;
   dataset.InitializeFromFile(fileName);
 
-  DcmTagKey tagKey(group, element);
+  if (dataset.IsInitialized())
+    {
+    DcmTagKey tagKey(group, element);
+    value = dataset.GetAllElementValuesAsString(tagKey);
+    }
+  else
+    {
+    value = TagNotInInstance;
+    }
 
-  value = dataset.GetAllElementValuesAsString(tagKey);
   this->cacheTag(sopInstanceUID, tag, value);
-  return( value );
+  return value;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
More gracefully handle an error case that can
be anticipated.  Exception is not appropriate
when a meaningful return option is avaiable.

Closes #706