### PR TITLE
Update ctk vtk discretizable color transfer widget to support qvtk open gl widget

### DIFF
--- a/Libs/Core/ctkCompilerDetections_p.h
+++ b/Libs/Core/ctkCompilerDetections_p.h
@@ -1,0 +1,41 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+#ifndef __ctkCompilerDetections_p_h
+#define __ctkCompilerDetections_p_h
+
+//
+// This file is not part of the CTK API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+/*
+ * C++11 keywords and expressions
+ */
+#ifdef Q_NULLPTR
+# define CTK_NULLPTR Q_NULLPTR
+#else
+# define CTK_NULLPTR NULL
+#endif
+
+#endif

--- a/Libs/Visualization/VTK/Core/ctkVTKScalarsToColorsUtils.cpp
+++ b/Libs/Visualization/VTK/Core/ctkVTKScalarsToColorsUtils.cpp
@@ -18,6 +18,7 @@
 
 =========================================================================*/
 // CTK includes
+#include "ctkCompilerDetections_p.h" // For CTK_NULLPTR
 #include "ctkLogger.h"
 #include "ctkVTKScalarsToColorsUtils.h"
 
@@ -55,7 +56,7 @@ void ctk::remapColorScale(
   }
 
   /// Opacity
-  if (rescaledColorTransferFunction->GetScalarOpacityFunction() != nullptr)
+  if (rescaledColorTransferFunction->GetScalarOpacityFunction() != CTK_NULLPTR)
   {
     rescaledColorTransferFunction->GetScalarOpacityFunction()->
       RemoveAllPoints();
@@ -67,7 +68,7 @@ void ctk::remapColorScale(
     rescaledColorTransferFunction->SetScalarOpacityFunction(opacityFunction);
   }
 
-  if (colorTransferFunction->GetScalarOpacityFunction() == nullptr)
+  if (colorTransferFunction->GetScalarOpacityFunction() == CTK_NULLPTR)
   {
     rescaledColorTransferFunction->Build();
     return;
@@ -101,7 +102,7 @@ void ctk::remapColorScale(
 // ----------------------------------------------------------------------------
 void ctk::reverseColorMap(vtkDiscretizableColorTransferFunction* ctf)
 {
-  if (ctf == nullptr)
+  if (ctf == CTK_NULLPTR)
   {
     return;
   }
@@ -127,7 +128,7 @@ void ctk::reverseColorMap(vtkDiscretizableColorTransferFunction* ctf)
 void ctk::setTransparency(vtkDiscretizableColorTransferFunction* ctf,
   double transparency)
 {
-  if (ctf == nullptr)
+  if (ctf == CTK_NULLPTR)
   {
     return;
   }

--- a/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferChart.cpp
+++ b/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferChart.cpp
@@ -20,6 +20,7 @@
 #include "vtkDiscretizableColorTransferChart.h"
 
 #include "ctkVTKScalarsToColorsUtils.h"
+#include "ctkCompilerDetections_p.h" // For CTK_NULLPTR
 #include "vtkDiscretizableColorTransferControlPointsItem.h"
 
 #include <vtkAxis.h>
@@ -127,15 +128,15 @@ vtkDiscretizableColorTransferChart::vtkDiscretizableColorTransferChart()
     this->GetAxis(i)->SetTitle("");
   }
 
-  this->CompositeHiddenItem = nullptr;
-  this->ControlPoints = nullptr;
+  this->CompositeHiddenItem = CTK_NULLPTR;
+  this->ControlPoints = CTK_NULLPTR;
 }
 
 // ----------------------------------------------------------------------------
 void vtkDiscretizableColorTransferChart::SetColorTransferFunction(
   vtkDiscretizableColorTransferFunction* function)
 {
-  if (function == nullptr)
+  if (function == CTK_NULLPTR)
   {
     vtkSmartPointer<vtkDiscretizableColorTransferFunction> emptyCtf =
       vtkSmartPointer<vtkDiscretizableColorTransferFunction>::New();
@@ -241,7 +242,7 @@ void vtkDiscretizableColorTransferChart::UpdateMarkerPosition(
       this->CurrentRange[0] = newValue;
     }
     this->MinMarker->SetPosition(this->CurrentRange[0]);
-    if (this->ColorTransferFunction != nullptr)
+    if (this->ColorTransferFunction != CTK_NULLPTR)
     {
       this->ControlPoints->StartProcessing();
       ctk::remapColorScale(this->ColorTransferFunction, this->CurrentRange[0],
@@ -418,7 +419,7 @@ void vtkDiscretizableColorTransferChart::SetCurrentRange(
     this->MaxMarker->SetPosition(this->CurrentRange[1]);
   }
 
-  if (this->ColorTransferFunction != nullptr)
+  if (this->ColorTransferFunction != CTK_NULLPTR)
   {
     this->ControlPoints->StartProcessing();
     ctk::remapColorScale(this->ColorTransferFunction,

--- a/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferChart.cpp
+++ b/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferChart.cpp
@@ -230,7 +230,7 @@ void vtkDiscretizableColorTransferChart::UpdateMarkerPosition(
   this->Transform->InverseTransformPoints(m.GetScenePos().GetData(),
     pos.GetData(), 1);
 
-  if (rangeMoving == RangeMoving::MIN)
+  if (rangeMoving == RangeMoving_MIN)
   {
     double newValue = static_cast<double>(pos.GetX());
     if (newValue < this->OriginalRange[0])
@@ -250,7 +250,7 @@ void vtkDiscretizableColorTransferChart::UpdateMarkerPosition(
       this->ControlPoints->EndProcessing();
     }
   }
-  else if (rangeMoving == RangeMoving::MAX)
+  else if (rangeMoving == RangeMoving_MAX)
   {
     double newValue = static_cast<double>(pos.GetX());
     if (newValue > this->OriginalRange[1])
@@ -277,7 +277,7 @@ bool vtkDiscretizableColorTransferChart::MouseMoveEvent(
   const vtkContextMouseEvent &mouse)
 {
   if (mouse.GetButton() == vtkContextMouseEvent::LEFT_BUTTON &&
-    rangeMoving != RangeMoving::NONE)
+    rangeMoving != RangeMoving_NONE)
   {
     this->UpdateMarkerPosition(mouse);
   }
@@ -298,7 +298,7 @@ bool vtkDiscretizableColorTransferChart::MouseButtonPressEvent(
 {
   if (mouse.GetButton() == vtkContextMouseEvent::LEFT_BUTTON)
   {
-    if (rangeMoving == RangeMoving::NONE)
+    if (rangeMoving == RangeMoving_NONE)
     {
       this->CalculateUnscaledPlotTransform(
         this->CompositeHiddenItem->GetXAxis(),
@@ -318,12 +318,12 @@ bool vtkDiscretizableColorTransferChart::MouseButtonPressEvent(
       if (IsInRange(pixelMin[0] - catchWidth,
         pixelMin[0] + catchWidth, mouse.GetPos().GetX()))
       {
-        rangeMoving = RangeMoving::MIN;
+        rangeMoving = RangeMoving_MIN;
       }
       else if (IsInRange( pixelMax[0] - catchWidth, pixelMax[0] + catchWidth,
         mouse.GetPos().GetX()))
       {
-        rangeMoving = RangeMoving::MAX;
+        rangeMoving = RangeMoving_MAX;
       }
     }
   }
@@ -334,7 +334,7 @@ bool vtkDiscretizableColorTransferChart::MouseButtonPressEvent(
 bool vtkDiscretizableColorTransferChart::MouseButtonReleaseEvent(
   const vtkContextMouseEvent &mouse)
 {
-  rangeMoving = RangeMoving::NONE;
+  rangeMoving = RangeMoving_NONE;
   return this->Superclass::MouseButtonReleaseEvent(mouse);
 }
 

--- a/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferChart.h
+++ b/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferChart.h
@@ -91,9 +91,11 @@ protected:
   vtkSmartPointer<vtkHistogramMarker> MinMarker;
   vtkSmartPointer<vtkHistogramMarker> MaxMarker;
 
-  enum class RangeMoving {
-    NONE, MIN, MAX
-  } rangeMoving = RangeMoving::NONE;
+  enum RangeMoving {
+    RangeMoving_NONE, RangeMoving_MIN, RangeMoving_MAX
+  };
+  RangeMoving rangeMoving = RangeMoving_NONE;
+
   double DataRange[2];
   double CurrentRange[2];
   double OriginalRange[2];

--- a/Libs/Visualization/VTK/Core/vtkScalarsToColorsContextItem.cpp
+++ b/Libs/Visualization/VTK/Core/vtkScalarsToColorsContextItem.cpp
@@ -21,6 +21,7 @@
 
 // CTK includes
 #include "ctkVTKScalarsToColorsUtils.h"
+#include "ctkCompilerDetections_p.h" // For CTK_NULLPTR
 #include "vtkDiscretizableColorTransferChart.h"
 #include "vtkScalarsToColorsHistogramChart.h"
 #include "vtkScalarsToColorsPreviewChart.h"
@@ -90,7 +91,7 @@ vtkScalarsToColorsContextItem::vtkScalarsToColorsContextItem()
     vtkSmartPointer<vtkScalarsToColorsPreviewChart>::New();
   AddItem(this->PreviewChart.GetPointer());
 
-  this->SetColorTransferFunction(nullptr);
+  this->SetColorTransferFunction(CTK_NULLPTR);
 }
 
 // ----------------------------------------------------------------------------
@@ -105,9 +106,9 @@ vtkScalarsToColorsContextItem::~vtkScalarsToColorsContextItem()
 void vtkScalarsToColorsContextItem::SetColorTransferFunction(
   vtkScalarsToColors* ctf)
 {
-  if (ctf == nullptr)
+  if (ctf == CTK_NULLPTR)
   {
-    this->SetDiscretizableColorTransferFunction(nullptr);
+    this->SetDiscretizableColorTransferFunction(CTK_NULLPTR);
     return;
   }
 
@@ -143,7 +144,7 @@ void vtkScalarsToColorsContextItem::SetDiscretizableColorTransferFunction(
   vtkSmartPointer<vtkCompositeControlPointsItem> oldControlPoints =
     this->EditorChart->GetControlPointsItem();
 
-  if (oldControlPoints != nullptr)
+  if (oldControlPoints != CTK_NULLPTR)
   {
     oldControlPoints->RemoveObservers(vtkCommand::EndEvent);
     oldControlPoints->RemoveObservers(
@@ -167,7 +168,7 @@ void vtkScalarsToColorsContextItem::SetDiscretizableColorTransferFunction(
     this->PrivateEventForwarder, &EventForwarder::ForwardEvent);
 
   /// Set the preview chart range to the color transfer function range
-  if (this->ColorTransferFunction == nullptr)
+  if (this->ColorTransferFunction == CTK_NULLPTR)
   {
     this->PreviewChart->GetAxis(vtkAxis::BOTTOM)->SetRange(0, 0);
     return;

--- a/Libs/Visualization/VTK/Core/vtkScalarsToColorsPreviewChart.cpp
+++ b/Libs/Visualization/VTK/Core/vtkScalarsToColorsPreviewChart.cpp
@@ -20,6 +20,9 @@
 
 #include "vtkScalarsToColorsPreviewChart.h"
 
+#include "ctkCompilerDetections_p.h" // For CTK_NULLPTR
+
+// VTK includes
 #include <vtkAxis.h>
 #include <vtkColorTransferFunctionItem.h>
 #include <vtkColorTransferFunction.h>
@@ -69,7 +72,7 @@ void vtkScalarsToColorsPreviewChart::SetColorTransferFunction(
   compositeVisibleItem->SetInteractive(false);
   compositeVisibleItem->SetOpacity(1);
   compositeVisibleItem->SelectableOff();
-  if (function == nullptr)
+  if (function == CTK_NULLPTR)
   {
     vtkSmartPointer<vtkColorTransferFunction> ctf =
       vtkSmartPointer<vtkColorTransferFunction>::New();

--- a/Libs/Visualization/VTK/Widgets/Resources/UI/ctkVTKDiscretizableColorTransferWidget.ui
+++ b/Libs/Visualization/VTK/Widgets/Resources/UI/ctkVTKDiscretizableColorTransferWidget.ui
@@ -60,9 +60,11 @@
      </property>
     </widget>
    </item>
+   <!--
    <item row="3" column="2" rowspan="7">
     <widget class="QVTKWidget" name="scalarsToColorsView" native="true"/>
    </item>
+   -->
    <item row="3" column="3">
     <widget class="QToolButton" name="resetRangeButton">
      <property name="toolTip">
@@ -174,12 +176,14 @@
    <extends>QComboBox</extends>
    <header>ctkVTKScalarsToColorsComboBox.h</header>
   </customwidget>
+  <!--
   <customwidget>
    <class>QVTKWidget</class>
    <extends>QWidget</extends>
    <header>QVTKWidget.h</header>
    <container>1</container>
   </customwidget>
+  -->
  </customwidgets>
  <resources>
   <include location="../ctkVTKWidgets.qrc"/>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsComboBoxTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsComboBoxTest1.cpp
@@ -24,6 +24,7 @@
 #include <QTimer>
 
 // CTK includes
+#include "ctkCompilerDetections_p.h" // For CTK_NULLPTR
 #include "ctkVTKScalarsToColorsComboBox.h"
 
 // VTK includes
@@ -66,7 +67,7 @@ int ctkVTKScalarsToColorsComboBoxTest1(int argc, char * argv [] )
       "\tCurrent count: " << scalarsToColorsComboBox.count() << "\n";
     return EXIT_FAILURE;
   }
-  scalarsToColorsComboBox.addScalarsToColors(nullptr, "(none)");
+  scalarsToColorsComboBox.addScalarsToColors(CTK_NULLPTR, "(none)");
 
   scalarsToColorsComboBox.show();
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
@@ -22,6 +22,7 @@
 
 // CTK includes
 #include "ctkColorPickerButton.h"
+#include "ctkCompilerDetections_p.h" // For CTK_NULLPTR
 #include "ctkDoubleSlider.h"
 #include "ctkVTKScalarsToColorsComboBox.h"
 #include "ctkVTKScalarsToColorsUtils.h"
@@ -65,6 +66,8 @@
 #include <vtkRenderWindow.h>
 #include <vtkScalarsToColors.h>
 #include <vtkTable.h>
+
+
 
 // ----------------------------------------------------------------------------
 class ctkVTKDiscretizableColorTransferWidgetPrivate :
@@ -113,12 +116,12 @@ ctkVTKDiscretizableColorTransferWidgetPrivate
   ctkVTKDiscretizableColorTransferWidget& object)
   : q_ptr(&object)
 {
-  this->scalarsToColorsSelector = nullptr;
+  this->scalarsToColorsSelector = CTK_NULLPTR;
 
   // Option menu
-  this->nanButton = nullptr;
-  this->discretizeCheckBox = nullptr;
-  this->nbOfDiscreteValuesSpinBox = nullptr;
+  this->nanButton = CTK_NULLPTR;
+  this->discretizeCheckBox = CTK_NULLPTR;
+  this->nbOfDiscreteValuesSpinBox = CTK_NULLPTR;
 
   this->dataRange[0] = VTK_DOUBLE_MAX;
   this->dataRange[1] = VTK_DOUBLE_MIN;
@@ -162,7 +165,7 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
 
   this->previousOpacityValue = opacitySlider->value();
 
-  this->scalarsToColorsSelector->addScalarsToColors(nullptr, q->tr("Reset"));
+  this->scalarsToColorsSelector->addScalarsToColors(CTK_NULLPTR, q->tr("Reset"));
   this->scalarsToColorsSelector->setCurrentIndex(-1);
 
   this->eventLink = vtkSmartPointer<vtkEventQtSlotConnect>::New();
@@ -202,7 +205,7 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
   discretizeLayout->setContentsMargins(0, 0, 0, 0);
 
   optionButton->setIcon(q->style()->standardIcon(
-    QStyle::SP_FileDialogDetailedView, nullptr, optionButton));
+    QStyle::SP_FileDialogDetailedView, CTK_NULLPTR, optionButton));
 
   QLabel* nanLabel = new QLabel(q->tr("NaN values"));
   nanButton = new ctkColorPickerButton;
@@ -259,7 +262,7 @@ ctkVTKDiscretizableColorTransferWidgetPrivate::colorTransferFunctionModifiedCall
   vtkSmartPointer<vtkDiscretizableColorTransferFunction> dctf =
     self->scalarsToColorsContextItem->GetDiscretizableColorTransferFunction();
 
-  if (dctf == nullptr)
+  if (dctf == CTK_NULLPTR)
   {
     return;
   }
@@ -316,7 +319,7 @@ void ctkVTKDiscretizableColorTransferWidget::setColorTransferFunction(
 
   vtkScalarsToColors* oldCtf =
     d->scalarsToColorsContextItem->GetDiscretizableColorTransferFunction();
-  if (oldCtf != nullptr)
+  if (oldCtf != CTK_NULLPTR)
   {
     oldCtf->RemoveObserver(d->colorTransferFunctionModified);
   }
@@ -328,7 +331,7 @@ void ctkVTKDiscretizableColorTransferWidget::setColorTransferFunction(
   ctf = d->scalarsToColorsContextItem->GetColorTransferFunction();
   emit(currentScalarsToColorsChanged(ctf));
 
-  if (ctf == nullptr)
+  if (ctf == CTK_NULLPTR)
   {
     d->rangeSlider->setRange(0., 255.);
     d->rangeSlider->setValues(0., 1.);
@@ -423,7 +426,7 @@ void ctkVTKDiscretizableColorTransferWidget::onPaletteIndexChanged(
 {
   Q_D(ctkVTKDiscretizableColorTransferWidget);
 
-  if (ctf == nullptr)
+  if (ctf == CTK_NULLPTR)
   {
     this->setColorTransferFunction(ctf);
     return;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
@@ -45,7 +45,11 @@
 #include <QWidgetAction>
 
 // VTK includes
+#if CTK_USE_QVTKOPENGLWIDGET
+#include <QVTKOpenGLWidget.h>
+#else
 #include <QVTKWidget.h>
+#endif
 #include <vtkCallbackCommand.h>
 #include <vtkContextScene.h>
 #include <vtkContextView.h>
@@ -75,6 +79,12 @@ public:
     ctkVTKDiscretizableColorTransferWidget& object);
 
   void setupUi(QWidget* widget);
+
+#if CTK_USE_QVTKOPENGLWIDGET
+  QVTKOpenGLWidget* ScalarsToColorsView;
+#else
+  QVTKWidget* ScalarsToColorsView;
+#endif
 
   vtkSmartPointer<vtkScalarsToColorsContextItem> scalarsToColorsContextItem;
   vtkSmartPointer<vtkContextView> scalarsToColorsContextView;
@@ -130,6 +140,13 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
 
   this->Ui_ctkVTKDiscretizableColorTransferWidget::setupUi(widget);
 
+#if CTK_USE_QVTKOPENGLWIDGET
+  this->ScalarsToColorsView = new QVTKOpenGLWidget;
+#else
+  this->ScalarsToColorsView = new QVTKWidget;
+#endif
+  this->gridLayout->addWidget(this->ScalarsToColorsView, 3, 2, 7, 1);
+
   this->scalarsToColorsContextItem =
     vtkSmartPointer<vtkScalarsToColorsContextItem>::New();
   this->scalarsToColorsContextView = vtkSmartPointer<vtkContextView> ::New();
@@ -137,8 +154,8 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
   this->scalarsToColorsContextView->GetScene()->AddItem(
     this->scalarsToColorsContextItem.Get());
   this->scalarsToColorsContextView->SetInteractor(
-    this->scalarsToColorsView->GetInteractor());
-  this->scalarsToColorsView->SetRenderWindow(
+    this->ScalarsToColorsView->GetInteractor());
+  this->ScalarsToColorsView->SetRenderWindow(
     this->scalarsToColorsContextView->GetRenderWindow());
 
   q->setViewBackgroundColor(QColor(49, 54, 59));
@@ -273,7 +290,7 @@ ctkVTKDiscretizableColorTransferWidgetPrivate::colorTransferFunctionModifiedCall
   QColor selected = QColor::fromRgbF(r, g, b);
   self->nanButton->setColor(selected);
 
-  self->scalarsToColorsView->GetInteractor()->Render();
+  self->ScalarsToColorsView->GetInteractor()->Render();
 }
 
 // ----------------------------------------------------------------------------
@@ -397,7 +414,7 @@ void ctkVTKDiscretizableColorTransferWidget::setHistogram(
 
   d->scalarsToColorsContextItem->SetDataRange(d->dataRange[0], d->dataRange[1]);
 
-  d->scalarsToColorsView->GetInteractor()->Render();
+  d->ScalarsToColorsView->GetInteractor()->Render();
 }
 
 // ----------------------------------------------------------------------------

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.h
@@ -22,6 +22,7 @@
 #define __ctkVTKDiscretizableColorTransferWidget_h
 
 // CTK includes
+#include "ctkCompilerDetections_p.h" // For CTK_NULLPTR
 #include "ctkVisualizationVTKWidgetsExport.h"
 class ctkVTKDiscretizableColorTransferWidgetPrivate;
 class ctkVTKScalarsToColorsComboBox;
@@ -48,7 +49,7 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKDiscretizableColorTransferWidge
   /// \accessors viewBackgroundColor() setViewBackgroundColor()
   Q_PROPERTY(QColor viewBackgroundColor READ viewBackgroundColor WRITE setViewBackgroundColor)
 public:
-  explicit ctkVTKDiscretizableColorTransferWidget(QWidget* parent_ = nullptr);
+  explicit ctkVTKDiscretizableColorTransferWidget(QWidget* parent_ = CTK_NULLPTR);
   virtual ~ctkVTKDiscretizableColorTransferWidget();
 
   void setColorTransferFunction(vtkScalarsToColors* ctf);

--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsComboBox.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsComboBox.cpp
@@ -100,7 +100,7 @@ int ctkVTKScalarsToColorsComboBox::addScalarsToColors(
   }
   else
   {
-    img = QImage(this->iconSize(), QImage::Format::Format_ARGB32);
+    img = QImage(this->iconSize(), QImage::Format_ARGB32);
     img.fill(Qt::transparent);
   }
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsComboBox.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsComboBox.cpp
@@ -22,6 +22,7 @@
 #include <QPainter>
 
 // CTK includes
+#include "ctkCompilerDetections_p.h" // For CTK_NULLPTR
 #include "ctkVTKScalarsToColorsComboBox.h"
 #include "ctkVTKWidgetsUtils.h"
 
@@ -92,9 +93,9 @@ int ctkVTKScalarsToColorsComboBox::addScalarsToColors(
   vtkScalarsToColors* scFunction, const QString& name)
 {
   QImage img;
-  if (scFunction != nullptr)
+  if (scFunction != CTK_NULLPTR)
   {
-    scFunction->Register(nullptr);
+    scFunction->Register(CTK_NULLPTR);
     img = ctk::scalarsToColorsImage(scFunction, this->iconSize());
   }
   else
@@ -115,7 +116,7 @@ vtkScalarsToColors* ctkVTKScalarsToColorsComboBox::getScalarsToColors(
   QVariant data = itemData(index);
   if (!data.isValid())
   {
-    return nullptr;
+    return CTK_NULLPTR;
   }
 
   vtkScalarsToColors* ctf =
@@ -167,7 +168,7 @@ void ctkVTKScalarsToColorsComboBox::onRowsAboutToBeRemoved(
   {
     vtkScalarsToColors* scFunction = reinterpret_cast<vtkScalarsToColors*>(
       model()->data(model()->index(i, 0, parent)).value<void*>());
-    if (scFunction != nullptr)
+    if (scFunction != CTK_NULLPTR)
     {
       scFunction->Delete();
     }


### PR DESCRIPTION
This PR updates the transfer widget integrated in https://github.com/commontk/CTK/pull/755 so that it can be used with C++ < 11. Waiting we change the default build type in Slicer, we still need to support it. It is a matter of weeks. 