### PR TITLE
BUG: Fixed duplicate "Search" placeholder text in ctkSearchBox

### DIFF
--- a/Libs/Widgets/ctkSearchBox.cpp
+++ b/Libs/Widgets/ctkSearchBox.cpp
@@ -226,15 +226,11 @@ void ctkSearchBox::paintEvent(QPaintEvent * event)
   QRect cRect = d->clearRect();
   QRect sRect = d->showSearchIcon ? d->searchRect() : QRect();
 
-#if QT_VERSION >= 0x040700
+#if QT_VERSION < 0x040700
   QRect r = rect();
   QPalette pal = palette();
 
-#if QT_VERSION < QT_VERSION_CHECK(5,0,0)
   QStyleOptionFrameV2 panel;
-#else
-  QStyleOptionFrame panel;
-#endif
   initStyleOption(&panel);
   r = this->style()->subElementRect(QStyle::SE_LineEditContents, &panel, this);
   r.setX(r.x() + this->textMargins().left());


### PR DESCRIPTION
CTK rendered placeholderText even when built with Qt versions >= 4.7, while in these Qt versions Qt rendered placeholder text already.
On hi-DPI screens with Qt5, Qt rendered placeholderText in a slightly shifted position, which made duplicate rendering of the placeholderText by CTK and Qt very visible.

Fixed it by correcting the Qt version check (CTK paints placeholderText only when Qt version < 4.7.

Ghosting of placeholderText before the fix:
![image](https://user-images.githubusercontent.com/307929/39504144-ad7478f0-4d97-11e8-8781-433b08736e64.png)

