### PR TITLE
BUG: Fixed DICOM browser refresh issue when multiple browsers are created

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -31,6 +31,7 @@
 #include <QSqlQuery>
 #include <QSqlRecord>
 #include <QStringList>
+#include <QUuid>
 #include <QVariant>
 
 // ctkDICOM includes
@@ -293,7 +294,12 @@ void ctkDICOMDatabase::openDatabase(const QString databaseFile, const QString& c
 {
   Q_D(ctkDICOMDatabase);
   d->DatabaseFileName = databaseFile;
-  d->Database = QSqlDatabase::addDatabase("QSQLITE", connectionName);
+  QString verifiedConnectionName = connectionName;
+  if (verifiedConnectionName.isEmpty())
+    {
+    verifiedConnectionName = QUuid::createUuid().toString();
+    }
+  d->Database = QSqlDatabase::addDatabase("QSQLITE", verifiedConnectionName);
   d->Database.setDatabaseName(databaseFile);
   if ( ! (d->Database.open()) )
     {

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -101,10 +101,13 @@ public:
   ///        stored to. If specified with ":memory:", the database is not
   ///        written to disk at all but instead only kept in memory (and
   ///        thus expires after destruction of this object).
-  /// @param connectionName The database connection name.
+  /// @param connectionName The database connection name. If not specified
+  ///        then a random name is generated (reusing a connection name
+  ///        must be avoided as it breaks previously created database object
+  ///        that used the same connection name).
   /// @param update the schema if it is found to be out of date
   Q_INVOKABLE virtual void openDatabase(const QString databaseFile,
-                                        const QString& connectionName = "DICOM-DB");
+                                        const QString& connectionName = "");
 
   ///
   /// close the database. It must not be used afterwards.


### PR DESCRIPTION
Problem (reported in #744):

Studies/Series only gets updated upon patient selection for the latest created ctkDICOMBrowser. When selecting another patient in an earlier instance, neither Studies nor Series list gets updated.
The following code reproduces the problem:

  import ctk
  dicomBrowser = ctk.ctkDICOMBrowser()
  dicomBrowser.show()

  dicomBrowser1 = ctk.ctkDICOMBrowser()
  dicomBrowser1.show()

  dicomBrowser2 = ctk.ctkDICOMBrowser()
  dicomBrowser2.show()

Studies/series list only updates in dicomBrowser2, the two other instances are broken.

Solution:

Unless a connection name is specified, ctkDICOMDatabase always generates a unique connection name.