### PR TITLE
COMP: Ensure main project is always re-configured

### DIFF
--- a/CMake/ctkExternalProjectAlwaysConfigure.cmake
+++ b/CMake/ctkExternalProjectAlwaysConfigure.cmake
@@ -1,0 +1,31 @@
+###########################################################################
+#
+#  Library:   CTK
+#
+#  Copyright (c) Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###########################################################################
+
+function(ExternalProject_AlwaysConfigure proj)
+  # This custom external project step forces the configure and later
+  # steps to run.
+  _ep_get_step_stampfile(${proj} "configure" stampfile)
+  ExternalProject_Add_Step(${proj} forceconfigure
+    COMMAND ${CMAKE_COMMAND} -E remove ${stampfile}
+    COMMENT "Forcing configure step for '${proj}'"
+    DEPENDEES build
+    ALWAYS 1
+    )
+endfunction()

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -57,25 +57,7 @@ ExternalProject_Add(${proj}
   INSTALL_COMMAND ""
   DEPENDS
     ${CTK_DEPENDENCIES}
-  STEP_TARGETS configure
   )
 
-# This custom external project step forces the build and later
-# steps to run whenever a top level build is done...
-#
-# BUILD_ALWAYS flag is available in CMake 3.1 that allows force build
-# of external projects without this workaround. Remove this workaround
-# and use the CMake flag instead, when CTK's required minimum CMake
-# version will be at least 3.1.
-#
-if(CMAKE_CONFIGURATION_TYPES)
-  set(BUILD_STAMP_FILE "${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${CMAKE_CFG_INTDIR}/${proj}-build")
-else()
-  set(BUILD_STAMP_FILE "${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${proj}-build")
-endif()
-ExternalProject_Add_Step(${proj} forcebuild
-  COMMAND ${CMAKE_COMMAND} -E remove ${BUILD_STAMP_FILE}
-  COMMENT "Forcing build step for '${proj}'"
-  DEPENDEES build
-  ALWAYS 1
-  )
+include(ctkExternalProjectAlwaysConfigure)
+ExternalProject_AlwaysConfigure(${proj})


### PR DESCRIPTION
This commit improves the code forcing a reconfiguration and
rebuild of the main project. This is an attempt to fix rebuild issues
discussed at https://github.com/Slicer/Slicer/pull/823#issuecomment-341566829

It also removes STEP_TARGETS obsoleted by f73c517 (Update dashboard
driver script to submit a regular project layout.)