### PR TITLE
BUG: Fixed maximum update rate computation in ctkVTKAbstractView

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
@@ -67,6 +67,7 @@ public:
   QTimer*                                       RequestTimer;
   QTime                                         RequestTime;
   bool                                          RenderEnabled;
+  double                                        MaximumUpdateRate;
   bool                                          FPSVisible;
   QTimer*                                       FPSTimer;
   int                                           FPS;


### PR DESCRIPTION
Render window's DesiredUpdateRate property was used to determine maximum update rate of ctkVTKAbstractView. This had two issues:

1. VTK often significantly overestimates rendering time and so DesiredUpdateRate have to be set to quite low value (few fps) to get acceptable quality rendering. However, if ctkVTKAbstractView uses this value as maximum update rate, it would severely limit the achievable actual refresh rate. Separating the two values allow controlling quality settings and event compression separately.

2. When DesiredUpdateRate was set to "still update rate" (0.0001 fps; this is the default value) then rendering was never enforced. This caused indefinitely delayed rendering updates on MacOSX, when events were continuously generated on the GUI (e.g., by moving image slice selector slider continuously, see https://issues.slicer.org/view.php?id=4496). DesiredUpdateRate is set to 60.0 by default now, which results in smooth updates, while still effectively suppressing rendering request submitted in quick succession.