### PR TITLE
ENH: Reduce warning logs during DICOM import

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMIndexer.cpp
+++ b/Libs/DICOM/Core/ctkDICOMIndexer.cpp
@@ -93,14 +93,10 @@ void ctkDICOMIndexer::addFile(ctkDICOMDatabase& database,
                                    const QString& destinationDirectoryName)
 {
   ctkDICOMIndexer::ScopedIndexing indexingBatch(*this, database);
-  if (!destinationDirectoryName.isEmpty())
-  {
-    logger.warn("Ignoring destinationDirectoryName parameter, just taking it as indication we should copy!");
-  }
-
   emit indexingFilePath(filePath);
-
-  database.insert(filePath, !destinationDirectoryName.isEmpty(), true);
+  // Ignoring destinationDirectoryName parameter, just taking it as indication we should copy
+  bool copyFileToDatabase = !destinationDirectoryName.isEmpty();
+  database.insert(filePath, copyFileToDatabase, true);
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Core/ctkDICOMIndexer.h
+++ b/Libs/DICOM/Core/ctkDICOMIndexer.h
@@ -77,7 +77,10 @@ public:
 
   ///
   /// \brief Adds a file to database and optionally copies the file to
-  /// destinationDirectory.
+  /// the database folder.
+  /// If destinationDirectory is non-empty string then the file is copied
+  /// to the database folder (exact value of destinationDirectoryName does not matter,
+  /// only if the string is empty or not).
   ///
   /// Scan the file using Dcmtk and populate the database with all the
   /// DICOM fields accordingly.


### PR DESCRIPTION
When ctkDICOMIndexer::addFile was called with non-empty destinationDirectoryName (to indicate that file should be copied) then "Ignoring destinationDirectoryName parameter, just taking it as indication we should copy!" warning message was logged for each file. This flooded the logs and had noticeable performance impact.

Since this warning is for developers, it is not necessary to log it for each file during runtime, but the behavior is documented instead in the header file.