### PR TITLE
ENH: Added read-only option for ctkDoubleSpinBox and ctkCoordinatesWidget

### DIFF
--- a/Libs/Widgets/ctkCoordinatesWidget.cpp
+++ b/Libs/Widgets/ctkCoordinatesWidget.cpp
@@ -40,6 +40,8 @@ ctkCoordinatesWidgetPrivate
   :q_ptr(&object)
 {
   this->Decimals = 3;
+  this->Frame = true;
+  this->ReadOnly = false;
   ctkDoubleSpinBox temp;
   this->DecimalsOption = temp.decimalsOption();
   this->SingleStep = 1.;
@@ -82,6 +84,7 @@ void ctkCoordinatesWidgetPrivate::addSpinBox()
   spinBox->setMaximum(this->Maximum);
   spinBox->setSizeHintPolicy(this->SizeHintPolicy);
   spinBox->setValueProxy(this->Proxy.data());
+  spinBox->setReadOnly(this->ReadOnly);
   connect( spinBox, SIGNAL(valueChanged(double)),
            q, SLOT(updateCoordinate(double)));
   // Same number of decimals within the spinboxes.
@@ -773,4 +776,50 @@ ctkValueProxy* ctkCoordinatesWidget::valueProxy() const
 {
   Q_D(const ctkCoordinatesWidget);
   return d->Proxy.data();
+}
+
+//----------------------------------------------------------------------------
+void ctkCoordinatesWidget::setReadOnly(bool readOnly)
+{
+  Q_D(ctkCoordinatesWidget);
+  if (d->ReadOnly == readOnly)
+    {
+    return;
+    }
+
+  d->ReadOnly = readOnly;
+  for (int i = 0; i < d->Dimension; ++i)
+  {
+    this->spinBox(i)->setReadOnly(d->ReadOnly);
+  }
+}
+
+//------------------------------------------------------------------------------
+bool ctkCoordinatesWidget::isReadOnly() const
+{
+  Q_D(const ctkCoordinatesWidget);
+  return d->ReadOnly;
+}
+
+//-----------------------------------------------------------------------------
+void ctkCoordinatesWidget::setFrame(bool frame)
+{
+  Q_D(ctkCoordinatesWidget);
+  if (d->Frame == frame)
+    {
+    return;
+    }
+
+  d->Frame = frame;
+  for (int i = 0; i < d->Dimension; ++i)
+    {
+    this->spinBox(i)->setFrame(d->Frame);
+    }
+}
+
+//-----------------------------------------------------------------------------
+bool ctkCoordinatesWidget::hasFrame() const
+{
+  Q_D(const ctkCoordinatesWidget);
+  return d->Frame;
 }

--- a/Libs/Widgets/ctkCoordinatesWidget.h
+++ b/Libs/Widgets/ctkCoordinatesWidget.h
@@ -71,6 +71,11 @@ class CTK_WIDGETS_EXPORT ctkCoordinatesWidget : public QWidget
   /// \sa ctkDoubleSpinBox::SizeHintPolicy
   Q_PROPERTY(ctkDoubleSpinBox::SizeHintPolicy sizeHintPolicy READ sizeHintPolicy WRITE setSizeHintPolicy)
 
+  Q_PROPERTY(bool frame READ hasFrame WRITE setFrame)
+
+  /// This property controls if values can be modified using the graphical user interface.
+  Q_PROPERTY(bool readOnly READ isReadOnly WRITE setReadOnly)
+
 public:
   explicit ctkCoordinatesWidget(QWidget* parent = 0);
   virtual ~ctkCoordinatesWidget();
@@ -141,6 +146,16 @@ public:
   /// \sa sizeHintPolicy
   ctkDoubleSpinBox::SizeHintPolicy sizeHintPolicy()const;
 
+  /// Set/Get the frame
+  void setFrame(bool frame);
+  bool hasFrame() const;
+
+  /// Returns true if the widget is read-only. Read-only widgets only display values,
+  /// the values cannot be modified using the graphical user interface, and
+  /// spinbox is not displayed.
+  /// \sa setReadOnly
+  bool isReadOnly() const;
+
   /// Set/Get the value proxy of the spinboxes used to display the coordinates.
   /// \sa setValueProxy(), valueProxy()
   void setValueProxy(ctkValueProxy* proxy);
@@ -153,6 +168,12 @@ public Q_SLOTS:
 
   /// Set the number of decimals of each coordinate spin box.
   void setDecimals(int decimals);
+
+  /// Set the widget to be read-only. Read-only widgets only display values,
+  /// the values cannot be modified using the graphical user interface, and
+  /// spinbox is not displayed.
+  /// \sa isReadOnly
+  void setReadOnly(bool readOnly);
 
 Q_SIGNALS:
   ///

--- a/Libs/Widgets/ctkCoordinatesWidget_p.h
+++ b/Libs/Widgets/ctkCoordinatesWidget_p.h
@@ -68,6 +68,8 @@ public:
   bool    Normalized;
   int     Dimension;
   ctkDoubleSpinBox::SizeHintPolicy SizeHintPolicy;
+  bool    Frame;
+  bool    ReadOnly;
 
   double* Coordinates;
   QList<int> LastUserEditedCoordinates;

--- a/Libs/Widgets/ctkDoubleSpinBox.cpp
+++ b/Libs/Widgets/ctkDoubleSpinBox.cpp
@@ -680,6 +680,21 @@ bool ctkDoubleSpinBox::hasFrame() const
 }
 
 //-----------------------------------------------------------------------------
