### PR TITLE
ENH: Remove QFILEDIALOG_OPTIONS definition

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkDirectoryButtonTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkDirectoryButtonTest1.cpp
@@ -49,7 +49,7 @@ int ctkDirectoryButtonTest1(int argc, char * argv [] )
   ctkDirectoryButton button3(icon, "..");
   ctkDirectoryButton button4;
   button4.setAcceptMode(QFileDialog::AcceptSave);
-  button4.setOptions(button4.options() | ctkDirectoryButton::DontUseNativeDialog);
+  button4.setOptions(button4.options() | QFileDialog::DontUseNativeDialog);
 
 
   QFormLayout* layout = new QFormLayout;
@@ -94,18 +94,10 @@ int ctkDirectoryButtonTest1(int argc, char * argv [] )
     std::cerr << "ctkDirectoryButton::setIcon() failed." << std::endl;
     return EXIT_FAILURE;
     }
-  
-#ifdef USE_QFILEDIALOG_OPTIONS
+
   button.setOptions(QFileDialog::ShowDirsOnly | QFileDialog::ReadOnly);
   if (button.options() != (QFileDialog::ShowDirsOnly |
                            QFileDialog::ReadOnly))
-#else
-  button.setOptions(ctkDirectoryButton::ShowDirsOnly |
-                    ctkDirectoryButton::ReadOnly);
-  
-  if (button.options() != (ctkDirectoryButton::ShowDirsOnly |
-                           ctkDirectoryButton::ReadOnly))
-#endif
     {
     std::cerr<< "ctkDirectoryButton::setOptions failed" << std::endl;
     return EXIT_FAILURE;
@@ -146,7 +138,7 @@ int ctkDirectoryButtonTest1(int argc, char * argv [] )
   // If Qt uses the default native dialog, a nested event loop won't
   // be created and app.quit() will have no effect (as it solely quits
   // event loops).
-  button.setOptions(button.options() | ctkDirectoryButton::DontUseNativeDialog);
+  button.setOptions(button.options() | QFileDialog::DontUseNativeDialog);
   QTimer::singleShot(100, &button, SLOT(browse()));
 
   return app.exec();

--- a/Libs/Widgets/Testing/Cpp/ctkPathLineEditTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkPathLineEditTest1.cpp
@@ -104,7 +104,7 @@ int ctkPathLineEditTest1(int argc, char * argv [] )
   QTimer::singleShot(100, &button, SLOT(retrieveHistory()));
   QTimer::singleShot(115, &button2, SLOT(addCurrentPathToHistory()));
   // The open dialog blocks QTimers (to quit the app).
-  button3.setOptions(button3.options() | ctkPathLineEdit::DontUseNativeDialog);
+  button3.setOptions(button3.options() | QFileDialog::DontUseNativeDialog);
   QTimer::singleShot(120, &button3, SLOT(browse()));
 
   return app.exec();

--- a/Libs/Widgets/ctkDirectoryButton.cpp
+++ b/Libs/Widgets/ctkDirectoryButton.cpp
@@ -47,11 +47,7 @@ public:
   QPushButton* PushButton;
   QString      DialogCaption;
   QString      DisplayText;
-#ifdef USE_QFILEDIALOG_OPTIONS
   QFileDialog::Options DialogOptions;
-#else
-  ctkDirectoryButton::Options DialogOptions;
-#endif
   // TODO expose DisplayAbsolutePath into the API
   bool         DisplayAbsolutePath;
   QFileDialog::AcceptMode AcceptMode;
@@ -61,11 +57,7 @@ public:
 ctkDirectoryButtonPrivate::ctkDirectoryButtonPrivate(ctkDirectoryButton& object)
   :q_ptr(&object)
 {
-#if USE_QFILEDIALOG_OPTIONS
   this->DialogOptions = QFileDialog::ShowDirsOnly;
-#else
-  this->DialogOptions = ctkDirectoryButton::ShowDirsOnly;
-#endif
   this->DisplayAbsolutePath = true;
   this->AcceptMode = QFileDialog::AcceptOpen;
 }
@@ -212,22 +204,14 @@ QIcon ctkDirectoryButton::icon()const
 }
 
 //-----------------------------------------------------------------------------
-#ifdef USE_QFILEDIALOG_OPTIONS
 void ctkDirectoryButton::setOptions(const QFileDialog::Options& dialogOptions)
-#else
-void ctkDirectoryButton::setOptions(const Options& dialogOptions)
-#endif
 {
   Q_D(ctkDirectoryButton);
   d->DialogOptions = dialogOptions;
 }
 
 //-----------------------------------------------------------------------------
-#ifdef USE_QFILEDIALOG_OPTIONS
 const QFileDialog::Options& ctkDirectoryButton::options()const
