### PR TITLE
BUG: Fixed Python console regressions

### DIFF
--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -828,7 +828,6 @@ void ctkConsolePrivate::internalExecuteCommand()
 
   QTextCursor c(this->document());
   c.movePosition(QTextCursor::End);
-  c.insertText("\n");
 
   this->InteractivePosition = this->documentEnd();
 
@@ -875,7 +874,6 @@ void ctkConsolePrivate::printString(const QString& text)
 {
   this->textCursor().movePosition(QTextCursor::End);
   this->textCursor().insertText(text);
-  this->InteractivePosition = this->documentEnd();
 }
 
 //----------------------------------------------------------------------------
@@ -970,7 +968,7 @@ void ctkConsolePrivate::insertCompletion(const QString& completion)
   // save the initial cursor position
   QTextCursor endOfCompletion = this->textCursor();
   endOfCompletion.setPosition(tc.position());
-  // Select the previous charactere
+  // Select the previous character
   tc.movePosition(QTextCursor::Left, QTextCursor::KeepAnchor);
   if (tc.selectedText()==".")
     {


### PR DESCRIPTION
1. Removed extra blank lines from Python console output. Fixes #731.

2. Fixed invalid command line when string is printed while editing command. For example, copy-paste the command below to the console (it prints a message after 3 and 6 seconds) then immediately enter "print" (without quotes, do not press Enter), wait for the message to appear, enter "123123123" (without quotes) to complete the command, and press Enter => now the command string is correct (before this fix it was corrupted).

def delayedprint():
  print "something printed 1"

qt.QTimer.singleShot(3000, delayedprint)