### PR TITLE
Update QtTesting to fix overload warnings

### DIFF
--- a/CMakeExternals/QtTesting.cmake
+++ b/CMakeExternals/QtTesting.cmake
@@ -24,7 +24,7 @@ endif()
 
 if(NOT DEFINED QtTesting_DIR)
 
-  set(revision_tag 9951bc69b007812dd5172218dd219a4e98e0fcf8)
+  set(revision_tag 828b35edbbac6b08668809c84391003a2f513d1b)
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()
@@ -36,7 +36,7 @@ if(NOT DEFINED QtTesting_DIR)
     set(location_args GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
                       GIT_TAG ${revision_tag})
   else()
-    set(location_args GIT_REPOSITORY "${git_protocol}://github.com/Kitware/QtTesting.git"
+    set(location_args GIT_REPOSITORY "${git_protocol}://github.com/commontk/QtTesting.git"
                       GIT_TAG ${revision_tag})
   endif()
 

--- a/Libs/QtTesting/ctkXMLEventObserver.cpp
+++ b/Libs/QtTesting/ctkXMLEventObserver.cpp
@@ -159,6 +159,6 @@ void ctkXMLEventObserver::onRecordEvent(const QString& widget,
       *this->Stream << this->XMLString;
       }
     this->XMLString = QString();
-    emit this->eventRecorded(widget, command, arguments);
+    emit this->eventRecorded(widget, command, arguments, eventType);
     }
 }

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderViewEventPlayer.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderViewEventPlayer.h
@@ -37,7 +37,10 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKRenderViewEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkVTKRenderViewEventPlayer(const QByteArray& classname, QObject* parent = 0);
+
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 protected:

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderViewEventTranslator.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderViewEventTranslator.h
@@ -37,9 +37,11 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKRenderViewEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkVTKRenderViewEventTranslator(const QByteArray& Classname, QObject* Parent=0);
   ~ctkVTKRenderViewEventTranslator();
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 protected:

