### PR TITLE
BUG: Fix build when CMAKE_CXX_STANDARD is not set

### DIFF
--- a/CMake/ctkBlockCheckDependencies.cmake
+++ b/CMake/ctkBlockCheckDependencies.cmake
@@ -38,16 +38,21 @@ if(CTK_SUPERBUILD)
   set(ep_common_c_flags "${CMAKE_C_FLAGS_INIT} ${ADDITIONAL_C_FLAGS}")
   set(ep_common_cxx_flags "${CMAKE_CXX_FLAGS_INIT} ${ADDITIONAL_CXX_FLAGS}")
 
+  set(ep_cxx_standard_arg)
+  if(CMAKE_CXX_STANDARD)
+    set(ep_cxx_standard_arg "-DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}")
+  endif()
+
   set(ep_common_cache_args
       -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
       -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
-      -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
       -DCMAKE_INSTALL_PREFIX:PATH=${ep_install_dir}
       -DCMAKE_PREFIX_PATH:STRING=${CMAKE_PREFIX_PATH}
       -DBUILD_TESTING:BOOL=OFF
+      ${ep_cxx_standard_arg}
      )
 endif()
 

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -34,6 +34,11 @@ endif()
 #-----------------------------------------------------------------------------
 set(proj CTK)
 
+set(ep_cxx_standard_arg)
+if(CMAKE_CXX_STANDARD)
+  set(ep_cxx_standard_arg "-DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}")
+endif()
+
 ExternalProject_Add(${proj}
   ${${proj}_EP_ARGS}
   DOWNLOAD_COMMAND ""
@@ -43,9 +48,9 @@ ExternalProject_Add(${proj}
     -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
     -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
     -DCMAKE_CXX_FLAGS_INIT:STRING=${CMAKE_CXX_FLAGS_INIT}
-    -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
     -DCMAKE_C_FLAGS_INIT:STRING=${CMAKE_C_FLAGS_INIT}
     -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
+    ${ep_cxx_standard_arg}
   SOURCE_DIR ${CTK_SOURCE_DIR}
   BINARY_DIR ${CTK_BINARY_DIR}/CTK-build
   INSTALL_COMMAND ""


### PR DESCRIPTION
Pass CMAKE_CXX_STANDARD to sub-projects only when it is set. This fixes
errors like:

    CMake Error at CMake/ctkMacroBuildLib.cmake:152 (add_library):
      CXX_STANDARD is set to invalid value ''
    Call Stack (most recent call first):
      Libs/Core/CMakeLists.txt:136 (ctkMacroBuildLib)