### PR TITLE
ENH: Update minimum Qt4 to 4.7

### DIFF
--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -57,7 +57,7 @@ macro(ctkMacroSetupQt)
     endif()
 
   else()
-    set(minimum_required_qt_version "4.6")
+    set(minimum_required_qt_version "4.7")
 
     find_package(Qt4)
 


### PR DESCRIPTION
This allow to remove the definition QFILEDIALOG_OPTIONS
in ctkDirectoryButton and ctkPathLineEdit, used to conserve
backwards compatibility.