### PR TITLE
BUG: fixing crash for spreadAllPoints in ctkVTKVolumePropertyWidget

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKVolumePropertyWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKVolumePropertyWidget.cpp
@@ -501,12 +501,18 @@ void ctkVTKVolumePropertyWidget::spreadAllPoints(double factor,
                                                  bool dontSpreadFirstAndLast)
 {
   Q_D(ctkVTKVolumePropertyWidget);
-  d->VolumeProperty->InvokeEvent(vtkCommand::StartEvent);
+  if (d->VolumeProperty)
+    {
+    d->VolumeProperty->InvokeEvent(vtkCommand::StartEvent);
+    }
   d->ScalarOpacityWidget->view()
     ->spreadAllPoints(factor, dontSpreadFirstAndLast);
   d->ScalarColorWidget->view()
     ->spreadAllPoints(factor, dontSpreadFirstAndLast);
   d->GradientWidget->view()
     ->spreadAllPoints(factor, dontSpreadFirstAndLast);
-  d->VolumeProperty->InvokeEvent(vtkCommand::EndEvent);
+  if (d->VolumeProperty)
+    {
+    d->VolumeProperty->InvokeEvent(vtkCommand::EndEvent);
+    }
 }


### PR DESCRIPTION
Hi @jcfr, may you kindly merge this?

This avoid crashes when the VolumeProperty is not set (analogous to the method moveAllPoints).  