### PR TITLE
ENH: Added filtering and multi-file export to DICOM metadata dialog

### DIFF
--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMObjectListWidget.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMObjectListWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>486</width>
-    <height>297</height>
+    <width>883</width>
+    <height>516</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -21,7 +21,7 @@
        <item>
         <widget class="QLabel" name="label">
          <property name="text">
-          <string>File Path:</string>
+          <string>File path:</string>
          </property>
         </widget>
        </item>
@@ -44,14 +44,7 @@
           <string>Copy the file full path to the clipboard.</string>
          </property>
          <property name="text">
-          <string>Copy Path</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="copyMetadataPushButton">
-         <property name="text">
-          <string>Copy Metadata</string>
+          <string>Copy path</string>
          </property>
         </widget>
        </item>
@@ -65,12 +58,56 @@
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_3"/>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <property name="topMargin">
+        <number>8</number>
+       </property>
+       <item>
+        <widget class="ctkSearchBox" name="metadataSearchBox"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="expandAllPushButton">
+         <property name="text">
+          <string>Expand all</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="collapseAllPushButton">
+         <property name="text">
+          <string>Collapse all</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="copyMetadataPushButton">
+         <property name="toolTip">
+          <string>Copy to clipboard metadata of this file</string>
+         </property>
+         <property name="text">
+          <string>Copy metadata</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="copyAllFilesMetadataPushButton">
+         <property name="toolTip">
+          <string>Copy to clipboard metadata of all files in the series</string>
+         </property>
+         <property name="text">
+          <string>Copy all files metadata</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2"/>
      </item>
      <item>
       <widget class="QTreeView" name="dcmObjectTreeView">
        <property name="toolTip">
-        <string>Double-click Tag to show its definition.</string>
+        <string>Double-click to show DICOM tag definition.</string>
        </property>
       </widget>
      </item>
@@ -79,6 +116,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>ctkSearchBox</class>
+   <extends>QLineEdit</extends>
+   <header>ctkSearchBox.h</header>
+  </customwidget>
   <customwidget>
    <class>ctkSliderWidget</class>
    <extends>QWidget</extends>

--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMObjectListWidget.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMObjectListWidget.ui
@@ -63,7 +63,11 @@
         <number>8</number>
        </property>
        <item>
-        <widget class="ctkSearchBox" name="metadataSearchBox"/>
+        <widget class="ctkSearchBox" name="metadataSearchBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Filter displayed metadata based on content in Tag, Attribute, and Value columns.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Simple search: &lt;/span&gt;enter any text to show only those items that contains the text. Use ? and * wildcards to represent &lt;span style=&quot; font-style:italic;&quot;&gt;any &lt;/span&gt;single character or sequence of characters.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Regular expression search (for advanced users):&lt;/span&gt; Enter &lt;span style=&quot; font-style:italic;&quot;&gt;regexp:&lt;/span&gt; followed by a regular expression. For example, show 3 specific tags, enter: &lt;span style=&quot; font-style:italic;&quot;&gt;regexp:0010,0010|0010,0020|0010,0030&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QPushButton" name="expandAllPushButton">

--- a/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.cpp
@@ -100,6 +100,7 @@ public:
   QStringList fileList;
   ctkDICOMObjectModel* dicomObjectModel;
   qRecursiveTreeProxyFilter* filterModel;
+  QString filterExpression;
 };
 
 //----------------------------------------------------------------------------
@@ -331,7 +332,7 @@ QString ctkDICOMObjectListWidget::metadataAsText(bool allFiles /*=false*/)
 
       qRecursiveTreeProxyFilter* afilterModel = new qRecursiveTreeProxyFilter();
       afilterModel->setSourceModel(aDicomObjectModel);
-      d->setFilterExpressionInModel(afilterModel, d->metadataSearchBox->text());
+      d->setFilterExpressionInModel(afilterModel, d->filterExpression);
 
       QString thisFileMetadata = d->dicomObjectModelAsString(afilterModel, QModelIndex(), 0, fileName + "\t");
 