--- a/Libs/Widgets/ctkAxesWidgetEventPlayer.h
+++ b/Libs/Widgets/ctkAxesWidgetEventPlayer.h
@@ -37,8 +37,10 @@ class CTK_WIDGETS_EXPORT ctkAxesWidgetEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkAxesWidgetEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkAxesWidgetEventTranslator.h
+++ b/Libs/Widgets/ctkAxesWidgetEventTranslator.h
@@ -34,8 +34,10 @@ class CTK_WIDGETS_EXPORT ctkAxesWidgetEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkAxesWidgetEventTranslator(QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkCheckableComboBoxEventPlayer.h
+++ b/Libs/Widgets/ctkCheckableComboBoxEventPlayer.h
@@ -37,8 +37,10 @@ class CTK_WIDGETS_EXPORT ctkCheckableComboBoxEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkCheckableComboBoxEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkCheckableComboBoxEventTranslator.h
+++ b/Libs/Widgets/ctkCheckableComboBoxEventTranslator.h
@@ -38,8 +38,10 @@ class CTK_WIDGETS_EXPORT ctkCheckableComboBoxEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkCheckableComboBoxEventTranslator(QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkCheckableHeaderViewEventPlayer.h
+++ b/Libs/Widgets/ctkCheckableHeaderViewEventPlayer.h
@@ -37,8 +37,10 @@ class CTK_WIDGETS_EXPORT ctkCheckableHeaderViewEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkCheckableHeaderViewEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkCheckableHeaderViewEventTranslator.h
+++ b/Libs/Widgets/ctkCheckableHeaderViewEventTranslator.h
@@ -35,8 +35,10 @@ class CTK_WIDGETS_EXPORT ctkCheckableHeaderViewEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkCheckableHeaderViewEventTranslator(QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkConsoleEventPlayer.h
+++ b/Libs/Widgets/ctkConsoleEventPlayer.h
@@ -32,8 +32,10 @@ class CTK_WIDGETS_EXPORT ctkConsoleEventPlayer : public pqWidgetEventPlayer
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkConsoleEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command,
                  const QString &Arguments, bool &Error);
 

--- a/Libs/Widgets/ctkConsoleEventTranslator.h
+++ b/Libs/Widgets/ctkConsoleEventTranslator.h
@@ -35,8 +35,10 @@ class CTK_WIDGETS_EXPORT ctkConsoleEventTranslator :public pqWidgetEventTranslat
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkConsoleEventTranslator(QObject* = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkDoubleRangeSliderEventPlayer.h
+++ b/Libs/Widgets/ctkDoubleRangeSliderEventPlayer.h
@@ -37,8 +37,10 @@ class CTK_WIDGETS_EXPORT ctkDoubleRangeSliderEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkDoubleRangeSliderEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkDoubleRangeSliderEventTranslator.h
+++ b/Libs/Widgets/ctkDoubleRangeSliderEventTranslator.h
@@ -36,8 +36,10 @@ class CTK_WIDGETS_EXPORT ctkDoubleRangeSliderEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkDoubleRangeSliderEventTranslator(QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkFileDialogEventPlayer.h
+++ b/Libs/Widgets/ctkFileDialogEventPlayer.h
@@ -40,6 +40,7 @@ public:
   typedef pqNativeFileDialogEventPlayer Superclass;
   ctkFileDialogEventPlayer(pqTestUtility* util, QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkFileDialogEventTranslator.h
+++ b/Libs/Widgets/ctkFileDialogEventTranslator.h
@@ -42,6 +42,7 @@ public:
   typedef pqNativeFileDialogEventTranslator Superclass;
   ctkFileDialogEventTranslator(pqTestUtility* util, QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkFontButtonEventPlayer.h
+++ b/Libs/Widgets/ctkFontButtonEventPlayer.h
@@ -37,8 +37,10 @@ class CTK_WIDGETS_EXPORT ctkFontButtonEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkFontButtonEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkFontButtonEventTranslator.h
+++ b/Libs/Widgets/ctkFontButtonEventTranslator.h
@@ -38,8 +38,10 @@ class CTK_WIDGETS_EXPORT ctkFontButtonEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkFontButtonEventTranslator(QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkMatrixWidgetEventPlayer.h
+++ b/Libs/Widgets/ctkMatrixWidgetEventPlayer.h
@@ -37,8 +37,10 @@ class CTK_WIDGETS_EXPORT ctkMatrixWidgetEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkMatrixWidgetEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkMatrixWidgetEventTranslator.h
+++ b/Libs/Widgets/ctkMatrixWidgetEventTranslator.h
@@ -36,8 +36,10 @@ class CTK_WIDGETS_EXPORT ctkMatrixWidgetEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkMatrixWidgetEventTranslator(QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkMenuComboBoxEventPlayer.h
+++ b/Libs/Widgets/ctkMenuComboBoxEventPlayer.h
@@ -37,8 +37,10 @@ class CTK_WIDGETS_EXPORT ctkMenuComboBoxEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkMenuComboBoxEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkMenuComboBoxEventTranslator.h
+++ b/Libs/Widgets/ctkMenuComboBoxEventTranslator.h
@@ -40,8 +40,10 @@ class CTK_WIDGETS_EXPORT ctkMenuComboBoxEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkMenuComboBoxEventTranslator(QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkPathLineEditEventPlayer.h
+++ b/Libs/Widgets/ctkPathLineEditEventPlayer.h
@@ -37,8 +37,10 @@ class CTK_WIDGETS_EXPORT ctkPathLineEditEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkPathLineEditEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkPathLineEditEventTranslator.h
+++ b/Libs/Widgets/ctkPathLineEditEventTranslator.h
@@ -36,8 +36,10 @@ class CTK_WIDGETS_EXPORT ctkPathLineEditEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkPathLineEditEventTranslator(QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkPopupWidgetEventPlayer.h
+++ b/Libs/Widgets/ctkPopupWidgetEventPlayer.h
@@ -37,8 +37,10 @@ class CTK_WIDGETS_EXPORT ctkPopupWidgetEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkPopupWidgetEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkPopupWidgetEventTranslator.h
+++ b/Libs/Widgets/ctkPopupWidgetEventTranslator.h
@@ -36,8 +36,10 @@ class CTK_WIDGETS_EXPORT ctkPopupWidgetEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkPopupWidgetEventTranslator(QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkRangeSliderEventPlayer.h
+++ b/Libs/Widgets/ctkRangeSliderEventPlayer.h
@@ -37,8 +37,10 @@ class CTK_WIDGETS_EXPORT ctkRangeSliderEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkRangeSliderEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkRangeSliderEventTranslator.h
+++ b/Libs/Widgets/ctkRangeSliderEventTranslator.h
@@ -36,8 +36,10 @@ class CTK_WIDGETS_EXPORT ctkRangeSliderEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkRangeSliderEventTranslator(QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkTreeComboBoxEventPlayer.h
+++ b/Libs/Widgets/ctkTreeComboBoxEventPlayer.h
@@ -37,8 +37,10 @@ class CTK_WIDGETS_EXPORT ctkTreeComboBoxEventPlayer :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventPlayer Superclass;
   ctkTreeComboBoxEventPlayer(QObject* parent = 0);
 
+  using Superclass::playEvent;
   bool playEvent(QObject *Object, const QString &Command, const QString &Arguments, bool &Error);
 
 private:

--- a/Libs/Widgets/ctkTreeComboBoxEventTranslator.h
+++ b/Libs/Widgets/ctkTreeComboBoxEventTranslator.h
@@ -38,8 +38,10 @@ class CTK_WIDGETS_EXPORT ctkTreeComboBoxEventTranslator :
   Q_OBJECT
 
 public:
+  typedef pqWidgetEventTranslator Superclass;
   ctkTreeComboBoxEventTranslator(QObject* parent = 0);
 
+  using Superclass::translateEvent;
   virtual bool translateEvent(QObject *Object, QEvent *Event, bool &Error);
 
 private:


### PR DESCRIPTION
```
$ git shortlog 9951bc6..828b35e --no-merges
Ben Boeckel (1):
      cmake: don't set the minimum version if not the top-level

Jean-Christophe Fillion-Robin (4):
      test: Fix pq(Double)SpinBoxEventTranslatorTest
      test: Fix pqEventRecorderTest
      Fix -Woverloaded-virtual warning in custom event player
      Fix -Woverloaded-virtual warning in custom event translator

Mathieu Westphal (2):
      Enable use of continuous flush
      Add feature to record interaction timings

Utkarsh Ayachit (1):
      Fixes for Qt 5 / OsX test playback.
```