### PR TITLE
ctkModelTester.cpp: long vs pointer have different size on MSYS2

### DIFF
--- a/Libs/Core/ctkModelTester.cpp
+++ b/Libs/Core/ctkModelTester.cpp
@@ -258,7 +258,7 @@ void ctkModelTester::testData(const QModelIndex& index)const
     {
     this->test(index.data(Qt::DisplayRole).isValid(), 
                QString("A valid index can't have invalid data: %1, %2, %3")
-               .arg(index.row()).arg(index.column()).arg(long(index.internalPointer())));
+               .arg(index.row()).arg(index.column()).arg(ptrdiff_t(index.internalPointer())));
     }
 }
 


### PR DESCRIPTION
Windows uses default long size of 32bit on 64bit systems, so casting a pointer to long fails with pedantic build options. This currently breaks MSYS2 build (MinGW based) but should likely cause problems on MSVC too.