### PR TITLE
COMP: Missing header

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
@@ -64,6 +64,7 @@
 #include <vtkImageData.h>
 #include <vtkPiecewiseFunction.h>
 #include <vtkRenderer.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkScalarsToColors.h>
 #include <vtkTable.h>
 


### PR DESCRIPTION
Solves error:
(gcc 8.1)

```
/Software/Slicer/build-relwithdebinfo/CTK/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp:378:45: error: invalid use of incomplete type ‘class vtkRenderWindowInteractor’
   self->ScalarsToColorsView->GetInteractor()->Render();
                                             ^~
In file included from /Software/Slicer/build-relwithdebinfo/CTK/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp:50:
/home/phc/Software/Slicer/build-relwithdebinfo/VTKv9/GUISupport/Qt/QVTKOpenGLWidget.h:31:7: note: forward declaration of ‘class vtkRenderWindowInteractor’
 class vtkRenderWindowInteractor;
Software/Slicer/build-relwithdebinfo/CTK/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp: In member function ‘void ctkVTKDiscretizableColorTransferWidget::onPaletteIndexChanged(vtkScalarsToColors*)’:
/Software/Slicer/build-relwithdebinfo/CTK/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp:756:42: error: invalid use of incomplete type ‘class vtkRenderWindowInteractor’
   d->ScalarsToColorsView->GetInteractor()->Render();
                                          ^~
In file included from /Software/Slicer/build-relwithdebinfo/CTK/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp:50:
/Software/Slicer/build-relwithdebinfo/VTKv9/GUISupport/Qt/QVTKOpenGLWidget.h:31:7: note: forward declaration of ‘class vtkRenderWindowInteractor’
 class vtkRenderWindowInteractor;

```