### PR TITLE
COMP: Fix catch by value warning in ctkDICOMAppWidget

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
@@ -404,7 +404,7 @@ void ctkDICOMAppWidget::setDatabaseDirectory(const QString& directory)
     {
     d->DICOMDatabase->openDatabase( databaseFileName );
     }
-  catch (std::exception e)
+  catch (std::exception &)
     {
     std::cerr << "Database error: " << qPrintable(d->DICOMDatabase->lastError()) << "\n";
     d->DICOMDatabase->closeDatabase();


### PR DESCRIPTION
```cpp
[374/516] Building CXX object Libs/DICOM/Widgets/CMakeFiles/CTKDICOMWidgets.dir/ctkDICOMBrowser.cpp.o
Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp: In member function ‘void ctkDICOMAppWidget::setDatabaseDirectory(const QString&)’:
Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp:407:25: warning: catching polymorphic type ‘class std::exception’ by value [-Wcatch-value=]
   catch (std::exception e)
```