### PR TITLE
ENH: Added Copy metadata button to DICOM metadata widget

### DIFF
--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMObjectListWidget.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMObjectListWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>312</width>
-    <height>206</height>
+    <width>486</width>
+    <height>297</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,18 +20,6 @@
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QLabel" name="label">
-         <property name="minimumSize">
-          <size>
-           <width>70</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>70</width>
-           <height>16777215</height>
-          </size>
-         </property>
          <property name="text">
           <string>File Path:</string>
          </property>
@@ -39,6 +27,12 @@
        </item>
        <item>
         <widget class="QLabel" name="currentPathLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string/>
          </property>
@@ -46,23 +40,18 @@
        </item>
        <item>
         <widget class="QPushButton" name="copyPathPushButton">
-         <property name="minimumSize">
-          <size>
-           <width>100</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
          <property name="toolTip">
           <string>Copy the file full path to the clipboard.</string>
          </property>
          <property name="text">
           <string>Copy Path</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="copyMetadataPushButton">
+         <property name="text">
+          <string>Copy Metadata</string>
          </property>
         </widget>
        </item>
@@ -79,7 +68,11 @@
       <layout class="QHBoxLayout" name="horizontalLayout_3"/>
      </item>
      <item>
-      <widget class="QTreeView" name="dcmObjectTreeView"/>
+      <widget class="QTreeView" name="dcmObjectTreeView">
+       <property name="toolTip">
+        <string>Double-click Tag to show its definition.</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.cpp
@@ -81,11 +81,7 @@ void ctkDICOMObjectListWidgetPrivate::setPathLabel(const QString& currentFile)
 QString ctkDICOMObjectListWidgetPrivate::dicomObjectModelAsString(QModelIndex parent /*=QModelIndex()*/, int indent /*=0*/)
 {
   QString dump;
-  QString indentString;
-  for (int i = 0; i < indent; ++i)
-    {
-    indentString += "\t";
-    }
+  QString indentString(indent, '\t'); // add tab characters, (indent) number of times
 #ifdef WIN32
   QString newLine = "\r\n";
 #else
@@ -97,12 +93,21 @@ QString ctkDICOMObjectListWidgetPrivate::dicomObjectModelAsString(QModelIndex pa
     for (int c = 0; c < this->dicomObjectModel->columnCount(); ++c)
       {
       QModelIndex index = this->dicomObjectModel->index(r, c, parent);
-      QVariant name = this->dicomObjectModel->data(index);
-      if (c > 0)
+      QString name = this->dicomObjectModel->data(index).toString();
+      if (c == 0)
         {
-        dump += "\t";
+        // Replace round brackets by square brackets.
+        // If the text is copied into Excel, Excel would recognize tag (0008,0012)
+        // as a negative number (-80,012). Instead, [0008,0012] is displayed fine.
+        name.replace('(', '[');
+        name.replace(')', ']');
+        dump += name;
         }
-      dump += name.toString();
+      else
+        {
+        dump += "\t" + name;
+        }
+      
       }
     dump += newLine;
     // here is your applicable code

--- a/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.h
@@ -44,6 +44,9 @@ public:
   QString currentFile();
   QStringList fileList();
 
+  /// Get metadata tree as plain text
+  QString metadataAsText();
+
 protected:
   QScopedPointer<ctkDICOMObjectListWidgetPrivate> d_ptr;
 
@@ -62,6 +65,7 @@ protected Q_SLOTS:
   void openLookupUrl(const QModelIndex&);
   void updateWidget();
   void copyPath();
+  void copyMetadata();
 };
 
 #endif


### PR DESCRIPTION
Added "Copy metadata" button (next to "Copy path" button) in the DICOM metadata browser (ctkDICOMObjectListWidget) to copy all metadata to the clipboard.
It is useful for collecting information from users when they reporting DICOM loading errors.

Also added tooltip for the existing, very useful, but hard-to-discover feature: if user clicks on a tag then its definition is displayed at http://dicomlookup.com.