### PR TITLE
BUG: BuildSystem: Remove duplicated else in ctkMacroSetupQt.cmake

### DIFF
--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -72,9 +72,6 @@ macro(ctkMacroSetupQt)
     else()
       message(FATAL_ERROR "error: Qt4 was not found on your system. You probably need to set the QT_QMAKE_EXECUTABLE variable")
     endif()
-
-  else()
-    message(FATAL_ERROR "error: Qt4 was not found on your system. You probably need to set the QT_QMAKE_EXECUTABLE variable")
   endif()
 
   mark_as_superbuild(CTK_QT_VERSION)


### PR DESCRIPTION
Fixes #715

Suggested-by: Samuel John <github@samueljohn.de>