### PR TITLE
BUG: Fix incorrect changed settings indicator

### DIFF
--- a/Libs/Widgets/ctkSettingsPanel.cpp
+++ b/Libs/Widgets/ctkSettingsPanel.cpp
@@ -418,6 +418,7 @@ void ctkSettingsPanel::applySettings()
     {
     PropertyType& prop = d->Properties[key];
     prop.setPreviousValue(prop.value());
+    emit settingChanged(key, prop.value());
     }
 }
 


### PR DESCRIPTION
This closes #799.

When settings are applied by pressing the "OK" button in the Settings Dialog, the changed settings indicator should be updated so that upon reopening the Settings Dialog there should be no changed settings indicators visible.  Currently, the indicator isn't updated after applying settings, so on showing the settings dialog again you have to toggle the setting to reset the indicator.

I've added a fix that emits the settingChanged signal when settings are applied so that it will then call the `updatePanelTitle` function for updating the changed settings indicator.

## BUG:
![ctk_bug](https://user-images.githubusercontent.com/15837524/42301787-39d89e0a-7fe5-11e8-848a-a3682fce402b.gif)

## FIX:
![ctk_fix](https://user-images.githubusercontent.com/15837524/42301790-405fc1b8-7fe5-11e8-8560-0798a27a504c.gif)
