### PR TITLE
Fix QtTesting event type attribute saving to file

### DIFF
--- a/Libs/QtTesting/Resources/XML/XMLDescription.xsd
+++ b/Libs/QtTesting/Resources/XML/XMLDescription.xsd
@@ -19,7 +19,14 @@
                     <xsd:attribute name="widget" type="xsd:string" />
                     <xsd:attribute name="command" type="xsd:string" />
                     <xsd:attribute name="arguments" type="xsd:string" />
-                    <xsd:attribute name="eventType" type="xsd:string" />
+                    <xsd:attribute name="type">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:enumeration value="action" />
+                                <xsd:enumeration value="check" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:attribute>
                 </xsd:complexType>
             </xsd:element>
         </xsd:sequence>

--- a/Libs/QtTesting/ctkQtTestingUtility.cpp.in
+++ b/Libs/QtTesting/ctkQtTestingUtility.cpp.in
@@ -1,8 +1,9 @@
 // Qt includes
 #include <QDebug>
 
-// CTKTesting inlcudes
+// CTKTesting includes
 #include "ctkQtTestingUtility.h"
+#include <pqEventSource.h>  // for pqEventTypes
 
 @CTK_ADD_HEADER_EVENT_PLAYERS@
 
@@ -66,5 +67,37 @@ void ctkQtTestingUtility::addPlayer(pqWidgetEventPlayer* player)
   if(player)
     {
     this->eventPlayer()->addWidgetEventPlayer(player);
+    }
+}
+
+//-----------------------------------------------------------------------------
+QString ctkQtTestingUtility::eventTypeToString(int eventType)
+{
+  switch (eventType)
+    {
+    case pqEventTypes::ACTION_EVENT:
+      return QString("action");
+    case pqEventTypes::CHECK_EVENT:
+      return QString("check");
+    default:
+      return QString("unknown");
+    }
+}
+
+//-----------------------------------------------------------------------------
+int ctkQtTestingUtility::eventTypeFromString(const QString& eventTypeStr)
+{
+  if (!eventTypeStr.compare("action", Qt::CaseInsensitive))
+    {
+    return pqEventTypes::ACTION_EVENT;
+    }
+  else if (!eventTypeStr.compare("check", Qt::CaseInsensitive))
+    {
+    return pqEventTypes::CHECK_EVENT;
+    }
+  else
+    {
+    // unknown event type name
+    return -1;
     }
 }

--- a/Libs/QtTesting/ctkQtTestingUtility.h
+++ b/Libs/QtTesting/ctkQtTestingUtility.h
@@ -47,6 +47,15 @@ public:
 
   void addTranslator(pqWidgetEventTranslator* translator);
   void addPlayer(pqWidgetEventPlayer* player);
+
+  /// Convert pqEventTypes enum to string.
+  /// Returns "unknown" if the event type value is invalid.
+  static QString eventTypeToString(int eventType);
+
+  /// Get pqEventTypes enum from string.
+  /// Returns -1 if the type is not recognized.
+  /// String comparison is case insensitive.
+  static int eventTypeFromString(const QString& eventTypeStr);
 };
 
 #endif

--- a/Libs/QtTesting/ctkXMLEventObserver.cpp
+++ b/Libs/QtTesting/ctkXMLEventObserver.cpp
@@ -27,6 +27,7 @@
 #include <QVariant>
 
 // CTKQtTesting includes
+#include "ctkQtTestingUtility.h"
 #include "ctkXMLEventObserver.h"
 
 //-----------------------------------------------------------------------------
@@ -152,7 +153,7 @@ void ctkXMLEventObserver::onRecordEvent(const QString& widget,
     this->XMLStream->writeAttribute("widget", widget);
     this->XMLStream->writeAttribute("command", command);
     this->XMLStream->writeAttribute("arguments", arguments);
-    this->XMLStream->writeAttribute("eventType", QString::number(eventType));
+    this->XMLStream->writeAttribute("type", ctkQtTestingUtility::eventTypeToString(eventType));
     this->XMLStream->writeEndElement();
     if (this->Stream)
       {

--- a/Libs/QtTesting/ctkXMLEventSource.cpp
+++ b/Libs/QtTesting/ctkXMLEventSource.cpp
@@ -30,6 +30,7 @@
 #include <QVariant>
 
 // CTKQtTesting includes
+#include "ctkQtTestingUtility.h"
 #include "ctkXMLEventSource.h"
 
 //-----------------------------------------------------------------------------
@@ -140,12 +141,8 @@ int ctkXMLEventSource::getNextEvent(QString& widget, QString& command,
   widget = attributes.value("widget").toString();
   command = attributes.value("command").toString();
   arguments = attributes.value("arguments").toString();
-  eventType = attributes.hasAttribute("eventType") ?
-#if QT_VERSION < 0x50101
-    this->XMLStream->attributes().value("eventType").toString().toInt() :
-#else
-    this->XMLStream->attributes().value("eventType").toInt() :
-#endif
+  eventType = attributes.hasAttribute("type") ?
+    ctkQtTestingUtility::eventTypeFromString(this->XMLStream->attributes().value("type").toString()) :
     pqEventTypes::ACTION_EVENT;
   return SUCCESS;
 }


### PR DESCRIPTION
Serialization of the recently added QtTesting event type attribute had two major issues: incorrect attribute name and attribute type. This pull request fixes both of them.

Since the attribute name is modified, this is not backward-compatible change. However, this should be negligible, as code has become functional only 5 days ago.

- Renamed "eventType" attribute to "type". It is redundant to have "event" in the name of the element and attribute. Before: <event eventType="..."/>. After <event type="..."/>
- Changed event type from integer magic number (0, 1) to string enum (action, check). Using magic numbers in files would make the format extremely inflexible and more difficult to interpret.
