### PR TITLE
BUG: Allow DICOM import from hidden folders

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMIndexer.cpp
+++ b/Libs/DICOM/Core/ctkDICOMIndexer.cpp
@@ -103,7 +103,8 @@ void ctkDICOMIndexer::addFile(ctkDICOMDatabase& database,
 //------------------------------------------------------------------------------
 void ctkDICOMIndexer::addDirectory(ctkDICOMDatabase& ctkDICOMDatabase,
                                    const QString& directoryName,
-                                   const QString& destinationDirectoryName)
+                                   const QString& destinationDirectoryName,
+                                   bool includeHidden/*=true*/)
 {
   QStringList listOfFiles;
   QDir directory(directoryName);
@@ -114,7 +115,12 @@ void ctkDICOMIndexer::addDirectory(ctkDICOMDatabase& ctkDICOMDatabase,
   }
   else
   {
-    QDirIterator it(directoryName,QDir::Files,QDirIterator::Subdirectories);
+    QDir::Filters filters = QDir::Files;
+    if (includeHidden)
+    {
+      filters |= QDir::Hidden;
+    }
+    QDirIterator it(directoryName, filters, QDirIterator::Subdirectories);
     while(it.hasNext())
     {
       listOfFiles << it.next();

--- a/Libs/DICOM/Core/ctkDICOMIndexer.h
+++ b/Libs/DICOM/Core/ctkDICOMIndexer.h
@@ -48,8 +48,12 @@ public:
   /// Scan the directory using Dcmtk and populate the database with all the
   /// DICOM images accordingly.
   ///
+  /// If includeHidden is set to false then hidden files and folders are not added.
+  /// DICOM folders may be created based on series or study name, which sometimes start
+  /// with a . character, therefore it is advisable to include hidden files and folders.
+  ///
   Q_INVOKABLE void addDirectory(ctkDICOMDatabase& database, const QString& directoryName,
-                    const QString& destinationDirectoryName = "");
+                    const QString& destinationDirectoryName = "", bool includeHidden = true);
 
   ///
   /// \brief Adds directory to database by using DICOMDIR and optionally copies files to


### PR DESCRIPTION
Import of a DICOM study partially failed because some of the folder names (that were generated from DICOM series description) started with . character. On Mac and Linux system, these folders were considered as hidden folders and were skipped from DICOM import because the DICOM indexer by default ignored hidden folders.

The problem is fixed by adding includeHidden argument (enabled by default) to ctkDICOMIndexer::addDirectory.