### PR TITLE
COMP: Fix missing ctkCompilerDetections_p.h when building configadmin tests

### DIFF
--- a/Plugins/org.commontk.configadmin/Testing/Cpp/CMakeLists.txt
+++ b/Plugins/org.commontk.configadmin/Testing/Cpp/CMakeLists.txt
@@ -10,7 +10,7 @@ set(MY_MOC_CXX )
 
 set(test_executable ${PROJECT_NAME}CppTests)
 
-set(${test_executable}_DEPENDENCIES ${fw_lib} ${fwtestutil_lib})
+set(${test_executable}_DEPENDENCIES ${fw_lib} ${fwtestutil_lib} CTKCore)
 
 set(my_includes)
 ctkFunctionGetIncludeDirs(my_includes ${test_executable})


### PR DESCRIPTION
This commit fixes the error reported below when building CTK
with:
  -DQt5_DIR:PATH=/path/to/Qt5 -DCTK_QT_VERSION:STRING=5 -DCTK_PLUGIN_org.commontk.configadmin:BOOL=1

```
In file included from /home/jcfr/Projects/CTK/Libs/PluginFramework/ctkPluginConstants.h:27:0,
                 from /home/jcfr/Projects/CTK/Plugins/org.commontk.configadmin/Testing/Cpp/ctkConfigAdminImplTestMain.cpp:26:
/home/jcfr/Projects/CTK-build/CTK-build/Libs/PluginFramework/ctkPluginFrameworkExport.h:11:37: fatal error: ctkCompilerDetections_p.h: No such file or directory
compilation terminated.

```

Fixes #802