### PR TITLE
BUG: consistent return for value of uninitialized data

### DIFF
--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest7.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest7.cpp
@@ -51,10 +51,18 @@ int ctkDICOMDatabaseTest7( int argc, char * argv [] )
     }
   std::cerr << "Database is in " << databaseDirectory.path().toStdString() << std::endl;
 
-  // try to call fileValue with bogus data - should not trigger and exception
+  // try to call fileValue with bogus data: invalid filename and arbitrary tag
+  // - should not trigger and exception
   // (see https://github.com/commontk/CTK/issues/706)
+  // - result should be empty string
+  // (see https://github.com/commontk/CTK/issues/749)
 
-  database.fileValue("/tmp/file-that-does-not-exist", "00ff,eeee");
+  QString result = database.fileValue("/tmp/file-that-does-not-exist", "00ff,eeee");
+  if (result != "")
+    {
+    std::cerr << "ctkDICOMDatabase::fileValue() failed for file that doesn't exist." << std::endl;
+    return EXIT_FAILURE;
+    }
 
   //
   // Close and clean up

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -998,17 +998,14 @@ QString ctkDICOMDatabase::fileValue(const QString fileName, const unsigned short
 
   ctkDICOMItem dataset;
   dataset.InitializeFromFile(fileName);
-
-  if (dataset.IsInitialized())
+  if (!dataset.IsInitialized())
     {
-    DcmTagKey tagKey(group, element);
-    value = dataset.GetAllElementValuesAsString(tagKey);
-    }
-  else
-    {
-    value = TagNotInInstance;
+    logger.error( "File " + fileName + " could not be initialized.");
+    return "";
     }
 
+  DcmTagKey tagKey(group, element);
+  value = dataset.GetAllElementValuesAsString(tagKey);
   this->cacheTag(sopInstanceUID, tag, value);
   return value;
 }


### PR DESCRIPTION
When a dataset cannot be initialized, log an error
and return an empty string for consistency.

Also do not cache value (means that a future call may
succeed with correct value if data file becomes available)

Fixes #749