### PR TITLE
COMP: DCMTK 3.6.4 updated function signatures

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMItem.cpp
+++ b/Libs/DICOM/Core/ctkDICOMItem.cpp
@@ -21,6 +21,7 @@
 
 #include "ctkDICOMItem.h"
 
+#include <dcmtk/dcmdata/dcuid.h>
 #include <dcmtk/dcmdata/dctk.h>
 #include <dcmtk/dcmdata/dcostrmb.h>
 #include <dcmtk/dcmdata/dcistrmb.h>
@@ -950,7 +951,11 @@ QString ctkDICOMItem::TagDescription( const DcmTag& tag )
   {
     returnName = entry->getTagName();
   }
+#if OFFIS_DCMTK_VERSION_NUMBER < 364
   dcmDataDict.unlock();
+#else
+  dcmDataDict.rdunlock();
+#endif
   return returnName;
 }
 
@@ -964,7 +969,11 @@ QString ctkDICOMItem::TagVR( const DcmTag& tag )
   {
     returnVR = entry->getVR().getVRName();
   }
+#if OFFIS_DCMTK_VERSION_NUMBER < 364
   dcmDataDict.unlock();
+#else
+  dcmDataDict.rdunlock();
+#endif
   return returnVR;
 }
 


### PR DESCRIPTION
The locking mechanism for the dcmtk global
dictionary was changed to support:

Class OFReadWriteLock now uses SRW locks on Windows.

Unfortunately SRW locks require different functions for unlocking read
and write locks, which causes an API change in class OFReadWriteLock and
in class GlobalDcmDataDictionary (which internally uses a read/write
lock to protect access to the DICOM dictionary.)