### PR TITLE
Fix QtDesigner crash in debug mode

### DIFF
--- a/Libs/Core/Testing/Cpp/ctkLoggerTest1.cpp
+++ b/Libs/Core/Testing/Cpp/ctkLoggerTest1.cpp
@@ -23,6 +23,7 @@
 
 // CTK includes
 #include <ctkLogger.h>
+#include <ctkUtils.h>
 
 // STL includes
 #include <cstdlib>
@@ -42,6 +43,12 @@ int ctkLoggerTest1(int argc, char * argv [] )
   logger.warn("logger.warn");
   logger.error("logger.error");
   logger.fatal("logger.fatal");
+
+  // This should log a warning "Assertion `5 == 6` failed ..."
+  CTK_SOFT_ASSERT(5 == 6);
+
+  // This should not log anything
+  CTK_SOFT_ASSERT(8 == 8);
 
   return EXIT_SUCCESS;
 }

--- a/Libs/Core/ctkUtils.h
+++ b/Libs/Core/ctkUtils.h
@@ -24,11 +24,26 @@
 // Qt includes
 #include <QStringList>
 #include <QDateTime>
+#include <QDebug>
 
 // STD includes
 #include <vector>
 
 #include "ctkCoreExport.h"
+
+/// This macro can be used instead of Q_ASSERT to warn developers
+/// when some assumption fails. CTK_SOFT_ASSERT behavior differs
+/// in two key aspects: (1) it only logs a warning (instead of terminating
+/// the application) and (2) the message is always logged (instead of
+/// ignoring the check in release builds).
+#define CTK_SOFT_ASSERT(condition) do \
+  { \
+    if (! (condition) ) \
+    { \
+      qWarning() << "Assertion `" #condition "` failed in " << __FILE__ \
+                 << " line " << __LINE__; \
+    } \
+  } while (false)
 
 namespace ctk {
 ///

--- a/Libs/Widgets/ctkMatrixWidget.cpp
+++ b/Libs/Widgets/ctkMatrixWidget.cpp
@@ -21,6 +21,7 @@
 // CTK includes
 #include "ctkMatrixWidget.h"
 #include "ctkDoubleSpinBox.h"
+#include "ctkUtils.h"
 
 // Qt includes
 #include <QDebug>
@@ -238,7 +239,7 @@ void ctkMatrixWidgetPrivate::updateGeometries()
     bool lastColumn = (j==(ccount-1));
     int newWidth = lastColumn ? lastColWidth : colWidth;
     this->Table->setColumnWidth(j, newWidth);
-    Q_ASSERT(this->Table->columnWidth(j) == newWidth);
+    CTK_SOFT_ASSERT(this->Table->columnWidth(j) == newWidth);
     }
   // rows
   const int rcount = q->rowCount();
@@ -249,7 +250,7 @@ void ctkMatrixWidgetPrivate::updateGeometries()
     bool lastRow = (i==(rcount-1));
     int newHeight = lastRow ? lastRowHeight : rowHeight;
     this->Table->setRowHeight(i, newHeight);
-    Q_ASSERT(this->Table->rowHeight(i) == newHeight);
+    CTK_SOFT_ASSERT(this->Table->rowHeight(i) == newHeight);
     }
   this->Table->updateGeometry();
 }


### PR DESCRIPTION
Debug-mode Qt Designer crashed when tried to instantiate a ctkMatrixWidget because of an assert failure.
It may be useful to know that some operations fail, but making the Qt Designer crash is a too strong way of notifying developers (especially when developers only use CTK and not intend to fix its potential internal errors).

Fixed by converting assert to a debug log.

See user problem report here: https://discourse.slicer.org/t/designer-will-not-load-with-slicer-widgets/5496/4