### PR TITLE
Fix issue #814

### DIFF
--- a/Libs/PluginFramework/ctkPluginStorageSQL.cpp
+++ b/Libs/PluginFramework/ctkPluginStorageSQL.cpp
@@ -53,7 +53,6 @@ enum TBindIndexes
 //----------------------------------------------------------------------------
 ctkPluginStorageSQL::ctkPluginStorageSQL(ctkPluginFrameworkContext *framework)
   : m_isDatabaseOpen(false)
-  , m_inTransaction(false)
   , m_framework(framework)
   , m_nextFreeId(-1)
 {

--- a/Libs/PluginFramework/ctkPluginStorageSQL.cpp
+++ b/Libs/PluginFramework/ctkPluginStorageSQL.cpp
@@ -57,7 +57,7 @@ ctkPluginStorageSQL::ctkPluginStorageSQL(ctkPluginFrameworkContext *framework)
   , m_nextFreeId(-1)
 {
   // See if we have a storage database
-  m_databasePath = ctkPluginFrameworkUtil::getFileStorage(framework, "").absoluteFilePath("plugins.db");
+  setDatabasePath(ctkPluginFrameworkUtil::getFileStorage(framework, "").absoluteFilePath("plugins.db"));
 
   this->open();
   restorePluginArchives();

--- a/Libs/PluginFramework/ctkPluginStorageSQL.cpp
+++ b/Libs/PluginFramework/ctkPluginStorageSQL.cpp
@@ -114,25 +114,26 @@ QString ctkPluginStorageSQL::getConnectionName() const
 }
 
 //----------------------------------------------------------------------------
-void ctkPluginStorageSQL::open()
+void ctkPluginStorageSQL::createDatabaseDirectory() const
 {
-  QString path;
+  QString path = getDatabasePath();
 
-  //Create full path to database
-  if(m_databasePath.isEmpty ())
-    m_databasePath = getDatabasePath();
-
-  path = m_databasePath;
-  QFileInfo dbFileInfo(path);
-  if (!dbFileInfo.dir().exists())
+  QFileInfo fileInfo(path);
+  if (!fileInfo.dir().exists())
   {
-    if(!QDir::root().mkpath(dbFileInfo.path()))
+    if (!QDir::root().mkpath(fileInfo.path()))
     {
       close();
-      QString errorText("Could not create database directory: %1");
-      throw ctkPluginDatabaseException(errorText.arg(dbFileInfo.path()), ctkPluginDatabaseException::DB_CREATE_DIR_ERROR);
+      throw ctkPluginDatabaseException(QString("Could not create database directory: %1").arg(fileInfo.path()),
+                                    ctkPluginDatabaseException::DB_CREATE_DIR_ERROR);
     }
   }
+}
+
+//----------------------------------------------------------------------------
+void ctkPluginStorageSQL::open()
+{
+  createDatabaseDirectory();
 
   QSqlDatabase database = getConnection();
 

--- a/Libs/PluginFramework/ctkPluginStorageSQL_p.h
+++ b/Libs/PluginFramework/ctkPluginStorageSQL_p.h
@@ -31,6 +31,7 @@
 #include <QSqlError>
 #include <QPluginLoader>
 #include <QDirIterator>
+#include <QThreadStorage>
 
 // CTK class forward declarations
 class ctkPluginFrameworkContext;
@@ -117,7 +118,8 @@ public:
    *
    * @throws ctkPluginDatabaseException
    */
-  void close();
+  void close(); // Satisfy abstract interface
+  void close() const;
 
   // -------------------------------------------------------------
   // end ctkPluginStorage interface
@@ -263,11 +265,20 @@ private:
   bool checkTables() const;
 
   /**
-   * Checks the database connection.
+   * Creates or returns an existing, thread-local database connection.
    *
+   * @param open Create and open connection.
+   * @return Database connection.
    * @throws ctkPluginDatabaseException
    */
-  void checkConnection() const;
+  QSqlDatabase getConnection(bool create = true) const;
+
+  /**
+   * Creates a thread-unique database connection name.
+   *
+   * @return Database connection name.
+   */
+  QString getConnectionName() const;
 
   /**
    * Compares the persisted plugin modification time with the
@@ -330,8 +341,7 @@ private:
 
 
   QString m_databasePath;
-  QString m_connectionName;
-  bool m_isDatabaseOpen;
+  mutable QThreadStorage<QString> m_connectionNames;
 
   QMutex m_archivesLock;
 

--- a/Libs/PluginFramework/ctkPluginStorageSQL_p.h
+++ b/Libs/PluginFramework/ctkPluginStorageSQL_p.h
@@ -281,6 +281,13 @@ private:
   QString getConnectionName() const;
 
   /**
+   * Creates the directory for the database.
+   *
+   * @throws ctkPluginDatabaseException
+   */
+  void createDatabaseDirectory() const;
+
+  /**
    * Compares the persisted plugin modification time with the
    * file system modification time and updates the database
    * if the persisted data is outdated.

--- a/Libs/PluginFramework/ctkPluginStorageSQL_p.h
+++ b/Libs/PluginFramework/ctkPluginStorageSQL_p.h
@@ -332,7 +332,6 @@ private:
   QString m_databasePath;
   QString m_connectionName;
   bool m_isDatabaseOpen;
-  bool m_inTransaction;
 
   QMutex m_archivesLock;
 


### PR DESCRIPTION
Use thread-local database connections in ctkPluginStorageSQL.

Instead of the checkConnection() method that was called in nearly every other method before actually getting the connection, I refactored this into a getConnection() method. The getConnection() method creates a thread-local connection if it does not yet exist and then checks the connection. So it can be described more like "ensure connection", I guess.

getConnection() is also used in open(), as most of its logic moved into getConnection(). To retrieve only existing connections, getConnection() has an optional parameter just like QSqlDatabase::database().

Public API didn't change. If something goes wrong, the same exceptions are still thrown at the same locations. There's an additional const close() method, as closing can be done const. The non-const close() method, which is required to satisfy an abstract interface, just calls the const version.

Works well with MITK and CTKPluginFrameworkCppTests. Connections for additional threads are created and reused as needed.