### PR TITLE
ENH: Update ExternalProjectDependency system based on commontk/Artichoke@9c98004

### DIFF
--- a/CMake/ctkMacroCheckExternalProjectDependency.cmake
+++ b/CMake/ctkMacroCheckExternalProjectDependency.cmake
@@ -271,9 +271,15 @@ function(_sb_cmakevar_to_cmakearg cmake_varname_and_type cmake_arg_var has_cfg_i
   _sb_extract_varname_and_vartype(${cmake_varname_and_type} _varname _vartype)
 
   set(_var_value "${${_varname}}")
-  get_property(_value_set_in_cache CACHE ${_varname} PROPERTY VALUE SET)
-  if(_value_set_in_cache)
-    get_property(_var_value CACHE ${_varname} PROPERTY VALUE)
+
+  # Use cache value unless it is INTERNAL
+  if(_vartype STREQUAL "INTERNAL")
+    set(_vartype "STRING")
+  else()
+    get_property(_value_set_in_cache CACHE ${_varname} PROPERTY VALUE SET)
+    if(_value_set_in_cache)
+      get_property(_var_value CACHE ${_varname} PROPERTY VALUE)
+    endif()
   endif()
 
   set(_has_cfg_intdir FALSE)
@@ -437,6 +443,9 @@ function(_sb_get_external_project_arguments proj varname)
   # Automatically propagate CMake options
   foreach(_cmake_option IN ITEMS
     CMAKE_EXPORT_COMPILE_COMMANDS
+    CMAKE_JOB_POOL_COMPILE
+    CMAKE_JOB_POOL_LINK
+    CMAKE_JOB_POOLS
     )
     if(DEFINED ${_cmake_option})
       list(APPEND _ep_arguments CMAKE_CACHE_ARGS


### PR DESCRIPTION
List of changes:

```
$ git shortlog 75af1d0..9c98004 --no-merges
Jean-Christophe Fillion-Robin (3):
      ExternalProjectDependency: Ignore CACHE value of type INTERNAL
      circleci: Use dockbuild/centos6 instead of unmaintained centosbuild/centos6
      ExternalProjectDependency: If set, propagate CMAKE_JOB_* variables
```