-#else
-const ctkDirectoryButton::Options& ctkDirectoryButton::options()const
-#endif
 {
   Q_D(const ctkDirectoryButton);
   return d->DialogOptions;
@@ -280,11 +264,7 @@ void ctkDirectoryButton::browse()
   QScopedPointer<ctkFileDialog> fileDialog(
     new ctkFileDialog(this, d->DialogCaption.isEmpty() ? this->toolTip() :
                       d->DialogCaption, d->Directory.path()));
-  #ifdef USE_QFILEDIALOG_OPTIONS
     fileDialog->setOptions(d->DialogOptions);
-  #else
-    fileDialog->setOptions(QFlags<QFileDialog::Option>(int(d->DialogOptions)));
-  #endif
     fileDialog->setAcceptMode(d->AcceptMode);
     fileDialog->setFileMode(QFileDialog::DirectoryOnly);
 

--- a/Libs/Widgets/ctkDirectoryButton.h
+++ b/Libs/Widgets/ctkDirectoryButton.h
@@ -31,10 +31,6 @@
 #include "ctkWidgetsExport.h"
 class ctkDirectoryButtonPrivate;
 
-// QFileDialog::Options can be used since Qt 4.7.0 (QT_VERSION >= 0x040700)
-// it is disabled to support older Qt versions
-//#define USE_QFILEDIALOG_OPTIONS 1
-
 /// \ingroup Widgets
 /// ctkDirectoryButton is a QPushButton to select a directory path.
 /// The absolute path is displayed on the button. When clicked, a
@@ -64,29 +60,9 @@ class CTK_WIDGETS_EXPORT ctkDirectoryButton: public QWidget
   /// Qt versions prior to 4.7.0 didn't expose QFileDialog::Options in the
   /// public API. We need to create a custom property that will be used when
   /// instanciating a QFileDialog in ctkDirectoryButton::browse()
-#ifdef USE_QFILEDIALOG_OPTIONS
   Q_PROPERTY(QFileDialog::Options options READ options WRITE setOptions)
-#else
-  Q_PROPERTY(Options options READ options WRITE setOptions)
-  Q_FLAGS(Option Options);
-#endif
 
 public:
-#ifndef USE_QFILEDIALOG_OPTIONS
-  // Same options than QFileDialog::Options
-  enum Option
-  {
-    ShowDirsOnly          = 0x00000001,
-    DontResolveSymlinks   = 0x00000002,
-    DontConfirmOverwrite  = 0x00000004,
-    DontUseSheet          = 0x00000008,
-    DontUseNativeDialog   = 0x00000010,
-    ReadOnly              = 0x00000020,
-    HideNameFilterDetails = 0x00000040
-  };
-  Q_DECLARE_FLAGS(Options, Option)
-#endif
-
   /// Constructor
   /// Creates a default ctkDirectoryButton that points to the application
   /// current directory.
@@ -128,13 +104,8 @@ public:
 
   /// Options of the file dialog pop up.
   /// \sa QFileDialog::getExistingDirectory
-#ifdef USE_QFILEDIALOG_OPTIONS
   void setOptions(const QFileDialog::Options& options);
   const QFileDialog::Options& options()const;
-#else
-  void setOptions(const Options& options);
-  const Options& options()const;
-#endif
 
   /// \sa setAcceptMode QFileDialog::AcceptMode
   QFileDialog::AcceptMode acceptMode() const;
@@ -168,9 +139,5 @@ private:
   Q_DECLARE_PRIVATE(ctkDirectoryButton);
   Q_DISABLE_COPY(ctkDirectoryButton);
 };
-
-#ifndef USE_QFILEDIALOG_OPTIONS
-Q_DECLARE_OPERATORS_FOR_FLAGS(ctkDirectoryButton::Options);
-#endif
 
 #endif

--- a/Libs/Widgets/ctkPathLineEdit.cpp
+++ b/Libs/Widgets/ctkPathLineEdit.cpp
@@ -69,11 +69,7 @@ public:
   QString               Label;              //!< used in file dialogs
   QStringList           NameFilters;        //!< Regular expression (in wildcard mode) used to help the user to complete the line
   QDir::Filters         Filters;            //!< Type of path (file, dir...)
-#ifdef USE_QFILEDIALOG_OPTIONS
   QFileDialog::Options DialogOptions;
-#else
-  ctkPathLineEdit::Options DialogOptions;
-#endif
 
   bool                  HasValidInput;      //!< boolean that stores the old state of valid input
   QString               SettingKey;
@@ -390,22 +386,14 @@ ctkPathLineEdit::Filters ctkPathLineEdit::filters()const
 }
 
 //-----------------------------------------------------------------------------
