### PR TITLE
ENH: emitting progress(int) signal only if the percentage value changed

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMIndexer.cpp
+++ b/Libs/DICOM/Core/ctkDICOMIndexer.cpp
@@ -132,10 +132,15 @@ void ctkDICOMIndexer::addListOfFiles(ctkDICOMDatabase& ctkDICOMDatabase,
   Q_D(ctkDICOMIndexer);
   d->Canceled = false;
   int CurrentFileIndex = 0;
+  int progressValue = 0;
+
   foreach(QString filePath, listOfFiles)
   {
     int percent = ( 100 * CurrentFileIndex ) / listOfFiles.size();
-    emit this->progress(percent);
+    if (percent != progressValue) {
+      progressValue = percent;
+      emit this->progress(percent);
+    }
     this->addFile(ctkDICOMDatabase, filePath, destinationDirectoryName);
     CurrentFileIndex++;
 


### PR DESCRIPTION
* before that it was emitted for every file that is imported:
  Example: for an import of 1000 files it will be emitted 1000 times
           instead of 100 times only
* it would make sense if the progress value was a float value but not as integer