### PR TITLE
BUG: Fixed multi-value argument parsing

### DIFF
--- a/Libs/Core/Testing/Cpp/ctkCommandLineParserTest1.cpp
+++ b/Libs/Core/Testing/Cpp/ctkCommandLineParserTest1.cpp
@@ -92,9 +92,9 @@ int ctkCommandLineParserTest1(int, char*[])
   arguments3 << "ctkCommandLineParserTest1";
   arguments3 << "--test-string" << "TestingIsGood";
   arguments3 << "--test-string2"<< "CTKSuperRocks";
-  arguments3 << "--test-integer"<< "-3";
 //  arguments3 << "--test-double"<< "-3.14";
   arguments3 << "--test-stringlist"<< "item1" << "item2" << "item3";
+  arguments3 << "--test-integer"<< "-3"; // test if argument is recognized after multi-value argument
   ctkCommandLineParser parser3;
   parser3.addArgument("--test-string", "", QVariant::String, "This is a test string");
   parser3.addArgument("--test-string2", "", QVariant::String, "This is a test string2", "CTKGood");

--- a/Libs/Core/ctkCommandLineParser.cpp
+++ b/Libs/Core/ctkCommandLineParser.cpp
@@ -447,8 +447,10 @@ QHash<QString, QVariant> ctkCommandLineParser::parseArguments(const QStringList&
             {
             qDebug() << "  Processing parameter" << j << ", value:" << parameter;
             }
-          if (this->argumentAdded(parameter))
+          if (this->Internal->argumentDescription(parameter) != 0)
             {
+            // we've found a known argument, it means there are no more
+            // parameter for the current argument
             this->Internal->ErrorString =
                 missingParameterError.arg(argument).arg(j-1).arg(numberOfParametersToProcess);
             if (this->Internal->Debug) { qDebug() << this->Internal->ErrorString; }
@@ -478,12 +480,15 @@ QHash<QString, QVariant> ctkCommandLineParser::parseArguments(const QStringList&
         int j = 1;
         while(j + i < arguments.size())
           {
-          if (this->argumentAdded(arguments.at(j + i)))
+          if (this->Internal->argumentDescription(arguments.at(j + i)) != 0)
             {
+            // we've found a known argument, it means there are no more
+            // parameter for the current argument
             if (this->Internal->Debug)
               {
               qDebug() << "  No more parameter for" << argument;
               }
+            j--; // this parameter does not belong to current argument
             break;
             }
           QString parameter = arguments.at(j + i);


### PR DESCRIPTION
When a multi-value argument was passed to the command-line parser, all subsequent parameters were considered part of the argument.
This caused several test errors in Slicer: --ptyhon-script parameter was ignored if --additional-module-paths argument was specified before,
which made --python-script parameter ignored, and as a result, the provided Python script was not executed, which caused test failures
(py_nomainwindow_SlicerTestingExitFailureTest, py_nomainwindow_SlicerUnitTestWithErrorsTest, py_SlicerTestingExitFailureTest).

The root cause of the problem was that the check that compared a parameter to a known argument was incorrect: the parameter name
contained the prefix (--python-script) and this string was searched among argument names (such as python-script).

Fixed by parsing each parameter after a multi-value argument. If a known argument is found, it is not added to the multi-value argument.

Added test: modified ctkCommandLineParserTest1 to test that arguments specified after a multi-value argument are parsed correctly.