@@ -399,5 +400,13 @@ void ctkDICOMObjectListWidget::onFilterChanged()
 void ctkDICOMObjectListWidget::setFilterExpression(const QString& expr)
 {
   Q_D(ctkDICOMObjectListWidget);
+  d->filterExpression = expr;
   d->setFilterExpressionInModel(d->filterModel, expr);
+}
+
+//------------------------------------------------------------------------------
+QString ctkDICOMObjectListWidget::filterExpression()
+{
+  Q_D(ctkDICOMObjectListWidget);
+  return d->filterExpression;
 }

--- a/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.cpp
@@ -26,6 +26,7 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QDesktopServices>
+#include <QSortFilterProxyModel>
 #include <QString>
 #include <QStringList>
 #include <QUrl>
@@ -35,6 +36,54 @@
 #include <ctkLogger.h>
 static ctkLogger logger("org.commontk.DICOM.Widgets.ctkDICOMObjectListWidget");
 
+class qRecursiveTreeProxyFilter : public QSortFilterProxyModel
+{
+public:
+  qRecursiveTreeProxyFilter(QObject *parent = NULL):
+    QSortFilterProxyModel(parent)
+  {
+  }
+
+  bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+  {
+    if (filterRegExp().isEmpty())
+      {
+      return true;
+      }
+    QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
+    return filterAcceptsIndex(index);
+  }
+
+private:
+  bool filterAcceptsIndex(const QModelIndex index) const
+  {
+    // Accept item if its tag, attribute, or value text matches
+    if ((sourceModel()->data(sourceModel()->index(index.row(), ctkDICOMObjectModel::TagColumn,
+      index.parent()), Qt::DisplayRole).toString().contains(filterRegExp()))
+      || (sourceModel()->data(sourceModel()->index(index.row(), ctkDICOMObjectModel::AttributeColumn,
+      index.parent()), Qt::DisplayRole).toString().contains(filterRegExp()))
+      || (sourceModel()->data(sourceModel()->index(index.row(), ctkDICOMObjectModel::ValueColumn,
+      index.parent()), Qt::DisplayRole).toString().contains(filterRegExp())))
+      {
+      return true;
+      }
+    // Accept item if any child matches
+    for (int row = 0; row < sourceModel()->rowCount(index); row++)
+      {
+      QModelIndex childIndex = sourceModel()->index(row, 0, index);
+      if (!childIndex.isValid())
+        {
+        break;
+        }
+      if (filterAcceptsIndex(childIndex))
+        {
+        return true;
+        }
+      }
+    return false;
+  }
+};
+
 //----------------------------------------------------------------------------
 class ctkDICOMObjectListWidgetPrivate: public Ui_ctkDICOMObjectListWidget
 {
@@ -43,11 +92,13 @@ public:
   ~ctkDICOMObjectListWidgetPrivate();
   void populateDICOMObjectTreeView(const QString& fileName);
   void setPathLabel(const QString& currentFile);
-  QString dicomObjectModelAsString(QModelIndex parent = QModelIndex(), int indent = 0);
+  QString dicomObjectModelAsString(QAbstractItemModel* dicomObjectModel, QModelIndex parent = QModelIndex(), int indent = 0, QString rowPrefix = QString());
 
+  QString endOfLine;
   QString currentFile;
   QStringList fileList;
   ctkDICOMObjectModel* dicomObjectModel;
+  qRecursiveTreeProxyFilter* filterModel;
 };
 
 //----------------------------------------------------------------------------
@@ -56,6 +107,13 @@ public:
 //----------------------------------------------------------------------------
 ctkDICOMObjectListWidgetPrivate::ctkDICOMObjectListWidgetPrivate()
 {
+#ifdef WIN32
+  this->endOfLine = "\r\n";
+#else
+  this->endOfLine = "\n";
+#endif
+  this->dicomObjectModel = 0;
+  this->filterModel = 0;
 }
 
 //----------------------------------------------------------------------------
