### PR TITLE
BUG: Fixed crash during exit caused by ctkMessageBox::confirmExit

### DIFF
--- a/Libs/Widgets/ctkMessageBox.cpp
+++ b/Libs/Widgets/ctkMessageBox.cpp
@@ -302,10 +302,15 @@ void ctkMessageBox::setVisible(bool visible)
 bool ctkMessageBox
 ::confirmExit(const QString& dontShowAgainKey, QWidget* parentWidget)
 {
-  ctkMessageBox dialog(parentWidget);
-  dialog.setText(tr("Are you sure you want to exit?"));
-  dialog.setIcon(QMessageBox::Question);
-  dialog.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
-  dialog.setDontShowAgainSettingsKey(dontShowAgainKey);
-  return dialog.exec() == QMessageBox::Ok;
+  ctkMessageBox* dialog = new ctkMessageBox(parentWidget);
+
+  // this will take care of destroying the window
+  // regardless the parent widget is null or non-null.
+  dialog->setAttribute(Qt::WA_DeleteOnClose);
+
+  dialog->setText(tr("Are you sure you want to exit?"));
+  dialog->setIcon(QMessageBox::Question);
+  dialog->setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+  dialog->setDontShowAgainSettingsKey(dontShowAgainKey);
+  return dialog->exec() == QMessageBox::Ok;
 }


### PR DESCRIPTION
The messagebox was deleted twice (first because it was created on the stack, second time when the parent window was destroyed). This caused crash on exit.

Fixed by not creating the messagebox object on the stack and deleting by setting WA_DeleteOnClose flag.