### PR TITLE
COMP: Fix PythonQt wrapping of classes using nullptr

### DIFF
--- a/CMake/ctkWrapPythonQt.py
+++ b/CMake/ctkWrapPythonQt.py
@@ -1,3 +1,17 @@
+""" ctkWrapPythonQt
+
+CLI allowing to generate PythonQt decorator for constructor and destructor of classes.
+
+The CLI expects one class per header file with a class name matching the filename.
+
+It generates the files `<namespace>_<target>.h` and `<namespace>_<target>_init.cpp`
+
+where:
+
+* `<namespace>` is a string like `org_commontk`
+
+* `<target>` is a string like `CTKWidgets`
+"""
 
 import errno
 import os
@@ -88,7 +102,7 @@ def ctk_wrap_pythonqt(target, namespace, output_dir, input_files, extra_verbose)
             #    my_class(QObject* newParent ...)
             #    my_class(QWidget* newParent ...)
             # Constructor with either QWidget or QObject as first parameter
-            regex = r"[^~]%s[\s\n]*\([\s\n]*((QObject|QWidget)[\s\n]*\*[\s\n]*\w+[\s\n]*(\=[\s\n]*(0|NULL)|,.*\=.*\)|\)|\)))" % className
+            regex = r"[^~]%s[\s\n]*\([\s\n]*((QObject|QWidget)[\s\n]*\*[\s\n]*\w+[\s\n]*(\=[\s\n]*(0|NULL|nullptr)|,.*\=.*\)|\)|\)))" % className
             res = re.search(regex, content, re.MULTILINE)
             if res is None:
                 if extra_verbose:
@@ -97,7 +111,7 @@ def ctk_wrap_pythonqt(target, namespace, output_dir, input_files, extra_verbose)
      
             # Skip wrapping if object has a virtual pure method
             # "x3b" is the unicode for semicolon
-            regex = r"virtual[\w\n\s\*\(\)]+\=[\s\n]*(0|NULL)[\s\n]*\x3b"
+            regex = r"virtual[\w\n\s\*\(\)]+\=[\s\n]*(0|NULL|nullptr)[\s\n]*\x3b"
             res = re.search(regex, content, re.MULTILINE)
             if res is not None:
                 if extra_verbose:
@@ -116,7 +130,7 @@ def ctk_wrap_pythonqt(target, namespace, output_dir, input_files, extra_verbose)
 
             if parentClassName is None:
                 # Does constructor signature is of the form: myclass(QObject * parent ...)
-                regex = r"%s[\s\n]*\([\s\n]*QObject[\s\n]*\*[\s\n]*\w+[\s\n]*(\=[\s\n]*(0|NULL)|,.*\=.*\)|\))" % className
+                regex = r"%s[\s\n]*\([\s\n]*QObject[\s\n]*\*[\s\n]*\w+[\s\n]*(\=[\s\n]*(0|NULL|nullptr)|,.*\=.*\)|\))" % className
                 res = re.search(regex, content, re.MULTILINE)
                 if res is not None:
                     parentClassName = "QObject"
@@ -125,7 +139,7 @@ def ctk_wrap_pythonqt(target, namespace, output_dir, input_files, extra_verbose)
 
             if parentClassName is None:
                 # Does constructor signature is of the form: myclass(QWidget * parent ...)
-                regex = r"%s[\s\n]*\([\s\n]*QWidget[\s\n]*\*[\s\n]*\w+[\s\n]*(\=[\s\n]*(0|NULL)|,.*\=.*\)|\))" % className
+                regex = r"%s[\s\n]*\([\s\n]*QWidget[\s\n]*\*[\s\n]*\w+[\s\n]*(\=[\s\n]*(0|NULL|nullptr)|,.*\=.*\)|\))" % className
                 res = re.search(regex, content, re.MULTILINE)
                 if res is not None:
                     parentClassName = "QWidget"


### PR DESCRIPTION
This commit updates the python script ctkWrapPythonQt.py to check for nullptr.

Reference: https://github.com/Slicer/Slicer/pull/1102