@@ -67,7 +125,8 @@ ctkDICOMObjectListWidgetPrivate::~ctkDICOMObjectListWidgetPrivate()
 void ctkDICOMObjectListWidgetPrivate::populateDICOMObjectTreeView(const QString& fileName)
 {
   this->dicomObjectModel->setFile(fileName);
-  this->dcmObjectTreeView->setModel(this->dicomObjectModel);
+  this->filterModel->invalidate();
+  this->dcmObjectTreeView->setModel(this->filterModel);
   this->dcmObjectTreeView->expandAll();
 }
 
@@ -78,22 +137,16 @@ void ctkDICOMObjectListWidgetPrivate::setPathLabel(const QString& currentFile)
 }
 
 // --------------------------------------------------------------------------
-QString ctkDICOMObjectListWidgetPrivate::dicomObjectModelAsString(QModelIndex parent /*=QModelIndex()*/, int indent /*=0*/)
+QString ctkDICOMObjectListWidgetPrivate::dicomObjectModelAsString(QAbstractItemModel* aDicomObjectModel, QModelIndex parent /*=QModelIndex()*/, int indent /*=0*/, QString rowPrefix /*=QString()*/)
 {
   QString dump;
   QString indentString(indent, '\t'); // add tab characters, (indent) number of times
-#ifdef WIN32
-  QString newLine = "\r\n";
-#else
-  QString newLine = "\n";
-#endif
-  for (int r = 0; r < this->dicomObjectModel->rowCount(parent); ++r)
+  for (int r = 0; r < aDicomObjectModel->rowCount(parent); ++r)
     {
-    dump += indentString;
-    for (int c = 0; c < this->dicomObjectModel->columnCount(); ++c)
+    for (int c = 0; c < aDicomObjectModel->columnCount(); ++c)
       {
-      QModelIndex index = this->dicomObjectModel->index(r, c, parent);
-      QString name = this->dicomObjectModel->data(index).toString();
+      QModelIndex index = aDicomObjectModel->index(r, c, parent);
+      QString name = aDicomObjectModel->data(index).toString();
       if (c == 0)
         {
         // Replace round brackets by square brackets.
@@ -101,20 +154,19 @@ QString ctkDICOMObjectListWidgetPrivate::dicomObjectModelAsString(QModelIndex pa
         // as a negative number (-80,012). Instead, [0008,0012] is displayed fine.
         name.replace('(', '[');
         name.replace(')', ']');
-        dump += name;
+        dump += rowPrefix + indentString + name;
         }
       else
         {
         dump += "\t" + name;
         }
-      
       }
-    dump += newLine;
-    // here is your applicable code
-    QModelIndex index0 = this->dicomObjectModel->index(r, 0, parent);
-    if (this->dicomObjectModel->hasChildren(index0))
+    dump += endOfLine;
+    // Print children
+    QModelIndex index0 = aDicomObjectModel->index(r, 0, parent);
+    if (aDicomObjectModel->hasChildren(index0))
       {
-      dump += dicomObjectModelAsString(index0, indent+1);
+      dump += dicomObjectModelAsString(aDicomObjectModel, index0, indent + 1, rowPrefix);
       }
     }
   return dump;
@@ -124,22 +176,39 @@ QString ctkDICOMObjectListWidgetPrivate::dicomObjectModelAsString(QModelIndex pa
 // ctkDICOMObjectListWidget methods
 
 //----------------------------------------------------------------------------
-ctkDICOMObjectListWidget::ctkDICOMObjectListWidget(QWidget* _parent):Superclass(_parent), 
+ctkDICOMObjectListWidget::ctkDICOMObjectListWidget(QWidget* _parent):Superclass(_parent),
   d_ptr(new ctkDICOMObjectListWidgetPrivate)
 {
   Q_D(ctkDICOMObjectListWidget);
 
   d->setupUi(this);
-  d->dicomObjectModel = new ctkDICOMObjectModel(this);
 
+  d->metadataSearchBox->setAlwaysShowClearIcon(true);
+  d->metadataSearchBox->setShowSearchIcon(true);
+
+  d->dicomObjectModel = new ctkDICOMObjectModel(this);
+  d->filterModel = new qRecursiveTreeProxyFilter(this);
+  d->filterModel->setSourceModel(d->dicomObjectModel);
+  d->filterModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
+
+  d->fileSliderWidget->setMaximum(1);
+  d->fileSliderWidget->setMinimum(1);
   d->fileSliderWidget->setPageStep(1);
 
   d->currentPathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
   connect(d->fileSliderWidget, SIGNAL(valueChanged(double)), this, SLOT(updateWidget()));
-  connect(d->dcmObjectTreeView, SIGNAL(doubleClicked(const QModelIndex&))
-                               ,this, SLOT(openLookupUrl(const QModelIndex&)));
+  connect(d->dcmObjectTreeView, SIGNAL(doubleClicked(const QModelIndex&)),
+    this, SLOT(itemDoubleClicked(const QModelIndex&)));
   connect(d->copyPathPushButton , SIGNAL(clicked(bool)),this, SLOT(copyPath()));
+
+  connect(d->expandAllPushButton, SIGNAL(clicked(bool)), d->dcmObjectTreeView, SLOT(expandAll()));
+  connect(d->collapseAllPushButton, SIGNAL(clicked(bool)), d->dcmObjectTreeView, SLOT(collapseAll()));
   connect(d->copyMetadataPushButton, SIGNAL(clicked(bool)), this, SLOT(copyMetadata()));
+  connect(d->copyAllFilesMetadataPushButton, SIGNAL(clicked(bool)), this, SLOT(copyAllFilesMetadata()));
+
+  QObject::connect(d->metadataSearchBox, SIGNAL(textChanged(QString)),
+    d->filterModel, SLOT(setFilterWildcard(QString)));
+  QObject::connect(d->metadataSearchBox, SIGNAL(textChanged(QString)), this, SLOT(onFilterChanged()));
 }
 
 //----------------------------------------------------------------------------
@@ -147,6 +216,7 @@ ctkDICOMObjectListWidget::~ctkDICOMObjectListWidget()
 {
   Q_D(ctkDICOMObjectListWidget);
   d->dicomObjectModel->deleteLater();
+  d->filterModel->deleteLater();
 }
 
 //----------------------------------------------------------------------------
@@ -164,11 +234,25 @@ void ctkDICOMObjectListWidget::setFileList(const QStringList& fileList)
   if (d->fileList.size() > 0)
     {
     d->currentFile = d->fileList[0];
-    d->setPathLabel(d->currentFile );
-    d->populateDICOMObjectTreeView(d->currentFile );
-    d->fileSliderWidget->setMaximum(fileList.size()-1);
+    
+    d->populateDICOMObjectTreeView(d->currentFile);
+    d->fileSliderWidget->setMaximum(fileList.size());
+    d->fileSliderWidget->setSuffix(QString(" / %1").arg(fileList.size()));
+    for (int columnIndex = 0; columnIndex < d->dicomObjectModel->columnCount(); ++columnIndex)
+      {
+      d->dcmObjectTreeView->resizeColumnToContents(columnIndex);
+      }
     }
+  else
+    {
+    d->currentFile.clear();
+    d->dicomObjectModel->clear();
+    }
+
+  d->setPathLabel(d->currentFile);
+  d->fileSliderWidget->setVisible(d->fileList.size() > 1);
 }
+
 // --------------------------------------------------------------------------
 QString ctkDICOMObjectListWidget::currentFile()
 {
@@ -182,29 +266,34 @@ QStringList ctkDICOMObjectListWidget::fileList()
   Q_D(ctkDICOMObjectListWidget);
   return d->fileList;
 }
-// --------------------------------------------------------------------------
 
-void ctkDICOMObjectListWidget::openLookupUrl(const QModelIndex& index)
+// --------------------------------------------------------------------------
+void ctkDICOMObjectListWidget::openLookupUrl(QString tag)
 {
-  if (index.column() == 0)
-  {
-    QVariant  data = index.data();
-    QString lookupUrl = "http://dicomlookup.com/lookup.asp?sw=Tnumber&q="+data.toString();
-    QUrl url(lookupUrl);
-    QDesktopServices::openUrl(url);
-  }
+  QString lookupUrl = "http://dicomlookup.com/lookup.asp?sw=Tnumber&q=" + tag;
+  QUrl url(lookupUrl);
+  QDesktopServices::openUrl(url);
 }
-// --------------------------------------------------------------------------
 
+// --------------------------------------------------------------------------
+void ctkDICOMObjectListWidget::itemDoubleClicked(const QModelIndex& index)
+{
+  Q_D(ctkDICOMObjectListWidget);
+  QModelIndex tagIndex = d->filterModel->index(index.row(), 0, index.parent());
+  QString tag = d->filterModel->data(tagIndex).toString();
+  openLookupUrl(tag);
+}
+
+// --------------------------------------------------------------------------
 void ctkDICOMObjectListWidget::updateWidget()
 {
   Q_D(ctkDICOMObjectListWidget);
-  d->currentFile = d->fileList[static_cast<int>(d->fileSliderWidget->value())];
+  d->currentFile = d->fileList[static_cast<int>(d->fileSliderWidget->value())-1];
   d->setPathLabel(d->currentFile);
   d->populateDICOMObjectTreeView(d->currentFile);
  }
-// --------------------------------------------------------------------------
 
+// --------------------------------------------------------------------------
 void ctkDICOMObjectListWidget::copyPath()
 {
   Q_D(ctkDICOMObjectListWidget);
@@ -213,18 +302,82 @@ void ctkDICOMObjectListWidget::copyPath()
 }
 
 // --------------------------------------------------------------------------
-
-QString ctkDICOMObjectListWidget::metadataAsText()
+QString ctkDICOMObjectListWidget::metadataAsText(bool allFiles /*=false*/)
 {
   Q_D(ctkDICOMObjectListWidget);
-  return d->dicomObjectModelAsString();
+  QString metadata;
+  if (allFiles)
+    {
+    foreach(QString fileName, d->fileList)
+      {
+      // copy metadata of all files
+
+      ctkDICOMObjectModel* aDicomObjectModel = new ctkDICOMObjectModel();
+      aDicomObjectModel->setFile(fileName);
+
+      qRecursiveTreeProxyFilter* afilterModel = new qRecursiveTreeProxyFilter();
+      afilterModel->setSourceModel(aDicomObjectModel);
+      afilterModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
+      afilterModel->setFilterWildcard(d->metadataSearchBox->text());
+
+      QString thisFileMetadata = d->dicomObjectModelAsString(afilterModel, QModelIndex(), 0, fileName + "\t");
+
+      if (!thisFileMetadata.isEmpty())
+        {
+        metadata += thisFileMetadata;
+        }
+      else
+        {
+        metadata += fileName + "\t(none)" + d->endOfLine;
+        }
+
+      delete afilterModel;
+      delete aDicomObjectModel;
+      }
+    }
+  else
+    {
+    // single file
+    metadata = d->dicomObjectModelAsString(d->filterModel);
+    }
+  return metadata;
 }
 
 // --------------------------------------------------------------------------
-
 void ctkDICOMObjectListWidget::copyMetadata()
 {
   Q_D(ctkDICOMObjectListWidget);
   QClipboard *clipboard = QApplication::clipboard();
   clipboard->setText(metadataAsText());
+}
+
+// --------------------------------------------------------------------------
+void ctkDICOMObjectListWidget::copyAllFilesMetadata()
+{
+  Q_D(ctkDICOMObjectListWidget);
+  QApplication::setOverrideCursor(QCursor(Qt::BusyCursor));
+  QClipboard *clipboard = QApplication::clipboard();
+  clipboard->setText(metadataAsText(true));
+  QApplication::restoreOverrideCursor();
+}
+
+//------------------------------------------------------------------------------
+void ctkDICOMObjectListWidget::onFilterChanged()
+{
+  Q_D(ctkDICOMObjectListWidget);
+
+  // Change the searchbox background to yellow
+  // if there are no matches
+  bool showWarning = (d->filterModel->rowCount() == 0 &&
+    d->dicomObjectModel->rowCount() != 0);
+  QPalette palette;
+  if (showWarning)
+    {
+    palette.setColor(QPalette::Base, Qt::yellow);
+    }
+  else
+    {
+    palette.setColor(QPalette::Base, Qt::white);
+    }
+  d->metadataSearchBox->setPalette(palette);
 }

--- a/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.h
@@ -21,7 +21,7 @@
 #ifndef __ctkDICOMObjectListWidget_h
 #define __ctkDICOMObjectListWidget_h
 
-// Qt includes 
+// Qt includes
 #include <QItemSelection>
 #include <QWidget>
 
@@ -45,7 +45,10 @@ public:
   QStringList fileList();
 
   /// Get metadata tree as plain text
-  QString metadataAsText();
+  QString metadataAsText(bool allFiles = false);
+
+  /// Open DICOM tag definition in a web browser
+  void openLookupUrl(QString tag);
 
 protected:
   QScopedPointer<ctkDICOMObjectListWidgetPrivate> d_ptr;
@@ -62,10 +65,12 @@ public Q_SLOTS:
   void setFileList(const QStringList& fileList);
 
 protected Q_SLOTS:
-  void openLookupUrl(const QModelIndex&);
+  void itemDoubleClicked(const QModelIndex&);
+  void onFilterChanged();
   void updateWidget();
   void copyPath();
   void copyMetadata();
+  void copyAllFilesMetadata();
 };
 
 #endif

--- a/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.h
@@ -66,6 +66,7 @@ public Q_SLOTS:
 
 protected Q_SLOTS:
   void itemDoubleClicked(const QModelIndex&);
+  void setFilterExpression(const QString& expr);
   void onFilterChanged();
   void updateWidget();
   void copyPath();

--- a/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.h
@@ -35,6 +35,7 @@ class CTK_DICOM_WIDGETS_EXPORT ctkDICOMObjectListWidget : public QWidget
   Q_OBJECT
   Q_PROPERTY(QString currentFile READ currentFile WRITE setCurrentFile)
   Q_PROPERTY(QStringList fileList READ fileList WRITE setFileList)
+  Q_PROPERTY(QString filterExpression READ filterExpression WRITE setFilterExpression)
 
 public:
   typedef QWidget Superclass;
@@ -43,6 +44,13 @@ public:
 
   QString currentFile();
   QStringList fileList();
+
+  /// Filter displayed metadata based on content in Tag, Attribute, and Value columns.
+  /// Simple search : enter any text to show only those items that contains the text.
+  /// Use ? and * wildcards to represent any single character or sequence of characters.
+  /// Regular expression search: Enter regexp: followed by a regular expression.
+  /// For example, show 3 specific tags, enter : regexp : 0010, 0010 | 0010, 0020 | 0010, 0030
+  QString filterExpression();
 
   /// Get metadata tree as plain text
   QString metadataAsText(bool allFiles = false);
@@ -63,10 +71,10 @@ Q_SIGNALS:
 public Q_SLOTS:
   void setCurrentFile(const QString& newFileName);
   void setFileList(const QStringList& fileList);
+  void setFilterExpression(const QString& expr);
 
 protected Q_SLOTS:
   void itemDoubleClicked(const QModelIndex&);
-  void setFilterExpression(const QString& expr);
   void onFilterChanged();
   void updateWidget();
   void copyPath();

--- a/Libs/DICOM/Widgets/ctkDICOMObjectModel.h
+++ b/Libs/DICOM/Widgets/ctkDICOMObjectModel.h
@@ -43,12 +43,22 @@ class CTK_DICOM_WIDGETS_EXPORT ctkDICOMObjectModel
   Q_OBJECT
   typedef QStandardItemModel Superclass;
   //Q_PROPERTY(setFile);
+  Q_ENUMS(ColumnIndex)
 
 public:
 
   explicit ctkDICOMObjectModel(QObject* parent = 0);
   virtual ~ctkDICOMObjectModel();
   Q_INVOKABLE void setFile (const QString& fileName);
+
+  enum ColumnIndex
+    {
+    TagColumn = 0,
+    AttributeColumn = 1,
+    ValueColumn = 2,
+    VRColumn = 3,
+    LengthColumn = 4
+    };
 
 protected:
   QScopedPointer<ctkDICOMObjectModelPrivate> d_ptr;


### PR DESCRIPTION
To further improve ability to collect DICOM metadata information from users, the following features were added to the DICOM metadata window:
- free-text search in tag, name, vale fields
- export of filtered results (useful for easily excluding patient identifiable information)
- exporting of tags in all files in the files list (useful for example for getting image position information that requires all values), it works combined with filtering
- expand/collapse of all branches
- show total number of files and 1-based file index
- resize column widths to content by default

GUI:
![image](https://user-images.githubusercontent.com/307929/28486008-dc31f9f0-6e4b-11e7-930c-a51b3867a2a1.png)

Example copy filtered metadata from all files in the series:

<pre>
images/1-270.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 55.500000	DS	34
images/10-268.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 10.500000	DS	34
images/11-198.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 4.500000	DS	32
images/12-171.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 64.500000	DS	34
images/13-248.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 67.500000	DS	34
images/14-257.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -40.500000	DS	34
images/15-287.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 73.500000	DS	34
images/16-183.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 16.500000	DS	34
images/17-258.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -22.500000	DS	34
images/18-157.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 46.500000	DS	34
images/19-046.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -10.500000	DS	34
images/2-295.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 70.500000	DS	34
images/20-147.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 22.500000	DS	34
images/21-089.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -43.500000	DS	34
images/22-230.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -25.500000	DS	34
images/23-124.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -19.500000	DS	34
images/24-150.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -58.500000	DS	34
images/25-155.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -31.500000	DS	34
images/26-216.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 1.500000	DS	32
images/27-001.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 7.500000	DS	32
images/28-011.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 37.500000	DS	34
images/29-260.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -16.500000	DS	34
images/3-031.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -64.500000	DS	34
images/30-280.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 40.500000	DS	34
images/31-167.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -7.500000	DS	34
images/32-175.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -49.500000	DS	34
images/33-026.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -13.500000	DS	34
images/34-106.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -55.500000	DS	34
images/35-177.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 43.500000	DS	34
images/36-021.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 34.500000	DS	34
images/37-264.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 49.500000	DS	34
images/38-212.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -73.500000	DS	34
images/39-156.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -67.500000	DS	34
images/4-177.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -1.500000	DS	34
images/40-005.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -70.500000	DS	34
images/41-273.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 61.500000	DS	34
images/42-185.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 13.500000	DS	34
images/43-196.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -46.500000	DS	34
images/44-208.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 28.500000	DS	34
images/45-227.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 25.500000	DS	34
images/46-142.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -34.500000	DS	34
images/47-229.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -4.500000	DS	34
images/48-295.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -37.500000	DS	34
images/49-031.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 31.500000	DS	34
images/5-147.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -61.500000	DS	34
images/50-202.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 52.500000	DS	34
images/6-195.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -52.500000	DS	34
images/7-229.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, -28.500000	DS	34
images/8-136.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 19.500000	DS	34
images/9-213.dcm	[0020,0032]	ImagePositionPatient	[3] -225.000000, -225.000000, 58.500000	DS	34
</pre>

