### PR TITLE
getMatchedObjectClasses does not collect class names

### DIFF
--- a/Libs/PluginFramework/ctkLDAPExpr.cpp
+++ b/Libs/PluginFramework/ctkLDAPExpr.cpp
@@ -189,7 +189,7 @@ bool ctkLDAPExpr::getMatchedObjectClasses(QSet<QString>& objClasses) const
 {
   if (d->m_operator == EQ)
   {
-    if (d->m_attrName.compare(ctkPluginConstants::OBJECTCLASS, Qt::CaseInsensitive) &&
+    if (d->m_attrName.compare(ctkPluginConstants::OBJECTCLASS, Qt::CaseInsensitive) == 0 &&
       d->m_attrValue.indexOf(WILDCARD) < 0) 
     {
       objClasses.insert( d->m_attrValue );


### PR DESCRIPTION
Bug that prevent to collect "objectclass" values because if the result of compare is 0, 0 is interpreted as "false". The result is that all fields value that does not correspond to objectclass are inserted. This is the inverse of what we want.