### PR TITLE
BUG: Fixed warped widgets in ctkVTKSliceView overlay

### DIFF
--- a/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
+++ b/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
@@ -373,6 +373,14 @@ void vtkLightBoxRendererManager::vtkInternal::setupRendering()
       // Add to RenderWindow
       this->RenderWindow->AddRenderer(item->Renderer);
 
+      // Parallel projection is needed to prevent actors from warping/tilting
+      // when they are near the edge of the window.
+      vtkCamera* camera = item->Renderer->GetActiveCamera();
+      if (camera)
+        {
+        camera->ParallelProjectionOn();
+        }
+
       xMin += viewportWidth;
       }
     }

--- a/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.cpp
@@ -70,6 +70,13 @@ void ctkVTKSliceViewPrivate::setupRendering()
   // Setup overlay renderer
   this->OverlayRenderer->SetLayer(1);
   this->RenderWindow->AddRenderer(this->OverlayRenderer);
+  // Parallel projection is needed to prevent actors from warping/tilting
+  // when they are near the edge of the window.
+  vtkCamera* camera = this->OverlayRenderer->GetActiveCamera();
+  if (camera)
+    {
+    camera->ParallelProjectionOn();
+    }
 
   // Create cornerAnnotation and set its default property
   this->OverlayCornerAnnotation = vtkSmartPointer<vtkCornerAnnotation>::New();


### PR DESCRIPTION
Default camera for overlay layer in ctkVTKSliceView was a default VTK camera with perspective projection.
This caused widgets appear tilted/warped when displayed near the edge of the render window.
This was particularly visible in vector text rendered by VTK seed widget (markup fiducials in 3D Slicer).

Before the fix:
![image](https://user-images.githubusercontent.com/307929/27387137-dd8ebda4-5665-11e7-8de4-971767847b6d.png)

After the fix:
![image](https://user-images.githubusercontent.com/307929/27387156-ea1c3876-5665-11e7-920a-a671e9572350.png)