-#ifdef USE_QFILEDIALOG_OPTIONS
 void ctkPathLineEdit::setOptions(const QFileDialog::Options& dialogOptions)
-#else
-void ctkPathLineEdit::setOptions(const Options& dialogOptions)
-#endif
 {
   Q_D(ctkPathLineEdit);
   d->DialogOptions = dialogOptions;
 }
 
 //-----------------------------------------------------------------------------
-#ifdef USE_QFILEDIALOG_OPTIONS
 const QFileDialog::Options& ctkPathLineEdit::options()const
-#else
-const ctkPathLineEdit::Options& ctkPathLineEdit::options()const
-#endif
 {
   Q_D(const ctkPathLineEdit);
   return d->DialogOptions;
@@ -427,11 +415,7 @@ void ctkPathLineEdit::browse()
 	                                this->currentPath(),
 	d->NameFilters.join(";;"),
 	0,
-#ifdef USE_QFILEDIALOG_OPTIONS
       d->DialogOptions);
-#else
-      QFlags<QFileDialog::Option>(int(d->DialogOptions)));
-#endif
       }
     else
       {
@@ -442,11 +426,7 @@ void ctkPathLineEdit::browse()
 	                               this->currentPath(),
         d->NameFilters.join(";;"),
 	0,
-#ifdef USE_QFILEDIALOG_OPTIONS
       d->DialogOptions);
-#else
-      QFlags<QFileDialog::Option>(int(d->DialogOptions)));
-#endif
       }
     }
   else //directory
@@ -456,11 +436,7 @@ void ctkPathLineEdit::browse()
       QString("Select a directory..."),
       this->currentPath().isEmpty() ? ctkPathLineEditPrivate::sCurrentDirectory :
                                       this->currentPath(),
-#ifdef USE_QFILEDIALOG_OPTIONS
       d->DialogOptions);
-#else
-      QFlags<QFileDialog::Option>(int(d->DialogOptions)));
-#endif
     }
   if (path.isEmpty())
     {

--- a/Libs/Widgets/ctkPathLineEdit.h
+++ b/Libs/Widgets/ctkPathLineEdit.h
@@ -47,6 +47,7 @@ MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 // Qt includes
 #include <QDir>
+#include <QFileDialog>
 #include <QWidget>
 class QComboBox;
 
@@ -69,12 +70,7 @@ class CTK_WIDGETS_EXPORT ctkPathLineEdit: public QWidget
   /// Qt versions prior to 4.7.0 didn't expose QFileDialog::Options in the
   /// public API. We need to create a custom property that will be used when
   /// instanciating a QFileDialog in ctkPathLineEdit::browse()
-#ifdef USE_QFILEDIALOG_OPTIONS
   Q_PROPERTY(QFileDialog::Options options READ options WRITE setOptions)
-#else
-  Q_PROPERTY(Options options READ options WRITE setOptions)
-  Q_FLAGS(Option Options)
-#endif
 
   /// This property controls the key used to search the settings for recorded
   /// paths.
@@ -138,21 +134,6 @@ public:
   };
   Q_DECLARE_FLAGS(Filters, Filter)
 
-#ifndef USE_QFILEDIALOG_OPTIONS
-  // Same options than QFileDialog::Options
-  enum Option
-  {
-    ShowDirsOnly          = 0x00000001,
-    DontResolveSymlinks   = 0x00000002,
-    DontConfirmOverwrite  = 0x00000004,
-    DontUseSheet          = 0x00000008,
-    DontUseNativeDialog   = 0x00000010,
-    ReadOnly              = 0x00000020,
-    HideNameFilterDetails = 0x00000040
-  };
-  Q_DECLARE_FLAGS(Options, Option)
-#endif
-
   enum SizeAdjustPolicy
   {
     /// The path line edit will always adjust to the contents.
@@ -192,13 +173,8 @@ public:
 
   /// Options of the file dialog pop up.
   /// \sa QFileDialog::getExistingDirectory
-#ifdef USE_QFILEDIALOG_OPTIONS
   void setOptions(const QFileDialog::Options& options);
   const QFileDialog::Options& options()const;
-#else
-  void setOptions(const Options& options);
-  const Options& options()const;
-#endif
 
   /// Change the current extension of the edit line.
   ///  If there is no extension yet, set it
@@ -280,8 +256,5 @@ private:
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(ctkPathLineEdit::Filters)
-#ifndef USE_QFILEDIALOG_OPTIONS
-Q_DECLARE_OPERATORS_FOR_FLAGS(ctkPathLineEdit::Options);
-#endif
 
 #endif // __ctkPathLineEdit_h


### PR DESCRIPTION
It was kept for backwards compatibility.
Not needed after update to Qt4.7