### PR TITLE
ENH: ctkVTKAbstractView: Update setUseDepthPeeling to also enable depth peel for volumes

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
@@ -483,6 +483,9 @@ void ctkVTKAbstractView::setUseDepthPeeling(bool useDepthPeeling)
     }
   this->renderWindow()->SetMultiSamples(useDepthPeeling ? 0 : nSamples);
   renderer->SetUseDepthPeeling(useDepthPeeling ? 1 : 0);
+#if CTK_USE_QVTKOPENGLWIDGET
+  renderer->SetUseDepthPeelingForVolumes(useDepthPeeling);
+#endif
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This commit updates the method so that it also enables depth peeling for
volumes along with the translucent geometry. Only supported on OpenGL2
with dual-depth peeling.

Suggested-by: Ken Martin <ken.martin@kitware.com>