### PR TITLE
BUG: Re-add range reset on bounds change if range is invalid

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsView.cpp
@@ -139,6 +139,16 @@ void ctkVTKScalarsToColorsView::addPlot(vtkPlot* plot)
 void ctkVTKScalarsToColorsView::onBoundsChanged()
 {
   this->boundAxesToChartBounds();
+
+  // Set range to bounds only if range is invalid. Otherwise keep it as is, because
+  // the user wants to keep the range they set after a transfer function is shifted
+  double extent[8];
+  this->chartExtent(extent);
+  if (extent[0] >= extent[1])
+    {
+    this->setAxesToChartBounds();
+    }
+
   this->Superclass::onChartUpdated();
 }
 


### PR DESCRIPTION
The setAxesToChartBounds call has recently been removed so that the chart extent is not reset when the transfer function bounds change. This prevented resetting the extent defined by the user when shifting the transfer function. However, if there was no valid extent defined, without this call the chart was not shown at all. By resetting the extent only if it was invalid solves both issues.