### PR TITLE
BUG: Fix python wrapping for classes with only default constructor

### DIFF
--- a/CMake/ctkWrapPythonQt.py
+++ b/CMake/ctkWrapPythonQt.py
@@ -88,7 +88,7 @@ def ctk_wrap_pythonqt(target, namespace, output_dir, input_files, extra_verbose)
             #    my_class(QObject* newParent ...)
             #    my_class(QWidget* newParent ...)
             # Constructor with either QWidget or QObject as first parameter
-            regex = r"[^~]%s[\s\n]*\([\s\n]*((QObject|QWidget)[\s\n]*\*[\s\n]*\w+[\s\n]*(\=[\s\n]*(0|NULL)|,.*\=.*\)|\)|\)))" % className
+            regex = r"[^~]%s[\s\n]*\([\s\n]*((QObject|QWidget)[\s\n]*\*[\s\n]*\w+[\s\n]*(\=[\s\n]*(0|NULL))?([\s\n]*,[\s\n]*.*\=.*)*)?[\s\n]*\)" % className
             res = re.search(regex, content, re.MULTILINE)
             if res is None:
                 if extra_verbose:

--- a/Libs/Widgets/ctkCheckableHeaderView.cpp
+++ b/Libs/Widgets/ctkCheckableHeaderView.cpp
@@ -117,6 +117,16 @@ void ctkCheckableHeaderViewPrivate::init()
 }
 
 //----------------------------------------------------------------------------
+ctkCheckableHeaderView::ctkCheckableHeaderView()
+	: QHeaderView(Qt::Horizontal, NULL)
+	, d_ptr(new ctkCheckableHeaderViewPrivate(*this))
+{
+	Q_D(ctkCheckableHeaderView);
+	d->init();
+}
+
+
+//----------------------------------------------------------------------------
 ctkCheckableHeaderView::ctkCheckableHeaderView(
   Qt::Orientation orient, QWidget *widgetParent)
   : QHeaderView(orient, widgetParent)

--- a/Libs/Widgets/ctkCheckableHeaderView.h
+++ b/Libs/Widgets/ctkCheckableHeaderView.h
@@ -75,6 +75,7 @@ class CTK_WIDGETS_EXPORT ctkCheckableHeaderView : public QHeaderView
 {
   Q_OBJECT;
 public:
+  ctkCheckableHeaderView();
   ctkCheckableHeaderView(Qt::Orientation orient, QWidget *parent=0);
   virtual ~ctkCheckableHeaderView();
 
@@ -103,21 +104,23 @@ public:
   /// Utility function that returns the checkState of the section. 
   /// One can access the same value through the model:
   /// model->headerData(orientation, section, Qt::CheckStateRole)
-  Qt::CheckState checkState(int section)const;
+  Q_INVOKABLE Qt::CheckState checkState(int section)const;
 
   ///
   /// Utility function that returns the checkState of the section. 
   /// One can access the same value through the model:
   /// model->headerData(orientation, section, Qt::CheckStateRole)
-  bool checkState(int section,Qt::CheckState& checkState )const;
+  Q_INVOKABLE bool checkState(int section, Qt::CheckState& checkState)const;
   
-  ctkCheckableModelHelper* checkableModelHelper()const;
+  /// Returns a pointer to the checkable model helper to give a direct access
+  /// to the check manager.
+  Q_INVOKABLE ctkCheckableModelHelper* checkableModelHelper()const;
 
 public Q_SLOTS:
   ///
   /// Warning, setting the check state automatically set the 
   /// header section checkable
-  void setCheckState(int section, Qt::CheckState checkState);
+  Q_INVOKABLE void setCheckState(int section, Qt::CheckState checkState);
 
 private Q_SLOTS:
   void onHeaderDataChanged(Qt::Orientation orient, int first, int last);


### PR DESCRIPTION
This PR includes the following:
- Fixes regular expression in `ctkWrapPythonQt.py` which parses the class constructors to populate the classes to be passed to PythonQT for wrapping. It was skipping the classes which only had default constructors (i.e. no constructors of the type `className(QObject* ...)`. Also, the closing parenthesis was not identified. @jcfr: you might want to check the RE! I have compared the build outputs (by switching on verbose in the `ctkMacroWrapPythonQt.cmake`), and the following classes are added to Python wrapping now: `ctkErrorLogLevel`, `ctkErrorLogQtMessageHandler`, `ctkErrorLogTerminalOutput`, and `ctkEventTranslatorPlayerWidget`. `ctkErrorLogAbstractMessageHandler` is skipped because it has a pure virtual method, and not because the constructor type is wrong.  The other classes are unaffected. 

- Adds a default constructor to `ctkCheckableHeaderView` class so that it will be included for Python wrapping. This is actually a hack. Some methods of the class are enabled for Python wrapping as well. 
