### PR TITLE
Support qvtkopennativewidget

### DIFF
--- a/CMake/ctkMacroBuildLib.cmake
+++ b/CMake/ctkMacroBuildLib.cmake
@@ -28,7 +28,7 @@
 #! \ingroup CMakeAPI
 macro(ctkMacroBuildLib)
   ctkMacroParseArguments(MY
-    "NAME;EXPORT_DIRECTIVE;SRCS;MOC_SRCS;GENERATE_MOC_SRCS;UI_FORMS;INCLUDE_DIRECTORIES;TARGET_LIBRARIES;RESOURCES;LIBRARY_TYPE"
+    "NAME;EXPORT_DIRECTIVE;SRCS;MOC_SRCS;GENERATE_MOC_SRCS;UI_FORMS;INCLUDE_DIRECTORIES;TARGET_LIBRARIES;RESOURCES;LIBRARY_TYPE;MOC_OPTIONS"
     "ENABLE_QTTESTING"
     ${ARGN}
     )
@@ -109,7 +109,7 @@ macro(ctkMacroBuildLib)
     # moc files can get very long and can't be resolved by the MSVC compiler.
     if(CTK_QT_VERSION VERSION_GREATER "4")
       foreach(moc_src ${MY_MOC_SRCS})
-        qt5_wrap_cpp(MY_MOC_CPP ${moc_src} OPTIONS -f${moc_src} OPTIONS -DHAVE_QT5)
+        qt5_wrap_cpp(MY_MOC_CPP ${moc_src} OPTIONS -f${moc_src} OPTIONS -DHAVE_QT5 ${MY_MOC_OPTIONS})
       endforeach()
     else()
       foreach(moc_src ${MY_MOC_SRCS})

