### PR TITLE
STYLE: Fix CircleCI link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Common Toolkit
 ==============
 
-.. image:: https://circleci.com/gh/commontk/CTK.svg?style=svg
-    :target: http://my.cdash.org/index.php?project=CTK
+.. image:: https://circleci.com/gh/commontk/CTK.png?style=shield
+    :target: https://circleci.com/gh/commontk/CTK
 
 The Common Toolkit is a community effort to provide support code for medical image analysis,
 surgical navigation, and related projects.


### PR DESCRIPTION
The CDash project for CTK seems retired. Clicking the test results link should
navigate to CircleCI. Additionally, update the build status icon to 'shield'
style, which includes the word 'circleci'.