### PR TITLE
STYLE: Simplify code introducing "ctkVTKOpenGLNativeWidget.h"

### DIFF
--- a/Libs/Visualization/VTK/Widgets/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Widgets/CMakeLists.txt
@@ -44,6 +44,7 @@ set(KIT_SRCS
   ctkVTKMagnifyView_p.h
   ctkVTKMatrixWidget.cpp
   ctkVTKMatrixWidget.h
+  ctkVTKOpenGLNativeWidget.h
   ctkVTKPiecewiseFunction.cpp
   ctkVTKPiecewiseFunction.h
   ctkVTKPropertyWidget.cpp
@@ -84,6 +85,7 @@ set(KIT_MOC_SRCS
   ctkVTKMagnifyView.h
   ctkVTKMagnifyView_p.h
   ctkVTKMatrixWidget.h
+  ctkVTKOpenGLNativeWidget.h
   ctkVTKPiecewiseFunction.h
   ctkVTKPropertyWidget.h
   ctkVTKRenderView.h

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
@@ -68,18 +68,11 @@ void ctkVTKAbstractViewPrivate::init()
   Q_Q(ctkVTKAbstractView);
 
   this->setParent(q);
-
+  this->VTKWidget = new ctkVTKOpenGLNativeWidget;
 #ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  this->VTKWidget = new QVTKOpenGLNativeWidget;
-# else
-  this->VTKWidget = new QVTKOpenGLWidget;
-# endif
   this->VTKWidget->setEnableHiDPI(true);
   QObject::connect(this->VTKWidget, SIGNAL(resized()),
                    q, SLOT(forceRender()));
-#else
-  this->VTKWidget = new QVTKWidget;
 #endif
   q->setLayout(new QVBoxLayout);
   q->layout()->setMargin(0);
@@ -300,15 +293,7 @@ vtkCornerAnnotation* ctkVTKAbstractView::cornerAnnotation() const
 }
 
 //----------------------------------------------------------------------------
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-QVTKOpenGLNativeWidget * ctkVTKAbstractView::VTKWidget() const
-# else
-QVTKOpenGLWidget * ctkVTKAbstractView::VTKWidget() const
-# endif
-#else
-QVTKWidget * ctkVTKAbstractView::VTKWidget() const
-#endif
+ctkVTKOpenGLNativeWidget * ctkVTKAbstractView::VTKWidget() const
 {
   Q_D(const ctkVTKAbstractView);
   return d->VTKWidget;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.h
@@ -24,18 +24,8 @@
 // Qt includes
 #include <QWidget>
 
-// VTK includes
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#else
-#include <QVTKWidget.h>
-#endif
-
 // CTK includes
+#include "ctkVTKOpenGLNativeWidget.h"
 #include "ctkVTKObject.h"
 #include "ctkVisualizationVTKWidgetsExport.h"
 class ctkVTKAbstractViewPrivate;
@@ -153,15 +143,7 @@ public:
   Q_INVOKABLE vtkCornerAnnotation* cornerAnnotation()const;
 
   /// Get the underlying QVTKWidget
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  Q_INVOKABLE QVTKOpenGLNativeWidget * VTKWidget() const;
-# else
-  Q_INVOKABLE QVTKOpenGLWidget * VTKWidget() const;
-# endif
-#else
-  Q_INVOKABLE QVTKWidget * VTKWidget() const;
-#endif
+  Q_INVOKABLE ctkVTKOpenGLNativeWidget * VTKWidget() const;
 
   /// Get background color
   virtual QColor backgroundColor() const;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
@@ -57,15 +57,10 @@ public:
   QList<vtkRenderer*> renderers()const;
   vtkRenderer* firstRenderer()const;
 
+  ctkVTKOpenGLNativeWidget*                     VTKWidget;
 #ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  QVTKOpenGLNativeWidget*                       VTKWidget;
-# else
-  QVTKOpenGLWidget*                             VTKWidget;
-# endif
   vtkSmartPointer<vtkGenericOpenGLRenderWindow> RenderWindow;
 #else
-  QVTKWidget*                                   VTKWidget;
   vtkSmartPointer<vtkRenderWindow>              RenderWindow;
 #endif
   QTimer*                                       RequestTimer;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKChartView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKChartView.h
@@ -23,49 +23,24 @@
 
 // CTK includes
 #include <ctkVTKObject.h>
+#include <ctkVTKOpenGLNativeWidget.h>
 #include "ctkVisualizationVTKWidgetsExport.h"
 class ctkVTKChartViewPrivate;
 
 // VTK includes
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#else
-#include <QVTKWidget.h>
-#endif
-
 class vtkChartXY;
 class vtkContextScene;
 class vtkPlot;
 
 /// \ingroup Visualization_VTK_Widgets
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKChartView : public QVTKOpenGLNativeWidget
-# else
-class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKChartView : public QVTKOpenGLWidget
-# endif
-#else
-class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKChartView : public QVTKWidget
-#endif
+class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKChartView : public ctkVTKOpenGLNativeWidget
 {
   Q_OBJECT
   QVTK_OBJECT
   Q_PROPERTY(QString title READ title WRITE setTitle)
 
 public:
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  typedef QVTKOpenGLNativeWidget Superclass;
-# else
-  typedef QVTKOpenGLWidget Superclass;
-# endif
-#else
-  typedef QVTKWidget Superclass;
-#endif
+  typedef ctkVTKOpenGLNativeWidget Superclass;
   ctkVTKChartView(QWidget* parent = 0);
   virtual ~ctkVTKChartView();
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
@@ -23,6 +23,7 @@
 // CTK includes
 #include "ctkColorPickerButton.h"
 #include "ctkDoubleSlider.h"
+#include "ctkVTKOpenGLNativeWidget.h"
 #include "ctkVTKScalarsToColorsComboBox.h"
 #include "ctkVTKScalarsToColorsUtils.h"
 #include "ui_ctkVTKDiscretizableColorTransferWidget.h"
@@ -46,15 +47,6 @@
 #include <QWidgetAction>
 
 // VTK includes
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#else
-#include <QVTKWidget.h>
-#endif
 #include <vtkCallbackCommand.h>
 #include <vtkContextScene.h>
 #include <vtkContextView.h>
@@ -97,15 +89,8 @@ public:
   bool popRangesFromHistory(double* currentRange, double* visibleRange);
   void clearUndoHistory();
 
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  QVTKOpenGLNativeWidget* ScalarsToColorsView;
-# else
-  QVTKOpenGLWidget* ScalarsToColorsView;
-# endif
-#else
-  QVTKWidget* ScalarsToColorsView;
-#endif
+
+  ctkVTKOpenGLNativeWidget* ScalarsToColorsView;
 
   vtkSmartPointer<vtkScalarsToColorsContextItem> scalarsToColorsContextItem;
   vtkSmartPointer<vtkContextView> scalarsToColorsContextView;
@@ -168,15 +153,7 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
 
   this->Ui_ctkVTKDiscretizableColorTransferWidget::setupUi(widget);
 
-#ifdef CTK_USE_QVTKOPENGLWIDGET
-# ifdef CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-  this->ScalarsToColorsView = new QVTKOpenGLNativeWidget;
-# else
-  this->ScalarsToColorsView = new QVTKOpenGLWidget;
-# endif
-#else
-  this->ScalarsToColorsView = new QVTKWidget;
-#endif
+  this->ScalarsToColorsView = new ctkVTKOpenGLNativeWidget;
   this->gridLayout->addWidget(this->ScalarsToColorsView, 2, 2, 5, 1);
 
   this->scalarsToColorsContextItem = vtkSmartPointer<vtkScalarsToColorsContextItem>::New();

--- a/Libs/Visualization/VTK/Widgets/ctkVTKOpenGLNativeWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKOpenGLNativeWidget.h
@@ -1,0 +1,74 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+#ifndef __ctkVTKOpenGLNativeWidget_h
+#define __ctkVTKOpenGLNativeWidget_h
+
+#include "ctkVisualizationVTKWidgetsExport.h"
+
+#if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
+#else
+# include <QVTKWidget.h>
+#endif
+
+/// \ingroup Visualization_VTK_Widgets
+#if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKOpenGLNativeWidget : public QVTKOpenGLNativeWidget
+{
+  Q_OBJECT
+public:
+  typedef QVTKOpenGLNativeWidget Superclass;
+  explicit ctkVTKOpenGLNativeWidget(QWidget* parent = 0) : Superclass(parent){}
+  virtual ~ctkVTKOpenGLNativeWidget(){}
+private:
+  Q_DISABLE_COPY(ctkVTKOpenGLNativeWidget);
+};
+# else
+class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKOpenGLNativeWidget : public QVTKOpenGLWidget
+{
+  Q_OBJECT
+public:
+  typedef QVTKOpenGLWidget Superclass;
+  explicit ctkVTKOpenGLNativeWidget(QWidget* parent = 0) : Superclass(parent){}
+  virtual ~ctkVTKOpenGLNativeWidget(){}
+private:
+  Q_DISABLE_COPY(ctkVTKOpenGLNativeWidget);
+};
+# endif
+#else
+class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKOpenGLNativeWidget : public QVTKWidget
+{
+  Q_OBJECT
+public:
+  typedef QVTKWidget Superclass;
+  explicit ctkVTKOpenGLNativeWidget(QWidget* parent = 0) : Superclass(parent){}
+  virtual ~ctkVTKOpenGLNativeWidget(){}
+private:
+  Q_DISABLE_COPY(ctkVTKOpenGLNativeWidget);
+};
+#endif
+
+#endif


### PR DESCRIPTION
Since using typedef or #ifdef prevents the real class associated with
ctkVTKOpenGLNativeWidget from being wrapped in PythonQt, this commit creates
a derived class.

Note also that the use of Q_DECLARE_METATYPE and qRegisterMetaType was
considered but it revealed not to be a possible alternative.
See https://github.com/commontk/CTK/pull/828

Fixes #829

Co-authored-by: Andras Lasso <lasso@queensu.ca>