--- a/Libs/Visualization/VTK/Widgets/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Widgets/CMakeLists.txt
@@ -207,8 +207,13 @@ if(CTK_QT_VERSION VERSION_LESS "5"
   set(_use_qvtkopenglwidget 0)
 endif()
 
+# Setting the moc options is required to ensure the correct classname
+# is associated with the wrapped method.
+set(moc_options -DctkVTKOpenGLNativeWidget=QVTKWidget)
+
 if(_use_qvtkopenglwidget)
   add_definitions(-DCTK_USE_QVTKOPENGLWIDGET)
+  set(moc_options -DctkVTKOpenGLNativeWidget=QVTKOpenGLWidget)
 endif()
 
 # Detect if QVTKOpenGLNativeWidget.h is available
@@ -231,7 +236,9 @@ endif()
 
 if(_has_QVTKOpenGLNativeWidget_h)
   add_definitions(-DCTK_HAS_QVTKOPENGLNATIVEWIDGET_H)
+  set(moc_options -DctkVTKOpenGLNativeWidget=QVTKOpenGLNativeWidget)
 endif()
+
 
 ctkMacroBuildLib(
   NAME ${PROJECT_NAME}
@@ -242,6 +249,7 @@ ctkMacroBuildLib(
   TARGET_LIBRARIES ${KIT_target_libraries}
   RESOURCES ${KIT_resources}
   LIBRARY_TYPE ${CTK_LIBRARY_MODE}
+  MOC_OPTIONS ${moc_options}
   )
 
 if(_use_qvtkopenglwidget)

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
@@ -68,18 +68,11 @@ void ctkVTKAbstractViewPrivate::init()
   Q_Q(ctkVTKAbstractView);
 
   this->setParent(q);
-
+  this->VTKWidget = new ctkVTKOpenGLNativeWidget;
 #ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  this->VTKWidget = new QVTKOpenGLNativeWidget;
-# else
-  this->VTKWidget = new QVTKOpenGLWidget;
-# endif
   this->VTKWidget->setEnableHiDPI(true);
   QObject::connect(this->VTKWidget, SIGNAL(resized()),
                    q, SLOT(forceRender()));
-#else
-  this->VTKWidget = new QVTKWidget;
 #endif
   q->setLayout(new QVBoxLayout);
   q->layout()->setMargin(0);
@@ -300,15 +293,7 @@ vtkCornerAnnotation* ctkVTKAbstractView::cornerAnnotation() const
 }
 
 //----------------------------------------------------------------------------
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-QVTKOpenGLNativeWidget * ctkVTKAbstractView::VTKWidget() const
-# else
-QVTKOpenGLWidget * ctkVTKAbstractView::VTKWidget() const
-# endif
-#else
-QVTKWidget * ctkVTKAbstractView::VTKWidget() const
-#endif
+ctkVTKOpenGLNativeWidget * ctkVTKAbstractView::VTKWidget() const
 {
   Q_D(const ctkVTKAbstractView);
   return d->VTKWidget;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.h
@@ -24,18 +24,8 @@
 // Qt includes
 #include <QWidget>
 
-// VTK includes
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#else
-#include <QVTKWidget.h>
-#endif
-
 // CTK includes
+#include "ctkVTKOpenGLNativeWidget.h"
 #include "ctkVTKObject.h"
 #include "ctkVisualizationVTKWidgetsExport.h"
 class ctkVTKAbstractViewPrivate;
@@ -153,15 +143,7 @@ public:
   Q_INVOKABLE vtkCornerAnnotation* cornerAnnotation()const;
 
   /// Get the underlying QVTKWidget
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  Q_INVOKABLE QVTKOpenGLNativeWidget * VTKWidget() const;
-# else
-  Q_INVOKABLE QVTKOpenGLWidget * VTKWidget() const;
-# endif
-#else
-  Q_INVOKABLE QVTKWidget * VTKWidget() const;
-#endif
+  Q_INVOKABLE ctkVTKOpenGLNativeWidget * VTKWidget() const;
 
   /// Get background color
   virtual QColor backgroundColor() const;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
@@ -57,15 +57,10 @@ public:
   QList<vtkRenderer*> renderers()const;
   vtkRenderer* firstRenderer()const;
 
+  ctkVTKOpenGLNativeWidget*                     VTKWidget;
 #ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  QVTKOpenGLNativeWidget*                       VTKWidget;
-# else
-  QVTKOpenGLWidget*                             VTKWidget;
-# endif
   vtkSmartPointer<vtkGenericOpenGLRenderWindow> RenderWindow;
 #else
-  QVTKWidget*                                   VTKWidget;
   vtkSmartPointer<vtkRenderWindow>              RenderWindow;
 #endif
   QTimer*                                       RequestTimer;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKChartView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKChartView.h
@@ -23,49 +23,24 @@
 
 // CTK includes
 #include <ctkVTKObject.h>
+#include <ctkVTKOpenGLNativeWidget.h>
 #include "ctkVisualizationVTKWidgetsExport.h"
 class ctkVTKChartViewPrivate;
 
 // VTK includes
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#else
-#include <QVTKWidget.h>
-#endif
-
 class vtkChartXY;
 class vtkContextScene;
 class vtkPlot;
 
 /// \ingroup Visualization_VTK_Widgets
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKChartView : public QVTKOpenGLNativeWidget
-# else
-class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKChartView : public QVTKOpenGLWidget
-# endif
-#else
-class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKChartView : public QVTKWidget
-#endif
+class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKChartView : public ctkVTKOpenGLNativeWidget
 {
   Q_OBJECT
   QVTK_OBJECT
   Q_PROPERTY(QString title READ title WRITE setTitle)
 
 public:
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  typedef QVTKOpenGLNativeWidget Superclass;
-# else
-  typedef QVTKOpenGLWidget Superclass;
-# endif
-#else
-  typedef QVTKWidget Superclass;
-#endif
+  typedef ctkVTKOpenGLNativeWidget Superclass;
   ctkVTKChartView(QWidget* parent = 0);
   virtual ~ctkVTKChartView();
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
@@ -23,6 +23,7 @@
 // CTK includes
 #include "ctkColorPickerButton.h"
 #include "ctkDoubleSlider.h"
+#include "ctkVTKOpenGLNativeWidget.h"
 #include "ctkVTKScalarsToColorsComboBox.h"
 #include "ctkVTKScalarsToColorsUtils.h"
 #include "ui_ctkVTKDiscretizableColorTransferWidget.h"
@@ -46,15 +47,6 @@
 #include <QWidgetAction>
 
 // VTK includes
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#else
-#include <QVTKWidget.h>
-#endif
 #include <vtkCallbackCommand.h>
 #include <vtkContextScene.h>
 #include <vtkContextView.h>
@@ -97,15 +89,8 @@ public:
   bool popRangesFromHistory(double* currentRange, double* visibleRange);
   void clearUndoHistory();
 
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  QVTKOpenGLNativeWidget* ScalarsToColorsView;
-# else
-  QVTKOpenGLWidget* ScalarsToColorsView;
-# endif
-#else
-  QVTKWidget* ScalarsToColorsView;
-#endif
+
+  ctkVTKOpenGLNativeWidget* ScalarsToColorsView;
 
   vtkSmartPointer<vtkScalarsToColorsContextItem> scalarsToColorsContextItem;
   vtkSmartPointer<vtkContextView> scalarsToColorsContextView;
@@ -168,15 +153,7 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
 
   this->Ui_ctkVTKDiscretizableColorTransferWidget::setupUi(widget);
 
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  this->ScalarsToColorsView = new QVTKOpenGLNativeWidget;
-# else
-  this->ScalarsToColorsView = new QVTKOpenGLWidget;
-# endif
-#else
-  this->ScalarsToColorsView = new QVTKWidget;
-#endif
+  this->ScalarsToColorsView = new ctkVTKOpenGLNativeWidget;
   this->gridLayout->addWidget(this->ScalarsToColorsView, 2, 2, 5, 1);
 
   this->scalarsToColorsContextItem = vtkSmartPointer<vtkScalarsToColorsContextItem>::New();

--- a/Libs/Visualization/VTK/Widgets/ctkVTKOpenGLNativeWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKOpenGLNativeWidget.h
@@ -1,0 +1,44 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+#ifndef __ctkVTKOpenGLNativeWidget_h
+#define __ctkVTKOpenGLNativeWidget_h
+
+#if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
+#else
+# include <QVTKWidget.h>
+#endif
+
+#if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+typedef QVTKOpenGLNativeWidget ctkVTKOpenGLNativeWidget;
+# else
+typedef QVTKOpenGLWidget ctkVTKOpenGLNativeWidget;
+# endif
+#else
+typedef QVTKWidget ctkVTKOpenGLNativeWidget;
+#endif
+
+#endif

--- a/Libs/Visualization/VTK/Widgets/ctkVTKOpenGLNativeWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKOpenGLNativeWidget.h
@@ -33,12 +33,13 @@
 
 #if CTK_USE_QVTKOPENGLWIDGET
 # if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-typedef QVTKOpenGLNativeWidget ctkVTKOpenGLNativeWidget;
+#  define ctkVTKOpenGLNativeWidget QVTKOpenGLNativeWidget
 # else
-typedef QVTKOpenGLWidget ctkVTKOpenGLNativeWidget;
+#  define ctkVTKOpenGLNativeWidget QVTKOpenGLWidget
 # endif
 #else
-typedef QVTKWidget ctkVTKOpenGLNativeWidget;
+# define ctkVTKOpenGLNativeWidget QVTKWidget
 #endif
+
 
 #endif


### PR DESCRIPTION
These changes are required to support building against the latest VTK and still allow building against older VTK version.