### PR TITLE
BUG: Fixed crash in histogram computation for inf image

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKHistogram.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKHistogram.cpp
@@ -348,8 +348,8 @@ void populateIrregularBins(vtkIntArray* bins, const ctkVTKHistogram* histogram)
   ptr += component;
   for (; ptr < endPtr; ptr += componentNumber)
     {
-    if (std::numeric_limits<T>::has_quiet_NaN &&
-        vtkMath::IsNan(*ptr))
+    if ((std::numeric_limits<T>::has_quiet_NaN &&
+      vtkMath::IsNan(*ptr)) || vtkMath::IsInf(*ptr))
       {
       continue;
       }


### PR DESCRIPTION
When an image contained an (inf) value, it caused ctkVTKHistogram to crash because the computed bin index was out of bounds.