### PR TITLE
ENH: add Q_INVOKABLE to ctkRangeWidget::SetRange

### DIFF
--- a/Libs/Widgets/ctkRangeWidget.h
+++ b/Libs/Widgets/ctkRangeWidget.h
@@ -88,7 +88,7 @@ public:
   virtual void setMaximum(double maximum);
   /// Description
   /// Utility function that set the min/max in once
-  virtual void setRange(double min, double max);
+  Q_INVOKABLE virtual void setRange(double min, double max);
   virtual void range(double minimumAndMaximum[2])const;
 
   ///


### PR DESCRIPTION
@lassoan  @jcfr as discussed in https://github.com/Slicer/Slicer/pull/823, it will be nice to have the setRange method available in Python too (this avoid many crash when setting minimum and maximum which are greater/smaller than the current maximum/minimum of the widget).