+void ctkDoubleSpinBox::setReadOnly(bool readOnly)
+{
+  Q_D(const ctkDoubleSpinBox);
+  d->SpinBox->setReadOnly(readOnly);
+  d->SpinBox->setButtonSymbols(readOnly ? QAbstractSpinBox::NoButtons : QAbstractSpinBox::UpDownArrows);
+}
+
+//-----------------------------------------------------------------------------
+bool ctkDoubleSpinBox::isReadOnly() const
+{
+  Q_D(const ctkDoubleSpinBox);
+  return d->SpinBox->isReadOnly();
+}
+
+//-----------------------------------------------------------------------------
 QString ctkDoubleSpinBox::prefix() const
 {
   Q_D(const ctkDoubleSpinBox);

--- a/Libs/Widgets/ctkDoubleSpinBox.h
+++ b/Libs/Widgets/ctkDoubleSpinBox.h
@@ -51,6 +51,7 @@ class CTK_WIDGETS_EXPORT ctkDoubleSpinBox : public QWidget
 
   Q_PROPERTY(Qt::Alignment alignment READ alignment WRITE setAlignment)
   Q_PROPERTY(bool frame READ hasFrame WRITE setFrame)
+  Q_PROPERTY(bool readOnly READ isReadOnly WRITE setReadOnly)
   Q_PROPERTY(QString prefix READ prefix WRITE setPrefix)
   Q_PROPERTY(QString suffix READ suffix WRITE setSuffix)
   Q_PROPERTY(QString cleanText READ cleanText)
@@ -196,6 +197,12 @@ public:
   void setFrame(bool frame);
   bool hasFrame() const;
 
+  /// Returns true if the widget is read-only. Read-only widgets only display values,
+  /// the values cannot be modified using the graphical user interface, and
+  /// spinbox is not displayed.
+  /// \sa setReadOnly
+  bool isReadOnly() const;
+
   /// Add/Get a prefix to the displayed value. For example, one might want to
   /// add the $ sign.
   /// \sa suffix(), text()
@@ -305,6 +312,12 @@ public Q_SLOTS:
   /// Set the decimals property value.
   /// \sa decimals
   void setDecimals(int decimal);
+
+  /// Set the widget to be read-only. Read-only widgets only display values,
+  /// the values cannot be modified using the graphical user interface, and
+  /// spinbox is not displayed.
+  /// \sa isReadOnly
+  void setReadOnly(bool readOnly);
 
 Q_SIGNALS:
   /// Emitted everytime the spinbox value is modified


### PR DESCRIPTION
Read-only option allows displaying non-editable coordinate values without disabling the widget.
Disabling is not ideal because it usually makes the widget grayed out, which is harder to read; and it also prevents copying the value.

It is also possible to hide the frame around coordinate value using "frame" property.