### PR TITLE
BUG: Fix QtTesting xsd

### DIFF
--- a/Libs/QtTesting/Resources/XML/XMLDescription.xsd
+++ b/Libs/QtTesting/Resources/XML/XMLDescription.xsd
@@ -19,6 +19,7 @@
                     <xsd:attribute name="widget" type="xsd:string" />
                     <xsd:attribute name="command" type="xsd:string" />
                     <xsd:attribute name="arguments" type="xsd:string" />
+                    <xsd:attribute name="eventType" type="xsd:string" />
                 </xsd:complexType>
             </xsd:element>
         </xsd:sequence>


### PR DESCRIPTION
The optionnal attribute "eventType" was missing.
It made recorded macros fail before playing because of that XSD invalidation.