### PR TITLE
WIP: Modernize: clang-tidy 0 and NULL to nullptr

### DIFF
--- a/Libs/Core/ctkAbstractFactory.tpp
+++ b/Libs/Core/ctkAbstractFactory.tpp
@@ -142,7 +142,7 @@ BaseClassType* ctkAbstractFactoryItem<BaseClassType>::instantiate()
 template<typename BaseClassType>
 bool ctkAbstractFactoryItem<BaseClassType>::isInstantiated()const
 {
-  return (this->Instance != 0);
+  return (this->Instance != nullptr);
 }
 
 //----------------------------------------------------------------------------
@@ -163,7 +163,7 @@ void ctkAbstractFactoryItem<BaseClassType>::uninstantiate()
   delete this->Instance;
   // Make sure the pointer is set to 0. Doing so, Will prevent attempt to
   // delete unextising object if uninstantiate() methods is called multiple times.
-  this->Instance = 0; 
+  this->Instance = nullptr; 
 }
 
 //----------------------------------------------------------------------------
@@ -210,7 +210,7 @@ template<typename BaseClassType>
 BaseClassType* ctkAbstractFactory<BaseClassType>::instantiate(const QString& itemKey)
 {
   ctkAbstractFactoryItem<BaseClassType>* _item = this->item(itemKey);
-  BaseClassType* instance = 0;
+  BaseClassType* instance = nullptr;
   bool wasInstantiated = false;
   if (_item)
     {
@@ -249,7 +249,7 @@ template<typename BaseClassType>
 BaseClassType* ctkAbstractFactory<BaseClassType>::instance(const QString& itemKey)
 {
   ctkAbstractFactoryItem<BaseClassType>* factoryItem = this->item(itemKey);
-  return factoryItem ? factoryItem->instance() : 0;
+  return factoryItem ? factoryItem->instance() : nullptr;
 }
 
 //----------------------------------------------------------------------------
@@ -385,7 +385,7 @@ ctkAbstractFactoryItem<BaseClassType> * ctkAbstractFactory<BaseClassType>::item(
   ConstIterator iter = this->RegisteredItemMap.find(itemKey);
   if ( iter == this->RegisteredItemMap.constEnd())
     {
-    return 0;
+    return nullptr;
     }
   return iter.value().data();
 }
@@ -396,12 +396,12 @@ ctkAbstractFactoryItem<BaseClassType> * ctkAbstractFactory<BaseClassType>::share
 {
   if(this->SharedRegisteredItemMap.isNull())
     {
-    return 0;
+    return nullptr;
     }
   ConstIterator iter = this->SharedRegisteredItemMap.data()->find(itemKey);
   if ( iter == this->SharedRegisteredItemMap.data()->constEnd())
     {
-    return 0;
+    return nullptr;
     }
   return iter.value().data();
 }

--- a/Libs/Core/ctkAbstractFileBasedFactory.h
+++ b/Libs/Core/ctkAbstractFileBasedFactory.h
@@ -57,7 +57,7 @@ public:
   QString registerFileItem(const QFileInfo& file);
 
   /// Get path associated with the library identified by \a key
-  virtual QString path(const QString& key);
+  QString path(const QString& key) override;
 
 protected:
   void registerAllFileItems(const QStringList& directories);

--- a/Libs/Core/ctkAbstractFileBasedFactory.tpp
+++ b/Libs/Core/ctkAbstractFileBasedFactory.tpp
@@ -147,7 +147,7 @@ template<typename BaseClassType>
 ctkAbstractFactoryItem<BaseClassType>* ctkAbstractFileBasedFactory<BaseClassType>
 ::createFactoryFileBasedItem()
 {
-  return 0;
+  return nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Core/ctkAbstractLibraryFactory.h
+++ b/Libs/Core/ctkAbstractLibraryFactory.h
@@ -50,7 +50,7 @@ protected:
 public:
   //explicit ctkFactoryLibraryItem(const QString& path);
  
-  virtual bool load();
+  bool load() override;
 
   ///
   /// Set list of required symbols
@@ -86,8 +86,8 @@ public:
   void setSymbols(const QStringList& symbols);
 
 protected:
-  virtual bool isValidFile(const QFileInfo& file)const;
-  virtual void initItem(ctkAbstractFactoryItem<BaseClassType>* item);
+  bool isValidFile(const QFileInfo& file)const override;
+  void initItem(ctkAbstractFactoryItem<BaseClassType>* item) override;
 
 private:
   QStringList Symbols;

--- a/Libs/Core/ctkAbstractObjectFactory.h
+++ b/Libs/Core/ctkAbstractObjectFactory.h
@@ -46,9 +46,9 @@ class ctkFactoryObjectItem : public ctkAbstractFactoryItem<BaseClassType>
 protected:
   typedef BaseClassType *(*InstantiateObjectFunc)();
 public:
-  virtual bool load();
+  bool load() override;
 protected:
-  virtual BaseClassType* instanciator();
+  BaseClassType* instanciator() override;
 private:
   InstantiateObjectFunc instantiateObjectFunc;
 };

--- a/Libs/Core/ctkAbstractPluginFactory.h
+++ b/Libs/Core/ctkAbstractPluginFactory.h
@@ -34,11 +34,11 @@ template<typename BaseClassType>
 class ctkFactoryPluginItem : public ctkAbstractFactoryFileBasedItem<BaseClassType>
 {
 public:
-  virtual bool load();
+  bool load() override;
   virtual QString loadErrorString()const;
 
 protected:
-  virtual BaseClassType* instanciator();
+  BaseClassType* instanciator() override;
 
 private:
   QPluginLoader    Loader;
@@ -50,8 +50,8 @@ template<typename BaseClassType>
 class ctkAbstractPluginFactory : public ctkAbstractFileBasedFactory<BaseClassType>
 {
 protected:
-  virtual bool isValidFile(const QFileInfo& file)const;
-  virtual ctkAbstractFactoryItem<BaseClassType>* createFactoryFileBasedItem();
+  bool isValidFile(const QFileInfo& file)const override;
+  ctkAbstractFactoryItem<BaseClassType>* createFactoryFileBasedItem() override;
 };
 
 #include "ctkAbstractPluginFactory.tpp"

--- a/Libs/Core/ctkAbstractPluginFactory.tpp
+++ b/Libs/Core/ctkAbstractPluginFactory.tpp
@@ -73,7 +73,7 @@ BaseClassType* ctkFactoryPluginItem<BaseClassType>::instanciator()
       {
       this->appendLoadErrorString(QString("Failed to instantiate plugin: %1").arg(this->path()));
       }
-    return 0;
+    return nullptr;
     }
   BaseClassType* castedObject = qobject_cast<BaseClassType*>(object);
   if (!castedObject)
@@ -87,7 +87,7 @@ BaseClassType* ctkFactoryPluginItem<BaseClassType>::instanciator()
             .arg(object->metaObject()->className()));
       }
     delete object; // Clean memory
-    return 0;
+    return nullptr;
     }
   return castedObject;
 }

--- a/Libs/Core/ctkAbstractQObjectFactory.h
+++ b/Libs/Core/ctkAbstractQObjectFactory.h
@@ -36,7 +36,7 @@ public:
 
   /// Constructor/Desctructor
   explicit ctkAbstractQObjectFactory();
-  virtual ~ctkAbstractQObjectFactory();
+  ~ctkAbstractQObjectFactory() override ;
 
   /// \brief Return a name allowing to uniquely identify the QObject
   /// By default, it return \a objectName obtained using staticMetaObject.className()

--- a/Libs/Core/ctkBooleanMapper.h
+++ b/Libs/Core/ctkBooleanMapper.h
@@ -77,7 +77,7 @@ public:
   /// property and object must be valid and non empty. If signal is 0,
   /// \a valueChanged(bool) and \a complementChanged(bool) won't be fired.
   ctkBooleanMapper(QObject* targetObject, const QByteArray& propertyName, const QByteArray& signal);
-  virtual ~ctkBooleanMapper();
+  ~ctkBooleanMapper() override;
 
   QByteArray propertyName()const;
 

--- a/Libs/Core/ctkCallback.h
+++ b/Libs/Core/ctkCallback.h
@@ -52,9 +52,9 @@ class CTK_CORE_EXPORT ctkCallback : public QObject
   Q_OBJECT
 public:
 
-  ctkCallback(QObject * parentObject = 0);
-  ctkCallback(void (*callback)(void * data), QObject * parentObject = 0);
-  virtual ~ctkCallback();
+  ctkCallback(QObject * parentObject = nullptr);
+  ctkCallback(void (*callback)(void * data), QObject * parentObject = nullptr);
+  ~ctkCallback() override ;
 
   /// Returns the current pointer function
   void (*callback()const)(void*);

--- a/Libs/Core/ctkCommandLineParser.h
+++ b/Libs/Core/ctkCommandLineParser.h
@@ -81,7 +81,7 @@ public:
    *
    * @param newParent The QObject parent.
    */
-  ctkCommandLineParser(QObject* newParent = 0);
+  ctkCommandLineParser(QObject* newParent = nullptr);
 
   /**
    * Constructs a parser instance.
@@ -98,9 +98,9 @@ public:
    *
    *
    */
-  ctkCommandLineParser(QSettings* settings, QObject* newParent = 0);
+  ctkCommandLineParser(QSettings* settings, QObject* newParent = nullptr);
 
-  ~ctkCommandLineParser();
+  ~ctkCommandLineParser() override;
   
   /**
    * Parse a given list of command line arguments.
@@ -122,13 +122,13 @@ public:
    * @return A QHash object mapping the long argument (if empty, the short one)
    *         to a QVariant containing the value.
    */
-  QHash<QString, QVariant> parseArguments(const QStringList &arguments, bool* ok = 0);
+  QHash<QString, QVariant> parseArguments(const QStringList &arguments, bool* ok = nullptr);
 
   /**
     * Convenient method allowing to parse a given list of command line arguments.
     * @see parseArguments(const QStringList &, bool*)
     */
-  QHash<QString, QVariant> parseArguments(int argc, char** argv, bool* ok = 0);
+  QHash<QString, QVariant> parseArguments(int argc, char** argv, bool* ok = nullptr);
 
   /**
    * Returns a detailed error description if a call to <code>parseArguments()</code>

--- a/Libs/Core/ctkErrorLogAbstractMessageHandler.h
+++ b/Libs/Core/ctkErrorLogAbstractMessageHandler.h
@@ -43,7 +43,7 @@ public:
   typedef QObject Superclass;
   /// Disabled by default.
   ctkErrorLogAbstractMessageHandler();
-  virtual ~ctkErrorLogAbstractMessageHandler();
+  ~ctkErrorLogAbstractMessageHandler() override;
 
   virtual QString handlerName()const = 0;
 

--- a/Libs/Core/ctkErrorLogFDMessageHandler.h
+++ b/Libs/Core/ctkErrorLogFDMessageHandler.h
@@ -35,12 +35,12 @@ public:
   typedef ctkErrorLogAbstractMessageHandler Superclass;
 
   ctkErrorLogFDMessageHandler();
-  virtual ~ctkErrorLogFDMessageHandler();
+  ~ctkErrorLogFDMessageHandler() override;
 
   static QString HandlerName;
 
-  virtual QString handlerName()const;
-  virtual void setEnabledInternal(bool value);
+  QString handlerName()const override;
+  void setEnabledInternal(bool value) override;
 
 protected:
   QScopedPointer<ctkErrorLogFDMessageHandlerPrivate> d_ptr;

--- a/Libs/Core/ctkErrorLogQtMessageHandler.h
+++ b/Libs/Core/ctkErrorLogQtMessageHandler.h
@@ -43,8 +43,8 @@ public:
 
   static QString HandlerName;
 
-  virtual QString handlerName()const;
-  virtual void setEnabledInternal(bool value);
+  QString handlerName()const override;
+  void setEnabledInternal(bool value) override;
 
 #if QT_VERSION >= 0x50000
   QtMessageHandler SavedQtMessageHandler;

--- a/Libs/Core/ctkErrorLogStreamMessageHandler.h
+++ b/Libs/Core/ctkErrorLogStreamMessageHandler.h
@@ -36,12 +36,12 @@ public:
   typedef ctkErrorLogAbstractMessageHandler Superclass;
 
   ctkErrorLogStreamMessageHandler();
-  virtual ~ctkErrorLogStreamMessageHandler();
+  ~ctkErrorLogStreamMessageHandler() override;
 
   static QString HandlerName;
 
-  virtual QString handlerName()const;
-  virtual void setEnabledInternal(bool value);
+  QString handlerName()const override;
+  void setEnabledInternal(bool value) override;
 
 protected:
   QScopedPointer<ctkErrorLogStreamMessageHandlerPrivate> d_ptr;

--- a/Libs/Core/ctkErrorLogTerminalOutput.h
+++ b/Libs/Core/ctkErrorLogTerminalOutput.h
@@ -40,7 +40,7 @@ class CTK_CORE_EXPORT ctkErrorLogTerminalOutput : public QObject
 
 public:
   ctkErrorLogTerminalOutput();
-  virtual ~ctkErrorLogTerminalOutput();
+  ~ctkErrorLogTerminalOutput() override;
 
   enum TerminalOutput
     {

--- a/Libs/Core/ctkLinearValueProxy.h
+++ b/Libs/Core/ctkLinearValueProxy.h
@@ -45,12 +45,12 @@ class CTK_CORE_EXPORT ctkLinearValueProxy : public ctkValueProxy
 
 public:
   typedef ctkValueProxy Superclass;
-  explicit ctkLinearValueProxy(QObject* parent = 0);
-  virtual ~ctkLinearValueProxy();
+  explicit ctkLinearValueProxy(QObject* parent = nullptr);
+  ~ctkLinearValueProxy() override;
 
-  virtual double proxyValueFromValue(double value) const;
+  double proxyValueFromValue(double value) const override;
 
-  virtual double valueFromProxyValue(double proxyValue) const;
+  double valueFromProxyValue(double proxyValue) const override;
 
   virtual double coefficient() const;
   virtual double offset() const;

--- a/Libs/Core/ctkLogger.h
+++ b/Libs/Core/ctkLogger.h
@@ -39,8 +39,8 @@ class CTK_CORE_EXPORT ctkLogger : public QObject
 public:
   typedef QObject Superclass;
   /// Default mode is Off
-  explicit ctkLogger(QString name, QObject* parent = 0);
-  virtual ~ctkLogger ();
+  explicit ctkLogger(QString name, QObject* parent = nullptr);
+  ~ctkLogger () override ;
 
   void debug(const QString& s);
   void info(const QString& s);

--- a/Libs/Core/ctkModelTester.h
+++ b/Libs/Core/ctkModelTester.h
@@ -53,7 +53,7 @@ public:
   /// Constructor
   /// No model is set by default. To be tested, a model must be set using 
   /// setModel(...)
-  explicit ctkModelTester(QObject *parent = 0);
+  explicit ctkModelTester(QObject *parent = nullptr);
 
   ///
   /// Constructor that set the model to test.
@@ -62,11 +62,11 @@ public:
   ///             nestedInsert is false,
   ///             testDataEnabled is true,
   ///             verbose is true.
-  ctkModelTester(QAbstractItemModel *model, QObject *parent = 0);
+  ctkModelTester(QAbstractItemModel *model, QObject *parent = nullptr);
 
   ///
   /// Destructor
-  virtual ~ctkModelTester();
+  ~ctkModelTester() override ;
 
   ///
   /// Set the model to be tested, the model must remain valid during 

--- a/Libs/Core/ctkValueProxy.h
+++ b/Libs/Core/ctkValueProxy.h
@@ -61,8 +61,8 @@ class CTK_CORE_EXPORT ctkValueProxy : public QObject
 
 public:
   typedef QObject Superclass;
-  explicit ctkValueProxy(QObject* parent = 0);
-  virtual ~ctkValueProxy();
+  explicit ctkValueProxy(QObject* parent = nullptr);
+  ~ctkValueProxy() override;
 
   virtual double proxyValueFromValue(double value) const = 0;
   virtual double valueFromProxyValue(double proxyValue) const = 0;

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -61,9 +61,9 @@ class CTK_DICOM_CORE_EXPORT ctkDICOMDatabase : public QObject
   Q_PROPERTY(QStringList tagsToPrecache READ tagsToPrecache WRITE setTagsToPrecache)
 
 public:
-  explicit ctkDICOMDatabase(QObject *parent = 0);
+  explicit ctkDICOMDatabase(QObject *parent = nullptr);
   explicit ctkDICOMDatabase(QString databaseFile);
-  virtual ~ctkDICOMDatabase();
+  ~ctkDICOMDatabase() override;
 
   const QSqlDatabase& database() const;
   const QString lastError() const;

--- a/Libs/DICOM/Core/ctkDICOMIndexer.h
+++ b/Libs/DICOM/Core/ctkDICOMIndexer.h
@@ -38,8 +38,8 @@ class CTK_DICOM_CORE_EXPORT ctkDICOMIndexer : public QObject
 {
   Q_OBJECT
 public:
-  explicit ctkDICOMIndexer(QObject *parent = 0);
-  virtual ~ctkDICOMIndexer();
+  explicit ctkDICOMIndexer(QObject *parent = nullptr);
+  ~ctkDICOMIndexer() override;
 
   ///
   /// \brief Adds directory to database and optionally copies files to

--- a/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
@@ -404,7 +404,7 @@ void ctkDICOMAppWidget::setDatabaseDirectory(const QString& directory)
     {
     d->DICOMDatabase->openDatabase( databaseFileName );
     }
-  catch (std::exception e)
+  catch (std::exception &)
     {
     std::cerr << "Database error: " << qPrintable(d->DICOMDatabase->lastError()) << "\n";
     d->DICOMDatabase->closeDatabase();

--- a/Libs/ImageProcessing/ITK/Core/ctkITKErrorLogMessageHandler.cpp
+++ b/Libs/ImageProcessing/ITK/Core/ctkITKErrorLogMessageHandler.cpp
@@ -63,12 +63,12 @@ public:
   {}
   ~ctkITKOutputWindow(){}
 
-  virtual void DisplayText(const char*) ITK_OVERRIDE;
-  virtual void DisplayErrorText(const char*) ITK_OVERRIDE;
-  virtual void DisplayWarningText(const char*) ITK_OVERRIDE;
+  virtual void DisplayText(const char*) override;
+  virtual void DisplayErrorText(const char*) override;
+  virtual void DisplayWarningText(const char*) override;
   virtual void DisplayGenericWarningText(const char*);
 
-  virtual void DisplayDebugText(const char*) ITK_OVERRIDE;
+  virtual void DisplayDebugText(const char*) override;
 
   QString parseText(const QString &text, ctkErrorLogContext &context);
 

--- a/Libs/ImageProcessing/ITK/Core/ctkITKErrorLogMessageHandler.h
+++ b/Libs/ImageProcessing/ITK/Core/ctkITKErrorLogMessageHandler.h
@@ -39,13 +39,13 @@ public:
   typedef ctkErrorLogAbstractMessageHandler Superclass;
 
   ctkITKErrorLogMessageHandler();
-  virtual ~ctkITKErrorLogMessageHandler();
+  ~ctkITKErrorLogMessageHandler() override;
 
   static QString HandlerName;
 
-  virtual QString handlerName()const;
+  QString handlerName()const override;
 
-  virtual void setEnabledInternal(bool value);
+  void setEnabledInternal(bool value) override;
 
 protected:
   QScopedPointer<ctkITKErrorLogMessageHandlerPrivate> d_ptr;

--- a/Libs/QtTesting/ctkEventTranslatorPlayerWidget.h
+++ b/Libs/QtTesting/ctkEventTranslatorPlayerWidget.h
@@ -56,7 +56,7 @@ class CTK_QTTESTING_EXPORT ctkEventTranslatorPlayerWidget
 public:
   typedef QMainWindow Superclass;
   ctkEventTranslatorPlayerWidget();
-  ~ctkEventTranslatorPlayerWidget();
+  ~ctkEventTranslatorPlayerWidget() override;
 
   void addTestCase(QWidget* widget, QString fileName, void(*newCallback)(void* data));
   void addTestCase(QDialog* dialog, QString fileName, void(*newCallback)(void* data));

--- a/Libs/QtTesting/ctkQtTestingUtility.h
+++ b/Libs/QtTesting/ctkQtTestingUtility.h
@@ -39,8 +39,8 @@ class CTK_QTTESTING_EXPORT ctkQtTestingUtility : public pqTestUtility
 public:
   typedef pqTestUtility Superclass;
 
-  ctkQtTestingUtility(QObject* parent=0);
-  ~ctkQtTestingUtility();
+  ctkQtTestingUtility(QObject* parent=nullptr);
+  ~ctkQtTestingUtility() override;
 
   void addDefaultCTKWidgetEventTranslatorsToTranslator(pqTestUtility* util);
   void addDefaultCTKWidgetEventPlayersToPlayer(pqTestUtility* util);

--- a/Libs/QtTesting/ctkXMLEventObserver.h
+++ b/Libs/QtTesting/ctkXMLEventObserver.h
@@ -47,14 +47,14 @@ class CTK_QTTESTING_EXPORT ctkXMLEventObserver : public pqEventObserver
 
 public:
   ctkXMLEventObserver(QObject* testUtility);
-  ~ctkXMLEventObserver();
+  ~ctkXMLEventObserver() override;
 
-  virtual void setStream(QTextStream* stream);
+  void setStream(QTextStream* stream) override;
 
-  virtual void onRecordEvent(const QString& widget,
+  void onRecordEvent(const QString& widget,
                              const QString& command,
                              const QString& arguments,
-                             const int& eventType);
+                             const int& eventType) override;
 
   void recordApplicationSettings();
   void recordApplicationSetting(const QString& startElement,

--- a/Libs/QtTesting/ctkXMLEventSource.h
+++ b/Libs/QtTesting/ctkXMLEventSource.h
@@ -45,10 +45,10 @@ public:
   typedef pqEventSource Superclass;
 
   ctkXMLEventSource(QObject* testUtility);
-  ~ctkXMLEventSource();
+  ~ctkXMLEventSource() override;
 
-  virtual void setContent(const QString& xmlfilename);
-  int getNextEvent(QString& widget, QString& command, QString&arguments, int& eventType);
+  void setContent(const QString& xmlfilename) override;
+  int getNextEvent(QString& widget, QString& command, QString&arguments, int& eventType) override;
 
   void setRestoreSettingsAuto(bool value);
   bool restoreSettingsAuto() const;

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
@@ -44,8 +44,8 @@ class CTK_SCRIPTING_PYTHON_CORE_EXPORT ctkAbstractPythonManager : public QObject
 
 public:
   typedef QObject Superclass;
-  ctkAbstractPythonManager(QObject* _parent=NULL);
-  virtual ~ctkAbstractPythonManager();
+  ctkAbstractPythonManager(QObject* _parent=nullptr);
+  ~ctkAbstractPythonManager() override;
 
   /// Calling this function after mainContext() has been called at least once is a no-op.
   /// If not overridden calling this function, the default initialization flags are

--- a/Libs/Scripting/Python/Widgets/ctkPythonConsole.h
+++ b/Libs/Scripting/Python/Widgets/ctkPythonConsole.h
@@ -72,33 +72,33 @@ class CTK_SCRIPTING_PYTHON_WIDGETS_EXPORT ctkPythonConsole : public ctkConsole
   
 public:
   typedef ctkConsole Superclass;
-  ctkPythonConsole(QWidget* parentObject = 0);
-  virtual ~ctkPythonConsole();
+  ctkPythonConsole(QWidget* parentObject = nullptr);
+  ~ctkPythonConsole() override;
 
   /// Initialize
   void initialize(ctkAbstractPythonManager* newPythonManager);
 
   /// Returns the string used as primary prompt
-  virtual QString ps1() const;
+  QString ps1() const override;
 
   /// Set the string used as primary prompt
-  virtual void setPs1(const QString& newPs1);
+  void setPs1(const QString& newPs1) override;
 
   /// Returns the string used as secondary prompt
-  virtual QString ps2() const;
+  QString ps2() const override;
 
   /// Set the string used as secondary prompt
-  virtual void setPs2(const QString& newPs2);
+  void setPs2(const QString& newPs2) override;
 
 public Q_SLOTS:
 
 //  void executeScript(const QString&);
 
   /// Reset ps1 and ps2, clear the console and print the welcome message
-  virtual void reset();
+  void reset() override;
 
 protected:
-  virtual void executeCommand(const QString& command);
+  void executeCommand(const QString& command) override;
 
 private:
   Q_DECLARE_PRIVATE(ctkPythonConsole);

--- a/Libs/Testing/ctkTest.h
+++ b/Libs/Testing/ctkTest.h
@@ -106,7 +106,7 @@ static void mouseEvent(QTest::MouseAction action, QWidget *widget, Qt::MouseButt
 #if (QT_VERSION < 0x50000 && QT_GUI_LIB) || (QT_VERSION >= 0x50000 && QT_WIDGETS_LIB)
 
 // ----------------------------------------------------------------------------
-inline void mouseMove(QWidget *widget, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = 0,
+inline void mouseMove(QWidget *widget, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = nullptr,
                       QPoint pos = QPoint(), int delay=-1)
   { ctkTest::mouseEvent(QTest::MouseMove, widget, button, stateKey, pos, delay); }
 

--- a/Libs/Visualization/VTK/Core/ctkVTKConnection.h
+++ b/Libs/Visualization/VTK/Core/ctkVTKConnection.h
@@ -48,12 +48,12 @@ Q_OBJECT
 public:
   typedef QObject Superclass;
   explicit ctkVTKConnection(QObject* parent);
-  virtual ~ctkVTKConnection();
+  ~ctkVTKConnection() override ;
 
   ///
   QString shortDescription();
   static QString shortDescription(vtkObject* vtk_obj, unsigned long vtk_event,
-    const QObject* qt_obj, const char* qt_slot = 0);
+    const QObject* qt_obj, const char* qt_slot = nullptr);
 
   /// 
   /// Warning the slot must have its signature order:

--- a/Libs/Visualization/VTK/Core/ctkVTKErrorLogMessageHandler.cpp
+++ b/Libs/Visualization/VTK/Core/ctkVTKErrorLogMessageHandler.cpp
@@ -41,19 +41,19 @@ class ctkVTKOutputWindow : public vtkOutputWindow
 public:
   static ctkVTKOutputWindow *New();
   vtkTypeMacro(ctkVTKOutputWindow,vtkOutputWindow);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   ctkVTKOutputWindow()
     : MessageHandler(0)
   {}
   ~ctkVTKOutputWindow(){}
 
-  virtual void DisplayText(const char*) VTK_OVERRIDE;
-  virtual void DisplayErrorText(const char*) VTK_OVERRIDE;
-  virtual void DisplayWarningText(const char*) VTK_OVERRIDE;
-  virtual void DisplayGenericWarningText(const char*) VTK_OVERRIDE;
+  virtual void DisplayText(const char*) override;
+  virtual void DisplayErrorText(const char*) override;
+  virtual void DisplayWarningText(const char*) override;
+  virtual void DisplayGenericWarningText(const char*) override;
 
-  virtual void DisplayDebugText(const char*) VTK_OVERRIDE;
+  virtual void DisplayDebugText(const char*) override;
 
   QString parseText(const QString &text, ctkErrorLogContext &context);
 

--- a/Libs/Visualization/VTK/Core/ctkVTKErrorLogMessageHandler.h
+++ b/Libs/Visualization/VTK/Core/ctkVTKErrorLogMessageHandler.h
@@ -39,13 +39,13 @@ public:
   typedef ctkErrorLogAbstractMessageHandler Superclass;
 
   ctkVTKErrorLogMessageHandler();
-  virtual ~ctkVTKErrorLogMessageHandler();
+  ~ctkVTKErrorLogMessageHandler() override;
 
   static QString HandlerName;
 
-  virtual QString handlerName()const;
+  QString handlerName()const override;
 
-  virtual void setEnabledInternal(bool value);
+  void setEnabledInternal(bool value) override;
 
 protected:
   QScopedPointer<ctkVTKErrorLogMessageHandlerPrivate> d_ptr;

--- a/Libs/Visualization/VTK/Core/ctkVTKObjectEventsObserver.h
+++ b/Libs/Visualization/VTK/Core/ctkVTKObjectEventsObserver.h
@@ -60,8 +60,8 @@ Q_OBJECT
   Q_PROPERTY(bool strictTypeCheck READ strictTypeCheck WRITE setStrictTypeCheck)
 public:
   typedef QObject Superclass;
-  explicit ctkVTKObjectEventsObserver(QObject* parent = 0);
-  virtual ~ctkVTKObjectEventsObserver();
+  explicit ctkVTKObjectEventsObserver(QObject* parent = nullptr);
+  ~ctkVTKObjectEventsObserver() override;
 
   virtual void printAdditionalInfo();
 
@@ -127,7 +127,7 @@ public:
   /// \sa addConnection(), reconnection(), removeAllConnections(),
   /// containsConnection()
   int removeConnection(vtkObject* vtk_obj, unsigned long vtk_event = vtkCommand::NoEvent,
-                       const QObject* qt_obj = 0, const char* qt_slot = 0);
+                       const QObject* qt_obj = nullptr, const char* qt_slot = nullptr);
 
   ///
   /// Remove all the connections
@@ -159,7 +159,7 @@ public:
   /// \sa addConnection(), reconnection(), removeConnection(),
   /// removeAllConnections()
   bool containsConnection(vtkObject* vtk_obj, unsigned long vtk_event = vtkCommand::NoEvent,
-                          const QObject* qt_obj =0, const char* qt_slot =0)const;
+                          const QObject* qt_obj =nullptr, const char* qt_slot =nullptr)const;
 
 protected:
   QScopedPointer<ctkVTKObjectEventsObserverPrivate> d_ptr;

--- a/Libs/Visualization/VTK/Core/ctkVTKPythonQtWrapperFactory.h
+++ b/Libs/Visualization/VTK/Core/ctkVTKPythonQtWrapperFactory.h
@@ -34,9 +34,9 @@ class CTK_VISUALIZATION_VTK_CORE_EXPORT ctkVTKPythonQtWrapperFactory : public Py
 public:
   typedef PythonQtForeignWrapperFactory Superclass;
   ctkVTKPythonQtWrapperFactory();
-  virtual ~ctkVTKPythonQtWrapperFactory();
-  virtual PyObject* wrap(const QByteArray& classname, void *ptr);
-  virtual void* unwrap(const QByteArray& classname, PyObject* object);
+  ~ctkVTKPythonQtWrapperFactory() override;
+  PyObject* wrap(const QByteArray& classname, void *ptr) override;
+  void* unwrap(const QByteArray& classname, PyObject* object) override;
 };
 
 #endif

--- a/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferChart.h
+++ b/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferChart.h
@@ -74,9 +74,9 @@ public:
 
   bool IsProcessingColorTransferFunction() const;
 
-  bool MouseMoveEvent(const vtkContextMouseEvent &mouse) VTK_OVERRIDE;
-  bool MouseButtonPressEvent(const vtkContextMouseEvent& mouse) VTK_OVERRIDE;
-  bool MouseButtonReleaseEvent(const vtkContextMouseEvent &mouse) VTK_OVERRIDE;
+  bool MouseMoveEvent(const vtkContextMouseEvent &mouse) override;
+  bool MouseButtonPressEvent(const vtkContextMouseEvent& mouse) override;
+  bool MouseButtonReleaseEvent(const vtkContextMouseEvent &mouse) override;
 
 protected:
 

--- a/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferControlPointsItem.h
+++ b/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferControlPointsItem.h
@@ -38,9 +38,9 @@ public:
     vtkCompositeControlPointsItem)
   static vtkDiscretizableColorTransferControlPointsItem* New();
 
-  bool MouseMoveEvent(const vtkContextMouseEvent &mouse) VTK_OVERRIDE;
-  bool MouseButtonReleaseEvent(const vtkContextMouseEvent &mouse) VTK_OVERRIDE;
-  bool MouseButtonPressEvent(const vtkContextMouseEvent& mouse) VTK_OVERRIDE;
+  bool MouseMoveEvent(const vtkContextMouseEvent &mouse) override;
+  bool MouseButtonReleaseEvent(const vtkContextMouseEvent &mouse) override;
+  bool MouseButtonPressEvent(const vtkContextMouseEvent& mouse) override;
 
   bool IsProcessing();
   void StartProcessing();

--- a/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.h
+++ b/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.h
@@ -37,7 +37,7 @@ class vtkAlgorithmOutput;
 class CTK_VISUALIZATION_VTK_CORE_EXPORT vtkLightBoxRendererManager : public vtkObject
 {
   vtkTypeMacro(vtkLightBoxRendererManager,vtkObject);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   static vtkLightBoxRendererManager *New();
 
   void Initialize(vtkRenderWindow* renderWindow);

--- a/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.h
+++ b/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.h
@@ -176,7 +176,7 @@ class CTK_VISUALIZATION_VTK_CORE_EXPORT vtkLightBoxRendererManager : public vtkO
 protected:
 
   vtkLightBoxRendererManager();
-  ~vtkLightBoxRendererManager();
+  ~vtkLightBoxRendererManager() override;
   
 private:
   vtkLightBoxRendererManager(const vtkLightBoxRendererManager&); // Not implemented.

--- a/Libs/Visualization/VTK/Core/vtkScalarsToColorsContextItem.h
+++ b/Libs/Visualization/VTK/Core/vtkScalarsToColorsContextItem.h
@@ -63,7 +63,7 @@ public:
     const char* xAxisColumn, const char* yAxisColumn);
 
   /// Paint event.
-  bool Paint(vtkContext2D* painter) VTK_OVERRIDE;
+  bool Paint(vtkContext2D* painter) override;
 
   /// Get/Set the color of the current control point.
   void SetCurrentControlPointColor(const double rgb[3]);
@@ -108,7 +108,7 @@ protected:
 
 private:
   vtkScalarsToColorsContextItem();
-  ~vtkScalarsToColorsContextItem() VTK_OVERRIDE;
+  ~vtkScalarsToColorsContextItem() override;
 
   /// Cached geometry of the scene
   vtkVector2i LastSceneSize;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractMatrixWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractMatrixWidget.h
@@ -43,14 +43,14 @@ public:
 
   /// Constructors
   ctkVTKAbstractMatrixWidget(QWidget* parent);
-  virtual ~ctkVTKAbstractMatrixWidget();
+  ~ctkVTKAbstractMatrixWidget() override;
   vtkMatrix4x4* matrix()const;
 
 protected:
   void setMatrixInternal(vtkMatrix4x4* matrix);
 
-  virtual void setColumnCount(int newColumnCount);
-  virtual void setRowCount(int newRowCount);
+  void setColumnCount(int newColumnCount) override;
+  void setRowCount(int newRowCount) override;
 
 protected:
   QScopedPointer<ctkVTKAbstractMatrixWidgetPrivate> d_ptr;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.h
@@ -59,8 +59,8 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKAbstractView : public QWidget
 public:
 
   typedef QWidget Superclass;
-  explicit ctkVTKAbstractView(QWidget* parent = 0);
-  virtual ~ctkVTKAbstractView();
+  explicit ctkVTKAbstractView(QWidget* parent = nullptr);
+  ~ctkVTKAbstractView() override;
 
 public Q_SLOTS:
   /// Notify QVTKWidget that the view needs to be rendered.
@@ -217,10 +217,10 @@ public:
   /// \sa setMultiSamples()
   static int multiSamples();
 
-  virtual QSize minimumSizeHint()const;
-  virtual QSize sizeHint()const;
-  virtual bool hasHeightForWidth()const;
-  virtual int heightForWidth(int width)const;
+  QSize minimumSizeHint()const override;
+  QSize sizeHint()const override;
+  bool hasHeightForWidth()const override;
+  int heightForWidth(int width)const override;
 
 protected Q_SLOTS:
   void onRender();

--- a/Libs/Visualization/VTK/Widgets/ctkVTKChartView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKChartView.h
@@ -41,8 +41,8 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKChartView : public ctkVTKOpenGL
 
 public:
   typedef ctkVTKOpenGLNativeWidget Superclass;
-  ctkVTKChartView(QWidget* parent = 0);
-  virtual ~ctkVTKChartView();
+  ctkVTKChartView(QWidget* parent = nullptr);
+  ~ctkVTKChartView() override;
 
   /// Generic function to add a custom plot. \a plot is added into the chart
   /// Emit the plotAdded(vtkPlot*) signal.
@@ -103,7 +103,7 @@ Q_SIGNALS:
 protected:
   QScopedPointer<ctkVTKChartViewPrivate> d_ptr;
 
-  virtual void mouseDoubleClickEvent(QMouseEvent* event);
+  void mouseDoubleClickEvent(QMouseEvent* event) override;
   virtual void onChartUpdated();
   void chartBoundsToPlotBounds(double bounds[8], double plotBounds[4])const;
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKColorTransferFunction.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKColorTransferFunction.h
@@ -41,30 +41,30 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKColorTransferFunction: public c
 public:
   /// Please note that ctkVTKColorTransferFunction methods only work only if
   /// colorTransferFunction is set.
-  ctkVTKColorTransferFunction(QObject* parent = 0);
+  ctkVTKColorTransferFunction(QObject* parent = nullptr);
   ctkVTKColorTransferFunction(vtkColorTransferFunction* colorTransferFunction, 
-                              QObject* parent = 0);
-  virtual ~ctkVTKColorTransferFunction();
+                              QObject* parent = nullptr);
+  ~ctkVTKColorTransferFunction() override;
   
   /// Please note that controlPoint methods only works if you have at least one
   /// ControlPoint.
-  virtual ctkControlPoint* controlPoint(int index)const;
-  virtual QVariant value(qreal pos)const;
-  virtual int count()const;
-  virtual bool isDiscrete()const;
-  virtual bool isEditable()const;
+  ctkControlPoint* controlPoint(int index)const override;
+  QVariant value(qreal pos)const override;
+  int count()const override;
+  bool isDiscrete()const override;
+  bool isEditable()const override;
 
-  virtual void range(qreal& minRange, qreal& maxRange)const;
-  virtual QVariant minValue()const;
-  virtual QVariant maxValue()const;
+  void range(qreal& minRange, qreal& maxRange)const override;
+  QVariant minValue()const override;
+  QVariant maxValue()const override;
 
-  virtual int insertControlPoint(const ctkControlPoint& cp);
-  virtual int insertControlPoint(qreal pos);
+  int insertControlPoint(const ctkControlPoint& cp) override;
+  int insertControlPoint(qreal pos) override;
 
-  virtual void setControlPointPos(int index, qreal pos);
-  virtual void setControlPointValue(int index, const QVariant& value);
+  void setControlPointPos(int index, qreal pos) override;
+  void setControlPointValue(int index, const QVariant& value) override;
 
-  virtual void removeControlPoint( qreal pos );
+  void removeControlPoint( qreal pos ) override;
 
   void setColorTransferFunction(vtkColorTransferFunction* colorTransferFunction);
   vtkColorTransferFunction* colorTransferFunction()const;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDataSetArrayComboBox.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDataSetArrayComboBox.h
@@ -47,8 +47,8 @@ public:
   typedef QComboBox Superclass;
 
   /// Constructors
-  explicit ctkVTKDataSetArrayComboBox(QWidget* parent = 0);
-  virtual ~ctkVTKDataSetArrayComboBox();
+  explicit ctkVTKDataSetArrayComboBox(QWidget* parent = nullptr);
+  ~ctkVTKDataSetArrayComboBox() override;
 
   vtkAbstractArray* currentArray()const;
   QString currentArrayName()const;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDataSetModel.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDataSetModel.h
@@ -68,8 +68,8 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKDataSetModel
 public:
   typedef ctkVTKDataSetModel Self;
   typedef QStandardItemModel Superclass;
-  ctkVTKDataSetModel(QObject *parent=0);
-  virtual ~ctkVTKDataSetModel();
+  ctkVTKDataSetModel(QObject *parent=nullptr);
+  ~ctkVTKDataSetModel() override;
 
   enum AttributeType
     {
@@ -125,7 +125,7 @@ protected Q_SLOTS:
 
 protected:
 
-  ctkVTKDataSetModel(ctkVTKDataSetModelPrivate* pimpl, QObject *parent=0);
+  ctkVTKDataSetModel(ctkVTKDataSetModelPrivate* pimpl, QObject *parent=nullptr);
 
   virtual void insertArray(vtkAbstractArray* array, int location);
   virtual void insertArray(vtkAbstractArray* array, int location, int row);

--- a/Libs/Visualization/VTK/Widgets/ctkVTKHistogram.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKHistogram.h
@@ -43,26 +43,26 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKHistogram: public ctkHistogram
   Q_PROPERTY(QVariant minValue READ minValue)
   Q_PROPERTY(int numberOfBins READ numberOfBins WRITE setNumberOfBins)
 public:
-  ctkVTKHistogram(QObject* parent = 0);
-  ctkVTKHistogram(vtkDataArray* dataArray, QObject* parent = 0);
-  virtual ~ctkVTKHistogram();
+  ctkVTKHistogram(QObject* parent = nullptr);
+  ctkVTKHistogram(vtkDataArray* dataArray, QObject* parent = nullptr);
+  ~ctkVTKHistogram() override;
   
-  virtual ctkControlPoint* controlPoint(int index)const;
-  virtual QVariant value(qreal pos)const;
+  ctkControlPoint* controlPoint(int index)const override;
+  QVariant value(qreal pos)const override;
   /// Returns the number of bins. Returns 0 until build() is called.
-  virtual int count()const;
+  int count()const override;
 
   // Set/Get the range of the histogram.
   // Please note that after an array is set, the range will be reset.
   // \sa resetRange()
   virtual void setRange(qreal minRang, qreal maxRange);
-  virtual void range(qreal& minRange, qreal& maxRange)const;
+  void range(qreal& minRange, qreal& maxRange)const override;
 
   // Reset the range to the array's range.
   virtual void resetRange();
 
-  virtual QVariant minValue()const;
-  virtual QVariant maxValue()const;
+  QVariant minValue()const override;
+  QVariant maxValue()const override;
 
   Q_INVOKABLE void setDataArray(vtkDataArray* dataArray);
   Q_INVOKABLE vtkDataArray* dataArray()const;
@@ -75,9 +75,9 @@ public:
   int numberOfBins()const;
   void setNumberOfBins(int number);
 
-  Q_INVOKABLE virtual void removeControlPoint( qreal pos );
+  Q_INVOKABLE void removeControlPoint( qreal pos ) override;
 
-  Q_INVOKABLE virtual void build();
+  Q_INVOKABLE void build() override;
 protected:
   qreal indexToPos(int index)const;
   int posToIndex(qreal pos)const;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKOpenGLNativeWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKOpenGLNativeWidget.h
@@ -41,8 +41,8 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKOpenGLNativeWidget : public QVT
   Q_OBJECT
 public:
   typedef QVTKOpenGLNativeWidget Superclass;
-  explicit ctkVTKOpenGLNativeWidget(QWidget* parent = 0) : Superclass(parent){}
-  virtual ~ctkVTKOpenGLNativeWidget(){}
+  explicit ctkVTKOpenGLNativeWidget(QWidget* parent = nullptr) : Superclass(parent){}
+  ~ctkVTKOpenGLNativeWidget() override {}
 private:
   Q_DISABLE_COPY(ctkVTKOpenGLNativeWidget);
 };

--- a/Libs/Visualization/VTK/Widgets/ctkVTKPropertyWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKPropertyWidget.h
@@ -72,7 +72,7 @@ public:
 
   /// Construct a ctkVTKPropertyWidget with the given vtkProperty.
   ctkVTKPropertyWidget(vtkProperty* property, QWidget* parentWidget);
-  virtual ~ctkVTKPropertyWidget();
+  ~ctkVTKPropertyWidget() override;
 
   vtkProperty* property()const;
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
@@ -53,8 +53,8 @@ public:
   enum RotateDirection { PitchUp, PitchDown, RollLeft, RollRight, YawLeft, YawRight };
 
   typedef ctkVTKAbstractView Superclass;
-  explicit ctkVTKRenderView(QWidget* parent = 0);
-  virtual ~ctkVTKRenderView();
+  explicit ctkVTKRenderView(QWidget* parent = nullptr);
+  ~ctkVTKRenderView() override;
 
 public Q_SLOTS:
   /// Show/Hide Orientation widget
@@ -140,7 +140,7 @@ public:
 
   /// Set window interactor
   /// Reimplemented to propagate interaction to Orientation widget
-  virtual void setInteractor(vtkRenderWindowInteractor* interactor);
+  void setInteractor(vtkRenderWindowInteractor* interactor) override;
 
   /// Return pitch, roll or yaw increment (in degree)
   double pitchRollYawIncrement()const;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarBarWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarBarWidget.h
@@ -40,9 +40,9 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKScalarBarWidget : public QWidge
 
 public:
   /// Constructors
-  ctkVTKScalarBarWidget(QWidget* parentWidget = 0);
-  ctkVTKScalarBarWidget(vtkScalarBarWidget* scalarBar, QWidget* parentWidget = 0);
-  virtual ~ctkVTKScalarBarWidget();
+  ctkVTKScalarBarWidget(QWidget* parentWidget = nullptr);
+  ctkVTKScalarBarWidget(vtkScalarBarWidget* scalarBar, QWidget* parentWidget = nullptr);
+  ~ctkVTKScalarBarWidget() override;
 
   vtkScalarBarWidget* scalarBarWidget()const;
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsView.h
@@ -46,10 +46,10 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKScalarsToColorsView
 
 public:
   typedef ctkVTKChartView Superclass;
-  ctkVTKScalarsToColorsView(QWidget* parent = 0);
-  virtual ~ctkVTKScalarsToColorsView();
+  ctkVTKScalarsToColorsView(QWidget* parent = nullptr);
+  ~ctkVTKScalarsToColorsView() override;
 
-  Q_INVOKABLE virtual void addPlot(vtkPlot* plot);
+  Q_INVOKABLE void addPlot(vtkPlot* plot) override;
 
   Q_INVOKABLE vtkPlot* addLookupTable(vtkLookupTable* lut);
   Q_INVOKABLE vtkPlot* addColorTransferFunction(vtkColorTransferFunction* colorTF, bool editable = true);
@@ -91,7 +91,7 @@ public:
   Q_INVOKABLE void setPlotsUserBounds(double* bounds);
 
   /// Reimplemented to set the bounds to the plots as well
-  Q_INVOKABLE virtual void boundAxesToChartBounds();
+  Q_INVOKABLE void boundAxesToChartBounds() override;
 
 Q_SIGNALS:
   /// Emitted when a new function is set to the view

--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsWidget.h
@@ -62,8 +62,8 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKScalarsToColorsWidget : public 
   Q_PROPERTY(bool editColors READ editColors WRITE setEditColors)
   Q_PROPERTY(bool areTopWidgetsVisible READ areTopWidgetsVisible WRITE setTopWidgetsVisible)
 public:
-  ctkVTKScalarsToColorsWidget(QWidget* parent = 0);
-  virtual ~ctkVTKScalarsToColorsWidget();
+  ctkVTKScalarsToColorsWidget(QWidget* parent = nullptr);
+  ~ctkVTKScalarsToColorsWidget() override;
 
   Q_INVOKABLE ctkVTKScalarsToColorsView* view()const;
   Q_INVOKABLE vtkControlPointsItem* currentControlPointsItem()const;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.h
@@ -48,8 +48,8 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKSliceView : public ctkVTKAbstra
 public:
   /// Constructors
   typedef ctkVTKAbstractView Superclass;
-  explicit ctkVTKSliceView(QWidget* parent = 0);
-  virtual ~ctkVTKSliceView();
+  explicit ctkVTKSliceView(QWidget* parent = nullptr);
+  ~ctkVTKSliceView() override;
 
   /// The layout type determines how the image slices should be displayed
   /// within the different render view items.
@@ -71,11 +71,11 @@ public:
 
   /// Set background color
   /// \sa vtkLightBoxRendererManager::SetBackgroundColor
-  virtual void setBackgroundColor(const QColor& newBackgroundColor);
+  void setBackgroundColor(const QColor& newBackgroundColor) override;
 
   /// Get background color
   /// \sa setBackgroundColor();
-  virtual QColor backgroundColor()const;
+  QColor backgroundColor()const override;
 
   /// Get highlightedBox color
   /// \sa setHighlightedBoxColor();
@@ -137,7 +137,7 @@ Q_SIGNALS:
   void resized(const QSize& size);
 
 protected:
-  virtual bool eventFilter(QObject *object, QEvent *event);
+  bool eventFilter(QObject *object, QEvent *event) override;
 
 private:
   Q_DECLARE_PRIVATE(ctkVTKSliceView);

--- a/Libs/Visualization/VTK/Widgets/ctkVTKSurfaceMaterialPropertyWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKSurfaceMaterialPropertyWidget.h
@@ -41,7 +41,7 @@ public:
   /// Constructors
   ctkVTKSurfaceMaterialPropertyWidget(QWidget* parentWidget);
   ctkVTKSurfaceMaterialPropertyWidget(vtkProperty* property, QWidget* parentWidget);
-  virtual ~ctkVTKSurfaceMaterialPropertyWidget();
+  ~ctkVTKSurfaceMaterialPropertyWidget() override;
 
   vtkProperty* property()const;
 
@@ -54,13 +54,13 @@ protected Q_SLOTS:
 protected:
   QScopedPointer<ctkVTKSurfaceMaterialPropertyWidgetPrivate> d_ptr;
 
-  virtual void onColorChanged(const QColor& newColor);
-  virtual void onOpacityChanged(double newOpacity);
-  virtual void onAmbientChanged(double newAmbient);
-  virtual void onDiffuseChanged(double newDiffuse);
-  virtual void onSpecularChanged(double newSpecular);
-  virtual void onSpecularPowerChanged(double newSpecularPower);
-  virtual void onBackfaceCullingChanged(bool newBackfaceCulling);
+  void onColorChanged(const QColor& newColor) override;
+  void onOpacityChanged(double newOpacity) override;
+  void onAmbientChanged(double newAmbient) override;
+  void onDiffuseChanged(double newDiffuse) override;
+  void onSpecularChanged(double newSpecular) override;
+  void onSpecularPowerChanged(double newSpecularPower) override;
+  void onBackfaceCullingChanged(bool newBackfaceCulling) override;
 
 private:
   Q_DECLARE_PRIVATE(ctkVTKSurfaceMaterialPropertyWidget);

--- a/Libs/Visualization/VTK/Widgets/ctkVTKThumbnailView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKThumbnailView.h
@@ -39,8 +39,8 @@ public:
   typedef ctkVTKRenderView Superclass;
   
   /// Constructors
-  explicit ctkVTKThumbnailView(QWidget* parent = 0);
-  virtual ~ctkVTKThumbnailView();
+  explicit ctkVTKThumbnailView(QWidget* parent = nullptr);
+  ~ctkVTKThumbnailView() override;
 
   void setRendererToListen(vtkRenderer* renderer);
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKVolumePropertyWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKVolumePropertyWidget.h
@@ -49,8 +49,8 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKVolumePropertyWidget
   Q_PROPERTY(bool thresholdToggleVisibility READ isThresholdToggleVisible WRITE setThresholdToggleVisible)
 
 public:
-  ctkVTKVolumePropertyWidget(QWidget* parent = 0);
-  virtual ~ctkVTKVolumePropertyWidget();
+  ctkVTKVolumePropertyWidget(QWidget* parent = nullptr);
+  ~ctkVTKVolumePropertyWidget() override;
 
   vtkVolumeProperty* volumeProperty()const;
 

--- a/Libs/Widgets/ctkActionsWidget.h
+++ b/Libs/Widgets/ctkActionsWidget.h
@@ -57,8 +57,8 @@ class CTK_WIDGETS_EXPORT ctkActionsWidget : public QWidget
   /// \sa sortColumn(), setSortColumn()
   Q_PROPERTY(int sortColumn READ sortColumn WRITE setSortColumn)
 public:
-  explicit ctkActionsWidget(QWidget* parent = 0);
-  virtual ~ctkActionsWidget();
+  explicit ctkActionsWidget(QWidget* parent = nullptr);
+  ~ctkActionsWidget() override;
 
   /// Add an action into a specified group (or at top level if group is empty)
   /// An action can be added multiple times (in a different group). Once added,
@@ -125,8 +125,8 @@ class ctkSortFilterActionsProxyModel : public QSortFilterProxyModel
 {
   Q_OBJECT
 public:
-  explicit ctkSortFilterActionsProxyModel(QObject* parent=0);
-  virtual ~ctkSortFilterActionsProxyModel();
+  explicit ctkSortFilterActionsProxyModel(QObject* parent=nullptr);
+  ~ctkSortFilterActionsProxyModel() override;
 
   void setActionsWithNoShortcutVisible(bool);
   bool areActionsWithNoShortcutVisible()const;
@@ -135,7 +135,7 @@ public:
   bool areMenuActionsVisible()const;
 
 protected:
-  bool filterAcceptsRow(int source_row, const QModelIndex & source_parent) const;
+  bool filterAcceptsRow(int source_row, const QModelIndex & source_parent) const override;
   QScopedPointer<ctkSortFilterActionsProxyModelPrivate> d_ptr;
 
 private:
@@ -151,10 +151,10 @@ class ctkRichTextItemDelegate : public QStyledItemDelegate
 {
   Q_OBJECT
 protected:
-  virtual void paint(QPainter * painter, const QStyleOptionViewItem & option,
-             const QModelIndex & index) const;
-  virtual QSize sizeHint(const QStyleOptionViewItem & option,
-                         const QModelIndex & index)const;
+  void paint(QPainter * painter, const QStyleOptionViewItem & option,
+             const QModelIndex & index) const override;
+  QSize sizeHint(const QStyleOptionViewItem & option,
+                         const QModelIndex & index)const override;
 };
 
 #endif

--- a/Libs/Widgets/ctkAxesWidget.h
+++ b/Libs/Widgets/ctkAxesWidget.h
@@ -51,8 +51,8 @@ public :
     Posterior,
     };
   
-  ctkAxesWidget(QWidget *parent = 0);
-  virtual ~ctkAxesWidget();
+  ctkAxesWidget(QWidget *parent = nullptr);
+  ~ctkAxesWidget() override ;
 
   ///
   /// Current selected axis. None by default. 
@@ -97,16 +97,16 @@ public slots :
   QStringList axesLabels() const;
 
   /// Size hints
-  virtual QSize minimumSizeHint()const;
-  virtual QSize sizeHint()const;
-  virtual bool hasHeightForWidth()const;
-  virtual int heightForWidth(int width)const;
+  QSize minimumSizeHint()const override;
+  QSize sizeHint()const override;
+  bool hasHeightForWidth()const override;
+  int heightForWidth(int width)const override;
 
 protected: 
-  void paintEvent(QPaintEvent *);
-  void mousePressEvent(QMouseEvent *mouseEvent);
-  void mouseMoveEvent(QMouseEvent *mouseEvent);
-  void mouseReleaseEvent(QMouseEvent *mouseEvent);
+  void paintEvent(QPaintEvent *) override;
+  void mousePressEvent(QMouseEvent *mouseEvent) override;
+  void mouseMoveEvent(QMouseEvent *mouseEvent) override;
+  void mouseReleaseEvent(QMouseEvent *mouseEvent) override;
 
   QScopedPointer<ctkAxesWidgetPrivate> d_ptr;
 private :

--- a/Libs/Widgets/ctkBasePopupWidget.h
+++ b/Libs/Widgets/ctkBasePopupWidget.h
@@ -95,8 +95,8 @@ public:
   /// even if a parent is passed, the popup will display outside the possible
   /// parent layout.
   /// \sa baseWidget().
-  explicit ctkBasePopupWidget(QWidget* parent = 0);
-  virtual ~ctkBasePopupWidget();
+  explicit ctkBasePopupWidget(QWidget* parent = nullptr);
+  ~ctkBasePopupWidget() override ;
 
   /// Widget the popup is attached to. It opens right under \a baseWidget
   /// and if the ctkBasePopupWidget sizepolicy contains the growFlag/shrinkFlag,
@@ -183,7 +183,7 @@ Q_SIGNALS:
   void popupOpened(bool open);
 
 protected:
-  explicit ctkBasePopupWidget(ctkBasePopupWidgetPrivate* pimpl, QWidget* parent = 0);
+  explicit ctkBasePopupWidget(ctkBasePopupWidgetPrivate* pimpl, QWidget* parent = nullptr);
   QScopedPointer<ctkBasePopupWidgetPrivate> d_ptr;
   Q_PROPERTY(double effectAlpha READ effectAlpha WRITE setEffectAlpha DESIGNABLE false)
   Q_PROPERTY(QRect effectGeometry READ effectGeometry WRITE setEffectGeometry DESIGNABLE false)
@@ -192,8 +192,8 @@ protected:
   QRect effectGeometry()const;
 
   virtual void setBaseWidget(QWidget* baseWidget);
-  virtual bool event(QEvent* event);
-  virtual void paintEvent(QPaintEvent*);
+  bool event(QEvent* event) override;
+  void paintEvent(QPaintEvent*) override;
 
 protected Q_SLOTS:
   virtual void onEffectFinished();

--- a/Libs/Widgets/ctkButtonGroup.h
+++ b/Libs/Widgets/ctkButtonGroup.h
@@ -50,8 +50,8 @@ class CTK_WIDGETS_EXPORT ctkButtonGroup : public QButtonGroup
 {
   Q_OBJECT
 public:
-  explicit ctkButtonGroup(QObject *_parent = 0);
-  virtual ~ctkButtonGroup();
+  explicit ctkButtonGroup(QObject *_parent = nullptr);
+  ~ctkButtonGroup() override ;
 
 public Q_SLOTS:
   /// Check or uncheck the button.

--- a/Libs/Widgets/ctkCheckBox.h
+++ b/Libs/Widgets/ctkCheckBox.h
@@ -44,8 +44,8 @@ class CTK_WIDGETS_EXPORT ctkCheckBox : public QCheckBox
 public:
   typedef QCheckBox Superclass;
 
-  ctkCheckBox(QWidget *_parent = 0);
-  virtual ~ctkCheckBox();
+  ctkCheckBox(QWidget *_parent = nullptr);
+  ~ctkCheckBox() override ;
 
   void setIndicatorIcon(const QIcon& newIcon);
   QIcon indicatorIcon() const;

--- a/Libs/Widgets/ctkCheckBoxPixmaps.h
+++ b/Libs/Widgets/ctkCheckBoxPixmaps.h
@@ -76,8 +76,8 @@ public:
   ///
   /// The widget is used to retrieve the style of the checkboxes
   /// If the widget is 0 (not recommended) use the QApplication style.
-  ctkCheckBoxPixmaps(QWidget* parent = 0);
-  virtual ~ctkCheckBoxPixmaps();
+  ctkCheckBoxPixmaps(QWidget* parent = nullptr);
+  ~ctkCheckBoxPixmaps() override;
 
   ///
   /// Returns a pixmap for the given state .

--- a/Libs/Widgets/ctkCheckableComboBox.h
+++ b/Libs/Widgets/ctkCheckableComboBox.h
@@ -38,8 +38,8 @@ class CTK_WIDGETS_EXPORT ctkCheckableComboBox : public QComboBox
   Q_OBJECT
 
 public:
-  ctkCheckableComboBox(QWidget *parent = 0);
-  virtual ~ctkCheckableComboBox();
+  ctkCheckableComboBox(QWidget *parent = nullptr);
+  ~ctkCheckableComboBox() override ;
   
   /// Use setCheckableModel instead of setModel()
   Q_INVOKABLE QAbstractItemModel* checkableModel()const;
@@ -62,7 +62,7 @@ public:
   Q_INVOKABLE ctkCheckableModelHelper* checkableModelHelper()const;
   
   /// Reimplemented for internal reasons
-  bool eventFilter(QObject *o, QEvent *e);
+  bool eventFilter(QObject *o, QEvent *e) override ;
   
 Q_SIGNALS:
   void checkedIndexesChanged();
@@ -72,7 +72,7 @@ protected Q_SLOTS:
 
 protected:
   /// Reimplemented for internal reasons
-  virtual void paintEvent(QPaintEvent*);
+  void paintEvent(QPaintEvent*) override ;
 
 protected:
   QScopedPointer<ctkCheckableComboBoxPrivate> d_ptr;

--- a/Libs/Widgets/ctkCheckableHeaderView.h
+++ b/Libs/Widgets/ctkCheckableHeaderView.h
@@ -75,8 +75,8 @@ class CTK_WIDGETS_EXPORT ctkCheckableHeaderView : public QHeaderView
 {
   Q_OBJECT;
 public:
-  ctkCheckableHeaderView(Qt::Orientation orient, QWidget *parent=0);
-  virtual ~ctkCheckableHeaderView();
+  ctkCheckableHeaderView(Qt::Orientation orient, QWidget *parent=nullptr);
+  ~ctkCheckableHeaderView() override ;
 
   ///
   /// When setting the model, if PropagateToItems is true (by default), the check
@@ -85,10 +85,10 @@ public:
   /// (done by myView.setHeader(myCheckableHeaderView)), you can call
   /// myModel.setHeaderData(0, Qt::Horizontal, Qt::Checked, Qt::CheckStateRole)
   /// or myCheckableHeaderView->setCheckState(0, Qt::Checked)
-  virtual void setModel(QAbstractItemModel *model);
+  void setModel(QAbstractItemModel *model) override ;
 
   /// Reimplemented for internal reasons
-  virtual void setRootIndex(const QModelIndex &index);
+  void setRootIndex(const QModelIndex &index) override ;
 
   ///
   ///  Used to listen for focus in/out events.
@@ -96,7 +96,7 @@ public:
   /// \param e Event specific data.
   /// \return
   ///   True if the event should be filtered out.
-  virtual bool eventFilter(QObject *object, QEvent *e);
+  bool eventFilter(QObject *object, QEvent *e) override ;
   
   
   ///
@@ -127,8 +127,8 @@ private Q_SLOTS:
 protected:
   virtual void updateHeaderPixmaps(int first, int last);
   virtual void initStyleSectionOption(QStyleOptionHeader *option, int section, QRect rect)const;
-  virtual void mousePressEvent(QMouseEvent *e);
-  virtual void mouseReleaseEvent(QMouseEvent *e);
+  void mousePressEvent(QMouseEvent *e) override ;
+  void mouseReleaseEvent(QMouseEvent *e) override ;
   bool isPointInCheckBox(int section, QPoint pos)const;
 
 protected:

--- a/Libs/Widgets/ctkCheckableModelHelper.h
+++ b/Libs/Widgets/ctkCheckableModelHelper.h
@@ -73,8 +73,8 @@ class CTK_WIDGETS_EXPORT ctkCheckableModelHelper : public QObject
   Q_PROPERTY(Qt::CheckState defaultCheckState READ defaultCheckState WRITE setDefaultCheckState);
 
 public:
-  ctkCheckableModelHelper(Qt::Orientation orientation, QObject *parent=0);
-  virtual ~ctkCheckableModelHelper();
+  ctkCheckableModelHelper(Qt::Orientation orientation, QObject *parent=nullptr);
+  ~ctkCheckableModelHelper() override ;
 
   Qt::Orientation orientation()const;
 

--- a/Libs/Widgets/ctkCheckablePushButton.h
+++ b/Libs/Widgets/ctkCheckablePushButton.h
@@ -56,9 +56,9 @@ class CTK_WIDGETS_EXPORT ctkCheckablePushButton : public ctkPushButton
   Q_PROPERTY(bool checkBoxUserCheckable READ isCheckBoxUserCheckable WRITE setCheckBoxUserCheckable)
 
 public:
-  ctkCheckablePushButton(QWidget *parent = 0);
-  ctkCheckablePushButton(const QString& text, QWidget *parent = 0);
-  virtual ~ctkCheckablePushButton();
+  ctkCheckablePushButton(QWidget *parent = nullptr);
+  ctkCheckablePushButton(const QString& text, QWidget *parent = nullptr);
+  ~ctkCheckablePushButton() override;
 
   /// Set the alignment of the indicator (arrow) on the button,
   /// Qt::AlignLeft|Qt::AlignVCenter by default.
@@ -82,9 +82,9 @@ Q_SIGNALS:
 
 protected:
   /// Reimplemented for internal reasons
-  virtual void mousePressEvent(QMouseEvent* event);
+  void mousePressEvent(QMouseEvent* event) override;
   /// Reimplemented for internal reasons
-  virtual bool hitButton(const QPoint & pos) const;
+  bool hitButton(const QPoint & pos) const override;
 
 private:
   Q_DECLARE_PRIVATE(ctkCheckablePushButton);

--- a/Libs/Widgets/ctkCollapsibleButton.h
+++ b/Libs/Widgets/ctkCollapsibleButton.h
@@ -66,9 +66,9 @@ class CTK_WIDGETS_EXPORT ctkCollapsibleButton : public QAbstractButton
   Q_PROPERTY(Qt::Alignment indicatorAlignment READ indicatorAlignment WRITE setIndicatorAlignment)
 
 public:
-  ctkCollapsibleButton(QWidget *parent = 0);
-  ctkCollapsibleButton(const QString& text, QWidget *parent = 0);
-  virtual ~ctkCollapsibleButton();
+  ctkCollapsibleButton(QWidget *parent = nullptr);
+  ctkCollapsibleButton(const QString& text, QWidget *parent = nullptr);
+  ~ctkCollapsibleButton() override ;
 
   /// 
   /// Property that describes if the widget is collapsed or not.
@@ -126,24 +126,24 @@ public:
 
   /// 
   /// Reimplemented for internal reasons
-  virtual QSize minimumSizeHint()const;
+  QSize minimumSizeHint()const override;
 
   /// 
   /// Reimplemented for internal reasons
-  virtual QSize sizeHint()const;
+  QSize sizeHint()const override;
 
   /// Reimplemented to update the size of the button in case of font/style
   /// change
-  virtual bool event(QEvent* event);
+  bool event(QEvent* event) override;
 
   /// Reimplemented for internal reasons
   /// Catch when a child widget's visibility is externally changed
-  virtual bool eventFilter(QObject* child, QEvent* e);
+  bool eventFilter(QObject* child, QEvent* e) override;
   
   /// Reimplemented for internal reasons
   /// Don't process Show/Hide events of children when it is
   /// ctkCollapsibleButton that generate them.
-  virtual void setVisible(bool);
+  void setVisible(bool) override;
 Q_SIGNALS:
   /// 
   /// Signal emitted when the widget is collapsed or expanded.
@@ -157,12 +157,12 @@ protected Q_SLOTS:
   virtual void onToggled(bool clicked = false);
 
 protected:
-  virtual void paintEvent(QPaintEvent*);
+  void paintEvent(QPaintEvent*) override;
   //virtual void mousePressEvent(QMouseEvent* event);
   //virtual void mouseReleaseEvent(QMouseEvent* event);
-  virtual void childEvent(QChildEvent* c);
+  void childEvent(QChildEvent* c) override;
 
-  virtual bool hitButton(const QPoint & pos) const;
+  bool hitButton(const QPoint & pos) const override;
   /// Compute the size hint of the head button only. The sizehint depends on the text.
   virtual QSize buttonSizeHint() const;
 

--- a/Libs/Widgets/ctkCollapsibleGroupBox.h
+++ b/Libs/Widgets/ctkCollapsibleGroupBox.h
@@ -45,9 +45,9 @@ class CTK_WIDGETS_EXPORT ctkCollapsibleGroupBox : public QGroupBox
   Q_PROPERTY(int collapsedHeight READ collapsedHeight WRITE setCollapsedHeight)
 
 public:
-  ctkCollapsibleGroupBox(QWidget* parent = 0);
-  ctkCollapsibleGroupBox(const QString& title, QWidget* parent = 0);
-  virtual ~ctkCollapsibleGroupBox();
+  ctkCollapsibleGroupBox(QWidget* parent = nullptr);
+  ctkCollapsibleGroupBox(const QString& title, QWidget* parent = nullptr);
+  ~ctkCollapsibleGroupBox() override ;
   
   /// Utility function to collapse the groupbox
   /// Collapse(close) the group box if collapse is true, expand(open)
@@ -65,10 +65,10 @@ public:
 
   /// Reimplemented for internal reasons
   /// Catch when a child widget's visibility is externally changed
-  virtual bool eventFilter(QObject* child, QEvent* e);
+  bool eventFilter(QObject* child, QEvent* e) override;
 
   /// Reimplemented for internal reasons
-  virtual void setVisible(bool show);
+  void setVisible(bool show) override;
 protected Q_SLOTS:
   /// called when the arrow indicator is clicked
   /// users can call it programatically by calling setChecked(bool)
@@ -77,7 +77,7 @@ protected Q_SLOTS:
 protected:
   QScopedPointer<ctkCollapsibleGroupBoxPrivate> d_ptr;
   /// reimplemented for internal reasons
-  virtual void childEvent(QChildEvent*);
+  void childEvent(QChildEvent*) override;
 
 #if QT_VERSION < 0x040600
   virtual void paintEvent(QPaintEvent*);

--- a/Libs/Widgets/ctkColorDialog.h
+++ b/Libs/Widgets/ctkColorDialog.h
@@ -41,9 +41,9 @@ public:
   /// Constructor
   /// By default, behaves like a QColorDialog
   /// \sa QColorDialog()
-  explicit ctkColorDialog(QWidget* parent = 0);
-  explicit ctkColorDialog(const QColor& initial, QWidget* parent = 0);
-  virtual ~ctkColorDialog();
+  explicit ctkColorDialog(QWidget* parent = nullptr);
+  explicit ctkColorDialog(const QColor& initial, QWidget* parent = nullptr);
+  ~ctkColorDialog() override ;
 
   /// Add an extra widget under the file format combobox. If a label is
   /// given, it will appear in the first column.
@@ -89,7 +89,7 @@ public:
   /// The \a options argument allows you to customize the dialog;
   /// QColorDialog::DontUseNativeDialog is forced
   Q_INVOKABLE static QColor getColor(const QColor &initial, QWidget *parent,
-                         const QString &title, ColorDialogOptions options = 0);
+                         const QString &title, ColorDialogOptions options = nullptr);
   /// Return the last selected color name if any. getColorName() call is only
   /// valid after a getColor() call.
   /// \sa getColor
@@ -100,14 +100,14 @@ public:
   /// the widget whenever a QColor is changed, typically: SIGNAL(currentColorChanged(QColor)). It
   /// is internally connected to set the current color of the dialog
   Q_INVOKABLE static inline void addDefaultTab(QWidget* widget, const QString& label,
-                                   const char* colorSignal = 0,
-                                   const char* nameSignal = 0);
+                                   const char* colorSignal = nullptr,
+                                   const char* nameSignal = nullptr);
   /// Same as addDefaultTab, in addition, \a tabIndex control the tab index of the widget.
   /// If index is -1, the tab is appended (same as addDefaultTab). The last
   /// tab added with an index of 0 will be the first tab open
   Q_INVOKABLE static void insertDefaultTab(int tabIndex, QWidget* widget, const QString& label,
-                               const char* colorSignal = 0,
-                               const char* nameSignal = 0);
+                               const char* colorSignal = nullptr,
+                               const char* nameSignal = nullptr);
   /// Index of the tab to make default (active when getColor is called).
   /// -1 for the "Basic Colors", it's the default behavior
   Q_INVOKABLE static void setDefaultTab(int index);

--- a/Libs/Widgets/ctkColorPickerButton.h
+++ b/Libs/Widgets/ctkColorPickerButton.h
@@ -66,19 +66,19 @@ public:
   Q_DECLARE_FLAGS(ColorDialogOptions, ColorDialogOption)
 
   /// By default, the color is black
-  explicit ctkColorPickerButton(QWidget* parent = 0);
+  explicit ctkColorPickerButton(QWidget* parent = nullptr);
 
   /// By default, the color is black. The text will be shown on the button if
   /// displayColorName is false, otherwise the color name is shown.
   /// \sa QPushButton::setText
-  explicit ctkColorPickerButton(const QString& text, QWidget* parent = 0 );
+  explicit ctkColorPickerButton(const QString& text, QWidget* parent = nullptr );
 
   /// The text will be shown on the button if
   /// displayColorName is false, otherwise the color name is shown.
   /// \sa setColor, QPushButton::setText
-  explicit ctkColorPickerButton(const QColor& color, const QString & text, QWidget* parent = 0 );
+  explicit ctkColorPickerButton(const QColor& color, const QString & text, QWidget* parent = nullptr );
 
-  virtual ~ctkColorPickerButton();
+  ~ctkColorPickerButton() override ;
 
   /// Current selected color
   QColor color()const;
@@ -107,7 +107,7 @@ public:
   ///
   /// Reimplemented to return a toolbutton sizehint when no text is displayed
   /// in the button.
-  virtual QSize sizeHint()const;
+  QSize sizeHint()const override;
 
 public Q_SLOTS:
   ///
@@ -137,7 +137,7 @@ protected Q_SLOTS:
   void onToggled(bool change = true);
 
 protected:
-  virtual void paintEvent(QPaintEvent* event);
+  void paintEvent(QPaintEvent* event) override;
 
   QScopedPointer<ctkColorPickerButtonPrivate> d_ptr;
 private :

--- a/Libs/Widgets/ctkComboBox.h
+++ b/Libs/Widgets/ctkComboBox.h
@@ -58,8 +58,8 @@ class CTK_WIDGETS_EXPORT ctkComboBox : public QComboBox
   Q_ENUMS(ScrollEffect);
 public:
   /// Constructor, build a ctkComboBox that behaves like QComboBox.
-  explicit ctkComboBox(QWidget* parent = 0);
-  virtual ~ctkComboBox();
+  explicit ctkComboBox(QWidget* parent = nullptr);
+  ~ctkComboBox() override ;
 
   /// Empty by default (same behavior as QComboBox)
   void setDefaultText(const QString&);
@@ -101,9 +101,9 @@ public:
   void setScrollWheelEffect(ScrollEffect scroll);
 
   /// Reimplemented for internal reasons
-  virtual QSize minimumSizeHint()const;
+  QSize minimumSizeHint()const override ;
   /// Reimplemented for internal reasons
-  virtual QSize sizeHint()const;
+  QSize sizeHint()const override;
 
   /// Get current item's user data as string
   QString currentUserDataAsString()const;
@@ -114,9 +114,9 @@ public slots:
 
 protected:
   /// Reimplemented for internal reasons
-  virtual void paintEvent(QPaintEvent* event);
-  virtual void changeEvent(QEvent* event);
-  virtual void wheelEvent(QWheelEvent* event);
+  void paintEvent(QPaintEvent* event) override;
+  void changeEvent(QEvent* event) override;
+  void wheelEvent(QWheelEvent* event) override;
 
 protected:
   QScopedPointer<ctkComboBoxPrivate> d_ptr;

--- a/Libs/Widgets/ctkConsole.h
+++ b/Libs/Widgets/ctkConsole.h
@@ -106,9 +106,9 @@ public:
   };
   Q_DECLARE_FLAGS(RunFileOptions, RunFileOption)
 
-  ctkConsole(QWidget* parentObject = 0);
+  ctkConsole(QWidget* parentObject = nullptr);
   typedef QWidget Superclass;
-  virtual ~ctkConsole();
+  ~ctkConsole() override;
 
   /// Returns the current formatting that will be used by printMessage()
   QTextCharFormat getFormat() const;

--- a/Libs/Widgets/ctkCoordinatesWidget.h
+++ b/Libs/Widgets/ctkCoordinatesWidget.h
@@ -77,8 +77,8 @@ class CTK_WIDGETS_EXPORT ctkCoordinatesWidget : public QWidget
   Q_PROPERTY(bool readOnly READ isReadOnly WRITE setReadOnly)
 
 public:
-  explicit ctkCoordinatesWidget(QWidget* parent = 0);
-  virtual ~ctkCoordinatesWidget();
+  explicit ctkCoordinatesWidget(QWidget* parent = nullptr);
+  ~ctkCoordinatesWidget() override;
 
   /// Set/Get the dimension of the point
   /// The default dimension is 3

--- a/Libs/Widgets/ctkDirectoryButton.h
+++ b/Libs/Widgets/ctkDirectoryButton.h
@@ -90,14 +90,14 @@ public:
   /// Constructor
   /// Creates a default ctkDirectoryButton that points to the application
   /// current directory.
-  ctkDirectoryButton(QWidget * parent = 0);
+  ctkDirectoryButton(QWidget * parent = nullptr);
   /// Constructor
   /// Creates a ctkDirectoryButton that points to the given directory path
-  ctkDirectoryButton(const QString& directory, QWidget * parent = 0);
-  ctkDirectoryButton(const QIcon& icon, const QString& directory, QWidget * parent = 0);
+  ctkDirectoryButton(const QString& directory, QWidget * parent = nullptr);
+  ctkDirectoryButton(const QIcon& icon, const QString& directory, QWidget * parent = nullptr);
 
   /// Destructor
-  virtual ~ctkDirectoryButton();
+  ~ctkDirectoryButton() override ;
 
   /// Set/get the current directory
   /// If path is empty, the program's working directory, ("."), is used.

--- a/Libs/Widgets/ctkDoubleRangeSlider.h
+++ b/Libs/Widgets/ctkDoubleRangeSlider.h
@@ -59,14 +59,14 @@ public:
   
   /// Constructor, builds a ctkDoubleRangeSlider whose default values are the same
   /// as ctkRangeSlider.
-  ctkDoubleRangeSlider( Qt::Orientation o, QWidget* par= 0 );
+  ctkDoubleRangeSlider( Qt::Orientation o, QWidget* par= nullptr );
 
   /// Constructor, builds a ctkDoubleRangeSlider whose default values are the same
   /// as ctkRangeSlider.
-  ctkDoubleRangeSlider( QWidget* par = 0 );
+  ctkDoubleRangeSlider( QWidget* par = nullptr );
   
   /// Destructor
-  virtual ~ctkDoubleRangeSlider();
+  ~ctkDoubleRangeSlider() override ;
   
   /// 
   /// This property holds the single step.

--- a/Libs/Widgets/ctkDoubleSlider.h
+++ b/Libs/Widgets/ctkDoubleSlider.h
@@ -64,12 +64,12 @@ public:
 
   /// Constructors, builds a slider whose default values are the same as
   /// QSlider (vertical by default).
-  explicit ctkDoubleSlider(QWidget* parent = 0);
+  explicit ctkDoubleSlider(QWidget* parent = nullptr);
   /// Constructors, builds a slider whose default values are the same as
   /// QSlider (vertical by default).
-  explicit ctkDoubleSlider(Qt::Orientation orient, QWidget* parent = 0);
+  explicit ctkDoubleSlider(Qt::Orientation orient, QWidget* parent = nullptr);
   /// Destructor
-  virtual ~ctkDoubleSlider();
+  ~ctkDoubleSlider() override ;
 
   /// 
   /// This property holds the sliders's minimum value.
@@ -196,7 +196,7 @@ public:
   void setHandleToolTip(const QString& toolTip);
 
   /// Reimplemented for internal reasons (handle tooltip).
-  virtual bool eventFilter(QObject*, QEvent*);
+  bool eventFilter(QObject*, QEvent*) override ;
 
   /// Return a pointer to the QSlider used internally.
   /// Use with caution.

--- a/Libs/Widgets/ctkDoubleSpinBox.h
+++ b/Libs/Widgets/ctkDoubleSpinBox.h
@@ -162,9 +162,9 @@ public:
 
   /// Constructor, creates a ctkDoubleSpinBox. The look and feel
   /// are the same as of a QDoubleSpinBox
-  explicit ctkDoubleSpinBox(QWidget* parent = 0);
-  explicit ctkDoubleSpinBox(ctkDoubleSpinBox::SetMode mode, QWidget* parent = 0);
-  virtual ~ctkDoubleSpinBox();
+  explicit ctkDoubleSpinBox(QWidget* parent = nullptr);
+  explicit ctkDoubleSpinBox(ctkDoubleSpinBox::SetMode mode, QWidget* parent = nullptr);
+  ~ctkDoubleSpinBox() override;
 
   /// Get the spinbox current value
   /// \sa setValue(), cleanText()
@@ -286,10 +286,10 @@ public:
 
   /// Reimplemented to respect the sizeHintPolicy property value.
   /// \sa sizeHintPolicy
-  virtual QSize sizeHint()const;
+  QSize sizeHint()const override;
   /// Reimplemented to respect the sizeHintPolicy property value.
   /// \sa sizeHintPolicy
-  virtual QSize minimumSizeHint()const;
+  QSize minimumSizeHint()const override;
 
 public Q_SLOTS:
   /// Set the value of the spinbox following the current mode.
@@ -336,9 +336,9 @@ protected:
   ctkDoubleSpinBoxPrivate* const d_ptr;
 
   /// Reimplemented to support shortcuts.
-  virtual void keyPressEvent(QKeyEvent* event);
+  void keyPressEvent(QKeyEvent* event) override;
   /// Reimplemented to support shortcuts on the double spinbox.
-  virtual bool eventFilter(QObject *obj, QEvent *event);
+  bool eventFilter(QObject *obj, QEvent *event) override;
 
   friend class ctkCoordinatesWidgetPrivate;
 private:

--- a/Libs/Widgets/ctkDynamicSpacer.h
+++ b/Libs/Widgets/ctkDynamicSpacer.h
@@ -42,8 +42,8 @@ class CTK_WIDGETS_EXPORT ctkDynamicSpacer : public QWidget
   Q_PROPERTY(bool active READ isActive WRITE setActive);
 public:
   /// Constructor, builds a ctkDynamicSpacer, inactive by default
-  ctkDynamicSpacer(QWidget *parent = 0);
-  virtual ~ctkDynamicSpacer();
+  ctkDynamicSpacer(QWidget *parent = nullptr);
+  ~ctkDynamicSpacer() override;
 
   /// The active size policy of the spacer. By default the same as QWidget
   QSizePolicy activeSizePolicy() const;

--- a/Libs/Widgets/ctkErrorLogModel.h
+++ b/Libs/Widgets/ctkErrorLogModel.h
@@ -49,8 +49,8 @@ class CTK_WIDGETS_EXPORT ctkErrorLogModel : public QSortFilterProxyModel
 public:
   typedef QSortFilterProxyModel Superclass;
   typedef ctkErrorLogModel Self;
-  explicit ctkErrorLogModel(QObject* parentObject = 0);
-  virtual ~ctkErrorLogModel();
+  explicit ctkErrorLogModel(QObject* parentObject = nullptr);
+  ~ctkErrorLogModel() override;
 
   enum ColumnsIds
     {

--- a/Libs/Widgets/ctkErrorLogWidget.h
+++ b/Libs/Widgets/ctkErrorLogWidget.h
@@ -39,8 +39,8 @@ class CTK_WIDGETS_EXPORT ctkErrorLogWidget : public QWidget
   Q_OBJECT
 public:
   typedef QWidget Superclass;
-  explicit ctkErrorLogWidget(QWidget* parentWidget = 0);
-  virtual ~ctkErrorLogWidget();
+  explicit ctkErrorLogWidget(QWidget* parentWidget = nullptr);
+  ~ctkErrorLogWidget() override;
 
   ctkErrorLogModel* errorLogModel()const;
   Q_INVOKABLE void setErrorLogModel(ctkErrorLogModel * newErrorLogModel);

--- a/Libs/Widgets/ctkExpandButton.h
+++ b/Libs/Widgets/ctkExpandButton.h
@@ -50,8 +50,8 @@ public:
   /// Superclass typedef
   typedef QToolButton Superclass;
 
-  explicit ctkExpandButton(QWidget *_parent = 0);
-  virtual ~ctkExpandButton();
+  explicit ctkExpandButton(QWidget *_parent = nullptr);
+  ~ctkExpandButton() override ;
 
   void setMirrorOnExpand(bool newBehavior);
   bool mirrorOnExpand() const;
@@ -59,13 +59,13 @@ public:
   void setOrientation(Qt::Orientation newOrientation);
   Qt::Orientation orientation() const;
 
-  virtual QSize sizeHint() const;
+  QSize sizeHint() const override ;
 
 private Q_SLOTS:
   void updateIcon(Qt::LayoutDirection newDirection);
 
 protected:
-  virtual void nextCheckState();
+  void nextCheckState() override ;
 
 protected:
   QScopedPointer<ctkExpandButtonPrivate> d_ptr;

--- a/Libs/Widgets/ctkExpandableWidget.h
+++ b/Libs/Widgets/ctkExpandableWidget.h
@@ -70,8 +70,8 @@ class CTK_WIDGETS_EXPORT ctkExpandableWidget: public QFrame
 public:
   typedef QFrame Superclass;
 
-  ctkExpandableWidget(QWidget *parent=0);
-  virtual ~ctkExpandableWidget();
+  ctkExpandableWidget(QWidget *parent=nullptr);
+  ~ctkExpandableWidget() override;
 
   void setOrientations(Qt::Orientations orientations);
   Qt::Orientations orientations()const;
@@ -82,8 +82,8 @@ public:
   void setSizeGripMargins(QSize margins);
   QSize sizeGripMargins()const;
 
-  virtual QSize minimumSizeHint()const;
-  virtual QSize sizeHint()const;
+  QSize minimumSizeHint()const override;
+  QSize sizeHint()const override;
 
 public Q_SLOTS:
   /// Recompute the size hint of the widget and resize with regard to the
@@ -93,8 +93,8 @@ public Q_SLOTS:
 protected:
   QScopedPointer<ctkExpandableWidgetPrivate> d_ptr;
 
-  virtual void resizeEvent(QResizeEvent* event);
-  virtual bool event(QEvent* event);
+  void resizeEvent(QResizeEvent* event) override;
+  bool event(QEvent* event) override;
 
 private:
   Q_DECLARE_PRIVATE(ctkExpandableWidget);

--- a/Libs/Widgets/ctkFileDialog.h
+++ b/Libs/Widgets/ctkFileDialog.h
@@ -50,11 +50,11 @@ public:
   /// Constructor
   /// By default, behaves like a QFileDialog
   /// \sa QFileDialog()
-  explicit ctkFileDialog(QWidget *parent = 0,
+  explicit ctkFileDialog(QWidget *parent = nullptr,
               const QString &caption = QString(),
               const QString &directory = QString(),
               const QString &filter = QString());
-  virtual ~ctkFileDialog();
+  ~ctkFileDialog() override ;
   
   /// Add an extra widget under the file format combobox. If a label is
   /// given, it will appear in the first column.
@@ -80,7 +80,7 @@ public:
   QAbstractItemView::SelectionMode selectionMode() const;
 
   /// Internally used
-  bool eventFilter(QObject *obj, QEvent *event);
+  bool eventFilter(QObject *obj, QEvent *event) override ;
 
 public Q_SLOTS:
   /// Can be used to prevent the accept button to be enabled. It's typically
@@ -104,7 +104,7 @@ protected:
   QScopedPointer<ctkFileDialogPrivate> d_ptr;
 
   /// Reimplemented to override the return key behavior
-  virtual void accept();
+  void accept() override ;
 
 private:
   Q_DECLARE_PRIVATE(ctkFileDialog);

--- a/Libs/Widgets/ctkFittedTextBrowser.h
+++ b/Libs/Widgets/ctkFittedTextBrowser.h
@@ -48,8 +48,8 @@ class CTK_WIDGETS_EXPORT ctkFittedTextBrowser : public QTextBrowser
 
 
 public:
-  ctkFittedTextBrowser(QWidget* parent = 0);
-  virtual ~ctkFittedTextBrowser();
+  ctkFittedTextBrowser(QWidget* parent = nullptr);
+  ~ctkFittedTextBrowser() override ;
 
   /// Show only first line/the full text.
   /// Only has effect if collapsible = true.
@@ -73,11 +73,11 @@ public:
   Q_INVOKABLE QString collapsibleText() const;
 
   /// Reimplemented for internal reasons
-  virtual QSize sizeHint() const;
+  QSize sizeHint() const override ;
   /// Reimplemented for internal reasons
-  virtual QSize minimumSizeHint() const;
+  QSize minimumSizeHint() const override;
   /// Reimplemented for internal reasons
-  virtual int heightForWidth(int width) const;
+  int heightForWidth(int width) const override;
 
 public Q_SLOTS:
 
@@ -111,7 +111,7 @@ protected Q_SLOTS:
 protected:
   QScopedPointer<ctkFittedTextBrowserPrivate> d_ptr;
 
-  virtual void resizeEvent(QResizeEvent* e);
+  void resizeEvent(QResizeEvent* e) override;
 
 private:
   Q_DECLARE_PRIVATE(ctkFittedTextBrowser);

--- a/Libs/Widgets/ctkFlowLayout.h
+++ b/Libs/Widgets/ctkFlowLayout.h
@@ -74,10 +74,10 @@ class CTK_WIDGETS_EXPORT ctkFlowLayout : public QLayout
 
 public:
   typedef QLayout Superclass;
-  explicit ctkFlowLayout(Qt::Orientation orientation, QWidget* parent = 0);
+  explicit ctkFlowLayout(Qt::Orientation orientation, QWidget* parent = nullptr);
   explicit ctkFlowLayout(QWidget* parent);
   explicit ctkFlowLayout();
-  virtual ~ctkFlowLayout();
+  ~ctkFlowLayout() override ;
 
   void setOrientation(Qt::Orientation orientation);
   Qt::Orientation orientation()const;
@@ -112,16 +112,16 @@ public:
   virtual int widthForHeight(int) const;
 
   /// Reimplemented for internal reasons
-  virtual void addItem(QLayoutItem *item);
-  virtual Qt::Orientations expandingDirections() const;
-  virtual bool hasHeightForWidth() const;
-  virtual int heightForWidth(int) const;
-  virtual int count() const;
-  virtual QLayoutItem *itemAt(int index) const;
-  virtual QSize minimumSize() const;
-  virtual void setGeometry(const QRect &rect);
-  virtual QSize sizeHint() const;
-  virtual QLayoutItem *takeAt(int index);
+  void addItem(QLayoutItem *item) override ;
+  Qt::Orientations expandingDirections() const override ;
+  bool hasHeightForWidth() const override ;
+  int heightForWidth(int) const override ;
+  int count() const override ;
+  QLayoutItem *itemAt(int index) const override;
+  QSize minimumSize() const override;
+  void setGeometry(const QRect &rect) override;
+  QSize sizeHint() const override;
+  QLayoutItem *takeAt(int index) override;
   
 protected:
   QScopedPointer<ctkFlowLayoutPrivate> d_ptr;

--- a/Libs/Widgets/ctkFontButton.h
+++ b/Libs/Widgets/ctkFontButton.h
@@ -61,14 +61,14 @@ class CTK_WIDGETS_EXPORT ctkFontButton: public QPushButton
 public:
   /// Constructor
   /// Creates a default ctkFontButton initialized with QApplication font
-  ctkFontButton(QWidget * parent = 0);
+  ctkFontButton(QWidget * parent = nullptr);
 
   /// Constructor
   /// Creates a ctkFontButton with a given font
-  ctkFontButton(const QFont& currentFont, QWidget * parent = 0);
+  ctkFontButton(const QFont& currentFont, QWidget * parent = nullptr);
   
   /// Destructor
-  virtual ~ctkFontButton();
+  ~ctkFontButton() override;
 
   /// Set/get the current font
   void setCurrentFont(const QFont& newFont);

--- a/Libs/Widgets/ctkHistogram.h
+++ b/Libs/Widgets/ctkHistogram.h
@@ -45,24 +45,24 @@ class CTK_WIDGETS_EXPORT ctkHistogram: public ctkTransferFunction
 {
   Q_OBJECT
 public:
-  ctkHistogram(QObject* parent = 0);
-  virtual ~ctkHistogram();
+  ctkHistogram(QObject* parent = nullptr);
+  ~ctkHistogram() override;
   
-  virtual bool isDiscrete()const;
-  virtual bool isEditable()const;
+  bool isDiscrete()const override;
+  bool isEditable()const override;
 
   ///
-  virtual int insertControlPoint(const ctkControlPoint& cp);
-  virtual int insertControlPoint(qreal pos);
+  int insertControlPoint(const ctkControlPoint& cp) override;
+  int insertControlPoint(qreal pos) override;
 
   /// 
   /// be careful with it, as changing the value might require
   /// more changes to ctkControlPoint.
-  virtual void setControlPointPos(int index, qreal pos);
+  void setControlPointPos(int index, qreal pos) override;
   /// 
   /// be careful with it, as changing the value might require
   /// more changes to ctkControlPoint.
-  virtual void setControlPointValue(int index, const QVariant& value);
+  void setControlPointValue(int index, const QVariant& value) override;
   virtual void build()=0;
 protected:
   

--- a/Libs/Widgets/ctkIconEnginePlugin_qt5.h
+++ b/Libs/Widgets/ctkIconEnginePlugin_qt5.h
@@ -47,10 +47,10 @@ class CTK_WIDGETS_EXPORT ctkIconEnginePlugin
 {
   Q_OBJECT;
 public:
-  ctkIconEnginePlugin(QObject* parent = 0);
-  virtual ~ctkIconEnginePlugin();
+  ctkIconEnginePlugin(QObject* parent = nullptr);
+  ~ctkIconEnginePlugin() override ;
 
-  virtual QIconEngine* create(const QString& filename=QString());
+  QIconEngine* create(const QString& filename=QString()) override ;
 
   /// Support all the Qt image formats by default
   virtual QStringList keys()const;
@@ -103,9 +103,9 @@ class CTK_WIDGETS_EXPORT ctkIconEngine: public ctkPixmapIconEngine
 public:
   typedef ctkPixmapIconEngine Superclass;
   ctkIconEngine();
-  virtual ~ctkIconEngine();
-  virtual void addFile(const QString& fileName, const QSize& size,
-                       QIcon::Mode mode, QIcon::State state);
+  ~ctkIconEngine() override ;
+  void addFile(const QString& fileName, const QSize& size,
+                       QIcon::Mode mode, QIcon::State state) override ;
   /// Subdirectories where the icons should be searched, typically:
   /// "Small", "Medium", "Large", "XLarge" or
   /// "16x16", "32x32", "64x64", "128x128" or
@@ -113,7 +113,7 @@ public:
   void setSizeDirectories(const QStringList& sizeDirectories);
   QStringList sizeDirectories()const;
 
-  virtual QString key()const;
+  QString key()const override ;
 
 protected:
   QScopedPointer<ctkIconEnginePrivate> d_ptr;

--- a/Libs/Widgets/ctkLanguageComboBox.h
+++ b/Libs/Widgets/ctkLanguageComboBox.h
@@ -69,11 +69,11 @@ class CTK_WIDGETS_EXPORT ctkLanguageComboBox : public QComboBox
 public:
   typedef QComboBox Superclass;
   /// Constructor of ctkLanguageComboBox
-  ctkLanguageComboBox(QWidget *parent = 0);
+  ctkLanguageComboBox(QWidget *parent = nullptr);
   /// Constructor that specifies a default language.
   /// \sa defaultLanguage
-  ctkLanguageComboBox(const QString& defaultLanguage, QWidget *parent = 0);
-  virtual ~ctkLanguageComboBox();
+  ctkLanguageComboBox(const QString& defaultLanguage, QWidget *parent = nullptr);
+  ~ctkLanguageComboBox() override;
 
   /// Return the default language.
   /// \sa defaultLanguage, setDefaultLanguage()

--- a/Libs/Widgets/ctkLayoutFactory.h
+++ b/Libs/Widgets/ctkLayoutFactory.h
@@ -39,9 +39,9 @@ class CTK_WIDGETS_EXPORT ctkLayoutFactory: public ctkLayoutManager
 {
   Q_OBJECT
 public:
-  ctkLayoutFactory(QObject* parent = 0);
+  ctkLayoutFactory(QObject* parent = nullptr);
   explicit ctkLayoutFactory(QWidget* viewport, QObject* parent);
-  virtual ~ctkLayoutFactory();
+  ~ctkLayoutFactory() override;
 
   using ctkLayoutManager::setLayout;
   using ctkLayoutManager::layout;
@@ -65,16 +65,16 @@ public:
 protected:
   /// Call beginSetupLayout() and endSetupLayout() on all the registeredfactories.
   /// \sa setupView()
-  virtual void setupLayout();
+  void setupLayout() override;
   /// Find the layoutElement factory and call viewFromXML() on it.
   /// \sa viewsFromXML(), setupView()
-  virtual QWidget* viewFromXML(QDomElement layoutElement);
+  QWidget* viewFromXML(QDomElement layoutElement) override;
   /// Find the layoutElement factory and call viewsFromXML() on it.
   /// \sa viewFromXML(), setupView()
-  virtual QList<QWidget*> viewsFromXML(QDomElement layoutElement);
+  QList<QWidget*> viewsFromXML(QDomElement layoutElement) override;
   /// Find the layoutElement factory and setupView() on it.
   /// \sa viewFromXML(), viewsFromXML()
-  virtual void setupView(QDomElement layoutElement, QWidget* view);
+  void setupView(QDomElement layoutElement, QWidget* view) override;
 
   /// Return all the registered factories that can handle the layoutElement.
   QList<ctkLayoutViewFactory*> viewFactories(QDomElement viewElement)const;

--- a/Libs/Widgets/ctkLayoutManager.h
+++ b/Libs/Widgets/ctkLayoutManager.h
@@ -88,11 +88,11 @@ class CTK_WIDGETS_EXPORT ctkLayoutManager: public QObject
   Q_PROPERTY(int spacing READ spacing WRITE setSpacing)
 public:
   /// Constructor
-  ctkLayoutManager(QObject* parent = 0);
+  ctkLayoutManager(QObject* parent = nullptr);
   explicit ctkLayoutManager(QWidget* viewport, QObject* parent);
 
   /// Destructor
-  virtual ~ctkLayoutManager();
+  ~ctkLayoutManager() override;
 
   Q_INVOKABLE void setViewport(QWidget* widget);
   Q_INVOKABLE QWidget* viewport()const;

--- a/Libs/Widgets/ctkLayoutManager_p.h
+++ b/Libs/Widgets/ctkLayoutManager_p.h
@@ -47,7 +47,7 @@ public:
 
   virtual void init();
   void clearLayout(QLayout* layout);
-  void clearWidget(QWidget* widget, QLayout* parentLayout = 0);
+  void clearWidget(QWidget* widget, QLayout* parentLayout = nullptr);
 
   /// The widget where the layout is populated into.
   QWidget*       Viewport;

--- a/Libs/Widgets/ctkLayoutViewFactory.h
+++ b/Libs/Widgets/ctkLayoutViewFactory.h
@@ -48,10 +48,10 @@ class CTK_WIDGETS_EXPORT ctkLayoutViewFactory: public QObject
   Q_PROPERTY(bool useCachedViews READ useCachedViews WRITE setUseCachedViews);
 public:
   /// Constructor
-  ctkLayoutViewFactory(QObject* parent = 0);
+  ctkLayoutViewFactory(QObject* parent = nullptr);
 
   /// Destructor
-  virtual ~ctkLayoutViewFactory();
+  ~ctkLayoutViewFactory() override ;
 
   /// Returns the list of element names supported by the factory (e.g. "view",
   /// "myview"...). Returns ["view"] by default.
@@ -174,12 +174,12 @@ template<class T>
 class ctkTemplateLayoutViewFactory: public ctkLayoutViewFactory
 {
 public:
-  ctkTemplateLayoutViewFactory(QObject* parent = 0)
+  ctkTemplateLayoutViewFactory(QObject* parent = nullptr)
     : ctkLayoutViewFactory(parent)
   {
     this->setUseCachedViews(true);
   }
-  virtual QWidget* createViewFromXML(QDomElement layoutElement){
+  QWidget* createViewFromXML(QDomElement layoutElement) override {
     Q_UNUSED(layoutElement);
     return new T;
     }

--- a/Libs/Widgets/ctkMaterialPropertyWidget.h
+++ b/Libs/Widgets/ctkMaterialPropertyWidget.h
@@ -74,10 +74,10 @@ public:
   typedef QWidget Superclass;
 
   /// Constructor
-  explicit ctkMaterialPropertyWidget(QWidget* parent = 0);
+  explicit ctkMaterialPropertyWidget(QWidget* parent = nullptr);
 
   /// Destructor
-  virtual ~ctkMaterialPropertyWidget();
+  ~ctkMaterialPropertyWidget() override;
 
   QColor color()const;
   double opacity()const;
@@ -144,7 +144,7 @@ protected Q_SLOTS:
 protected:
   QScopedPointer<ctkMaterialPropertyWidgetPrivate> d_ptr;
 
-  virtual void resizeEvent(QResizeEvent* resize);
+  void resizeEvent(QResizeEvent* resize) override;
 private:
   Q_DECLARE_PRIVATE(ctkMaterialPropertyWidget);
   Q_DISABLE_COPY(ctkMaterialPropertyWidget);

--- a/Libs/Widgets/ctkMatrixWidget.h
+++ b/Libs/Widgets/ctkMatrixWidget.h
@@ -58,10 +58,10 @@ public:
   typedef QWidget Superclass;
 
   /// Constructor, builds a 4x4 identity matrix
-  explicit ctkMatrixWidget(QWidget* parent = 0);
+  explicit ctkMatrixWidget(QWidget* parent = nullptr);
   /// Constructor, builds a custom rowsXcolumns matrix
-  explicit ctkMatrixWidget(int rows, int columns, QWidget* parent = 0);
-  virtual ~ctkMatrixWidget();
+  explicit ctkMatrixWidget(int rows, int columns, QWidget* parent = nullptr);
+  ~ctkMatrixWidget() override;
 
   /// Set the number of columns of the matrix
   /// \sa rowCount, setRowCount
@@ -139,8 +139,8 @@ public:
 
   ///
   /// Reimplemented from QAbstractScrollArea
-  virtual QSize minimumSizeHint () const;
-  virtual QSize sizeHint () const;
+  QSize minimumSizeHint () const override;
+  QSize sizeHint () const override;
 
 public Q_SLOTS:
 
@@ -161,11 +161,11 @@ Q_SIGNALS:
   void decimalsChanged(int);
 
 protected:
-  virtual void resizeEvent(QResizeEvent* event);
+  void resizeEvent(QResizeEvent* event) override;
 
   ///
   /// protected constructor to derive private implementations
-  ctkMatrixWidget(ctkMatrixWidgetPrivate& pvt, QWidget* parent=0);
+  ctkMatrixWidget(ctkMatrixWidgetPrivate& pvt, QWidget* parent=nullptr);
 private:
   QScopedPointer<ctkMatrixWidgetPrivate> d_ptr;
   Q_DECLARE_PRIVATE(ctkMatrixWidget);

--- a/Libs/Widgets/ctkMenuButton.h
+++ b/Libs/Widgets/ctkMenuButton.h
@@ -43,22 +43,22 @@ class CTK_WIDGETS_EXPORT ctkMenuButton : public QPushButton
   Q_OBJECT
 
 public:
-  ctkMenuButton(QWidget *parent = 0);
-  ctkMenuButton(const QString& text, QWidget *parent = 0);
-  virtual ~ctkMenuButton();
+  ctkMenuButton(QWidget *parent = nullptr);
+  ctkMenuButton(const QString& text, QWidget *parent = nullptr);
+  ~ctkMenuButton() override;
 
   /// Reimplemented for internal reasons
-  virtual QSize minimumSizeHint()const;
+  QSize minimumSizeHint()const override;
   /// Reimplemented for internal reasons
-  virtual QSize sizeHint()const;
+  QSize sizeHint()const override;
 
 protected:
   /// Reimplemented for internal reasons
-  virtual void paintEvent(QPaintEvent*);
+  void paintEvent(QPaintEvent*) override;
   /// Reimplemented for internal reasons
-  virtual void mousePressEvent(QMouseEvent* event);
+  void mousePressEvent(QMouseEvent* event) override;
   /// Reimplemented for internal reasons
-  virtual bool hitButton(const QPoint & pos) const;
+  bool hitButton(const QPoint & pos) const override;
   /// Reimplemented for internal reasons
   virtual void initStyleOption ( QStyleOptionButton * option ) const;
 protected:

--- a/Libs/Widgets/ctkMenuComboBox.h
+++ b/Libs/Widgets/ctkMenuComboBox.h
@@ -88,8 +88,8 @@ public:
   typedef QWidget Superclass;
 
   ///
-  ctkMenuComboBox(QWidget* parent = 0);
-  virtual ~ctkMenuComboBox();
+  ctkMenuComboBox(QWidget* parent = nullptr);
+  ~ctkMenuComboBox() override;
 
   /// Add a menu to the QcomboBox and set a QCompleter
   void setMenu(QMenu* menu);
@@ -123,7 +123,7 @@ public:
   ctkCompleter* searchCompleter() const;
 
 protected:
-  virtual bool eventFilter(QObject* target, QEvent* event);
+  bool eventFilter(QObject* target, QEvent* event) override;
 
 public Q_SLOTS:
   void clearActiveAction();

--- a/Libs/Widgets/ctkMessageBox.h
+++ b/Libs/Widgets/ctkMessageBox.h
@@ -66,10 +66,10 @@ class CTK_WIDGETS_EXPORT ctkMessageBox : public QMessageBox
 
 public:
   typedef QMessageBox Superclass;
-  ctkMessageBox(QWidget* newParent = 0);
+  ctkMessageBox(QWidget* newParent = nullptr);
   ctkMessageBox(Icon icon, const QString & title, const QString & text, StandardButtons buttons = NoButton,
-                QWidget * parent = 0, Qt::WindowFlags f = Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint );
-  virtual ~ctkMessageBox();
+                QWidget * parent = nullptr, Qt::WindowFlags f = Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint );
+  ~ctkMessageBox() override ;
 
   bool dontShowAgain()const;
 
@@ -83,13 +83,13 @@ public:
   /// If \a dontShowAgainKey is empty, the dontShowAgain checkbox is hidden
   /// and the message box is always open for the user to confirm exit.
   static bool confirmExit(const QString& dontShowAgainKey = QString(),
-                          QWidget* parentWidget = 0);
+                          QWidget* parentWidget = nullptr);
 
   /// Reimplemented for internal reasons
-  virtual void setVisible(bool visible);
+  void setVisible(bool visible) override ;
 
   /// Reimplemented for internal reasons
-  virtual void done(int resultCode);
+  void done(int resultCode) override ;
 
 public Q_SLOTS:
   /// Change the checkbox and the settings if any

--- a/Libs/Widgets/ctkPathLineEdit.h
+++ b/Libs/Widgets/ctkPathLineEdit.h
@@ -166,7 +166,7 @@ public:
 
   /** Default constructor
   */
-  ctkPathLineEdit(QWidget *parent = 0);
+  ctkPathLineEdit(QWidget *parent = nullptr);
 
   /** Constructor
    *  /param label        Used in file dialogs
@@ -177,8 +177,8 @@ public:
   ctkPathLineEdit( const QString& label,
                    const QStringList& nameFilters,
                    Filters filters = ctkPathLineEdit::AllEntries,
-                   QWidget *parent=0 );
-  virtual ~ctkPathLineEdit();
+                   QWidget *parent=nullptr );
+  ~ctkPathLineEdit() override;
   QString currentPath()const;
 
   void setLabel(const QString &label);
@@ -231,11 +231,11 @@ public:
 
   /// The width returned, in pixels, is the length of the file name (with no
   /// path) if any. Otherwise, it's enough for 15 to 20 characters.
-  virtual QSize minimumSizeHint()const;
+  QSize minimumSizeHint()const override;
 
   /// The width returned, in pixels, is the entire length of the current path
   /// if any. Otherwise, it's enough for 15 to 20 characters.
-  virtual QSize sizeHint()const;
+  QSize sizeHint()const override;
 
 Q_SIGNALS:
   /** the signal is emit when the state of hasValidInput changed

--- a/Libs/Widgets/ctkPixmapIconEngine.h
+++ b/Libs/Widgets/ctkPixmapIconEngine.h
@@ -62,24 +62,24 @@ class CTK_WIDGETS_EXPORT ctkPixmapIconEngine
 public:
     ctkPixmapIconEngine();
     ctkPixmapIconEngine(const ctkPixmapIconEngine &);
-    ~ctkPixmapIconEngine();
-    void paint(QPainter *painter, const QRect &rect, QIcon::Mode mode, QIcon::State state);
-    QPixmap pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state);
+    ~ctkPixmapIconEngine() override ;
+    void paint(QPainter *painter, const QRect &rect, QIcon::Mode mode, QIcon::State state) override ;
+    QPixmap pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state) override ;
     ctkPixmapIconEngineEntry *bestMatch(const QSize &size, QIcon::Mode mode, QIcon::State state, bool sizeOnly);
-    QSize actualSize(const QSize &size, QIcon::Mode mode, QIcon::State state);
-    void addPixmap(const QPixmap &pixmap, QIcon::Mode mode, QIcon::State state);
-    void addFile(const QString &fileName, const QSize &size, QIcon::Mode mode, QIcon::State state);
+    QSize actualSize(const QSize &size, QIcon::Mode mode, QIcon::State state) override ;
+    void addPixmap(const QPixmap &pixmap, QIcon::Mode mode, QIcon::State state) override ;
+    void addFile(const QString &fileName, const QSize &size, QIcon::Mode mode, QIcon::State state) override ;
 
     // v2 functions
-    QString key() const;
+    QString key() const override ;
 #if QT_VERSION >= 0x050000
-    QIconEngine *clone() const;
+    QIconEngine *clone() const override ;
 #else
     QIconEngineV2 *clone() const;
 #endif
-    bool read(QDataStream &in);
-    bool write(QDataStream &out) const;
-    void virtual_hook(int id, void *data);
+    bool read(QDataStream &in) override ;
+    bool write(QDataStream &out) const override ;
+    void virtual_hook(int id, void *data) override ;
 
 private:
     ctkPixmapIconEngineEntry *tryMatch(const QSize &size, QIcon::Mode mode, QIcon::State state);

--- a/Libs/Widgets/ctkPopupWidget.h
+++ b/Libs/Widgets/ctkPopupWidget.h
@@ -78,8 +78,8 @@ public:
   typedef ctkBasePopupWidget Superclass;
   /// By default, the parent is the \a baseWidget.
   /// \sa baseWidget()
-  explicit ctkPopupWidget(QWidget* parent = 0);
-  virtual ~ctkPopupWidget();
+  explicit ctkPopupWidget(QWidget* parent = nullptr);
+  ~ctkPopupWidget() override;
 
   bool isActive()const;
   void setActive(bool);
@@ -109,21 +109,21 @@ public Q_SLOTS:
 
 public:
   /// Reimplemented for internal reasons
-  virtual void hidePopup();
+  void hidePopup() override;
 
 protected:
-  virtual void leaveEvent(QEvent* event);
-  virtual void enterEvent(QEvent* event);
-  virtual bool eventFilter(QObject* obj, QEvent* event);
+  void leaveEvent(QEvent* event) override;
+  void enterEvent(QEvent* event) override;
+  bool eventFilter(QObject* obj, QEvent* event) override;
 
   /// Widget the popup is attached to. It opens right under \a baseWidget
   /// and if the ctkPopupWidget sizepolicy contains the growFlag/shrinkFlag,
   /// it tries to resize itself to fit the same width of \a baseWidget.
-  virtual void setBaseWidget(QWidget* baseWidget);
+  void setBaseWidget(QWidget* baseWidget) override;
 
 protected Q_SLOTS:
   void updatePopup();
-  virtual void onEffectFinished();
+  void onEffectFinished() override;
 
 private:
   Q_DECLARE_PRIVATE(ctkPopupWidget);

--- a/Libs/Widgets/ctkProxyStyle.h
+++ b/Libs/Widgets/ctkProxyStyle.h
@@ -36,48 +36,48 @@ class CTK_WIDGETS_EXPORT ctkProxyStyle : public QProxyStyle
 {
   Q_OBJECT
 public:
-  ctkProxyStyle(QStyle *baseStyle = 0, QObject* parent = 0);
-  virtual ~ctkProxyStyle();
+  ctkProxyStyle(QStyle *baseStyle = nullptr, QObject* parent = nullptr);
+  ~ctkProxyStyle() override;
 
   void ensureBaseStyle()const;
 
-  virtual void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = 0) const;
-  virtual void drawControl(ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = 0) const;
-  virtual void drawComplexControl(ComplexControl control, const QStyleOptionComplex *option, QPainter *painter, const QWidget *widget = 0) const;
-  virtual void drawItemText(QPainter *painter, const QRect &rect, int flags, const QPalette &pal, bool enabled,
-                            const QString &text, QPalette::ColorRole textRole = QPalette::NoRole) const;
-  virtual void drawItemPixmap(QPainter *painter, const QRect &rect, int alignment, const QPixmap &pixmap) const;
+  void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = nullptr) const override;
+  void drawControl(ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = nullptr) const override;
+  void drawComplexControl(ComplexControl control, const QStyleOptionComplex *option, QPainter *painter, const QWidget *widget = nullptr) const override;
+  void drawItemText(QPainter *painter, const QRect &rect, int flags, const QPalette &pal, bool enabled,
+                            const QString &text, QPalette::ColorRole textRole = QPalette::NoRole) const override;
+  void drawItemPixmap(QPainter *painter, const QRect &rect, int alignment, const QPixmap &pixmap) const override;
 
-  virtual QSize sizeFromContents(ContentsType type, const QStyleOption *option, const QSize &size, const QWidget *widget) const;
+  QSize sizeFromContents(ContentsType type, const QStyleOption *option, const QSize &size, const QWidget *widget) const override;
 
-  virtual QRect subElementRect(SubElement element, const QStyleOption *option, const QWidget *widget) const;
-  virtual QRect subControlRect(ComplexControl cc, const QStyleOptionComplex *opt, SubControl sc, const QWidget *widget) const;
-  virtual QRect itemTextRect(const QFontMetrics &fm, const QRect &r, int flags, bool enabled, const QString &text) const;
-  virtual QRect itemPixmapRect(const QRect &r, int flags, const QPixmap &pixmap) const;
+  QRect subElementRect(SubElement element, const QStyleOption *option, const QWidget *widget) const override;
+  QRect subControlRect(ComplexControl cc, const QStyleOptionComplex *opt, SubControl sc, const QWidget *widget) const override;
+  QRect itemTextRect(const QFontMetrics &fm, const QRect &r, int flags, bool enabled, const QString &text) const override;
+  QRect itemPixmapRect(const QRect &r, int flags, const QPixmap &pixmap) const override;
 
-  virtual SubControl hitTestComplexControl(ComplexControl control, const QStyleOptionComplex *option, const QPoint &pos, const QWidget *widget = 0) const;
-  virtual int styleHint(StyleHint hint, const QStyleOption *option = 0, const QWidget *widget = 0, QStyleHintReturn *returnData = 0) const;
-  virtual int pixelMetric(PixelMetric metric, const QStyleOption *option = 0, const QWidget *widget = 0) const;
+  SubControl hitTestComplexControl(ComplexControl control, const QStyleOptionComplex *option, const QPoint &pos, const QWidget *widget = nullptr) const override;
+  int styleHint(StyleHint hint, const QStyleOption *option = nullptr, const QWidget *widget = nullptr, QStyleHintReturn *returnData = nullptr) const override;
+  int pixelMetric(PixelMetric metric, const QStyleOption *option = nullptr, const QWidget *widget = nullptr) const override;
 
-  virtual QPixmap standardPixmap(StandardPixmap standardPixmap, const QStyleOption *opt, const QWidget *widget = 0) const;
-  virtual QPixmap generatedIconPixmap(QIcon::Mode iconMode, const QPixmap &pixmap, const QStyleOption *opt) const;
-  virtual QPalette standardPalette() const;
+  QPixmap standardPixmap(StandardPixmap standardPixmap, const QStyleOption *opt, const QWidget *widget = nullptr) const override;
+  QPixmap generatedIconPixmap(QIcon::Mode iconMode, const QPixmap &pixmap, const QStyleOption *opt) const override;
+  QPalette standardPalette() const override;
 
-  virtual void polish(QWidget *widget);
-  virtual void polish(QPalette &pal);
-  virtual void polish(QApplication *app);
+  void polish(QWidget *widget) override;
+  void polish(QPalette &pal) override;
+  void polish(QApplication *app) override;
 
-  virtual void unpolish(QWidget *widget);
-  virtual void unpolish(QApplication *app);
+  void unpolish(QWidget *widget) override;
+  void unpolish(QApplication *app) override;
 
 protected:
   QScopedPointer<ctkProxyStylePrivate> d_ptr;
-  virtual bool event(QEvent *e);
+  bool event(QEvent *e) override;
 
 protected Q_SLOTS:
   virtual QIcon standardIconImplementation(StandardPixmap standardIcon, const QStyleOption *option, const QWidget *widget) const;
   virtual int layoutSpacingImplementation(QSizePolicy::ControlType control1, QSizePolicy::ControlType control2,
-                                  Qt::Orientation orientation, const QStyleOption *option = 0, const QWidget *widget = 0) const;
+                                  Qt::Orientation orientation, const QStyleOption *option = nullptr, const QWidget *widget = nullptr) const;
 private:
   Q_DISABLE_COPY(ctkProxyStyle)
   Q_DECLARE_PRIVATE(ctkProxyStyle)

--- a/Libs/Widgets/ctkPushButton.h
+++ b/Libs/Widgets/ctkPushButton.h
@@ -47,10 +47,10 @@ class CTK_WIDGETS_EXPORT ctkPushButton : public QPushButton
   Q_PROPERTY(Qt::Alignment iconAlignment READ iconAlignment WRITE setIconAlignment)
 
 public:
-  ctkPushButton(QWidget *parent = 0);
-  ctkPushButton(const QString& text, QWidget *parent = 0);
-  ctkPushButton(const QIcon& icon, const QString& text, QWidget *parent = 0);
-  virtual ~ctkPushButton();
+  ctkPushButton(QWidget *parent = nullptr);
+  ctkPushButton(const QString& text, QWidget *parent = nullptr);
+  ctkPushButton(const QIcon& icon, const QString& text, QWidget *parent = nullptr);
+  ~ctkPushButton() override;
 
   /// Set the buttonTextAlignment property value.
   /// \sa buttonTextAlignment
@@ -66,16 +66,16 @@ public:
   /// \sa iconAlignment
   Qt::Alignment iconAlignment()const;
 
-  virtual QSize minimumSizeHint()const;
-  virtual QSize sizeHint()const;
+  QSize minimumSizeHint()const override;
+  QSize sizeHint()const override;
 
 protected:
   /// Reimplemented for internal reasons
-  virtual void paintEvent(QPaintEvent*);
+  void paintEvent(QPaintEvent*) override;
 
 protected:
   QScopedPointer<ctkPushButtonPrivate> d_ptr;
-  ctkPushButton(ctkPushButtonPrivate*, QWidget* parent = 0);
+  ctkPushButton(ctkPushButtonPrivate*, QWidget* parent = nullptr);
 
 private:
   Q_DECLARE_PRIVATE(ctkPushButton);

--- a/Libs/Widgets/ctkRangeSlider.h
+++ b/Libs/Widgets/ctkRangeSlider.h
@@ -63,9 +63,9 @@ public:
   /// Constructor, builds a ctkRangeSlider that ranges from 0 to 100 and has
   /// a lower and upper values of 0 and 100 respectively, other properties
   /// are set the QSlider default properties.
-  explicit ctkRangeSlider( Qt::Orientation o, QWidget* par= 0 );
-  explicit ctkRangeSlider( QWidget* par = 0 );
-  virtual ~ctkRangeSlider();
+  explicit ctkRangeSlider( Qt::Orientation o, QWidget* par= nullptr );
+  explicit ctkRangeSlider( QWidget* par = nullptr );
+  ~ctkRangeSlider() override ;
 
   /// 
   /// This property holds the slider's current minimum value.
@@ -181,24 +181,24 @@ protected Q_SLOTS:
   void onRangeChanged(int minimum, int maximum);
 
 protected:
-  ctkRangeSlider( ctkRangeSliderPrivate* impl, Qt::Orientation o, QWidget* par= 0 );
-  ctkRangeSlider( ctkRangeSliderPrivate* impl, QWidget* par = 0 );
+  ctkRangeSlider( ctkRangeSliderPrivate* impl, Qt::Orientation o, QWidget* par= nullptr );
+  ctkRangeSlider( ctkRangeSliderPrivate* impl, QWidget* par = nullptr );
 
   // Description:
   // Standard Qt UI events
-  virtual void mousePressEvent(QMouseEvent* ev);
-  virtual void mouseMoveEvent(QMouseEvent* ev);
-  virtual void mouseReleaseEvent(QMouseEvent* ev);
+  void mousePressEvent(QMouseEvent* ev) override ;
+  void mouseMoveEvent(QMouseEvent* ev) override;
+  void mouseReleaseEvent(QMouseEvent* ev) override;
 
   // Description:
   // Rendering is done here.
-  virtual void paintEvent(QPaintEvent* ev);
+  void paintEvent(QPaintEvent* ev) override;
   virtual void initMinimumSliderStyleOption(QStyleOptionSlider* option) const;
   virtual void initMaximumSliderStyleOption(QStyleOptionSlider* option) const;
 
   // Description:
   // Reimplemented for the tooltips
-  virtual bool event(QEvent* event);
+  bool event(QEvent* event) override;
 
 protected:
   QScopedPointer<ctkRangeSliderPrivate> d_ptr;

--- a/Libs/Widgets/ctkRangeWidget.h
+++ b/Libs/Widgets/ctkRangeWidget.h
@@ -66,10 +66,10 @@ public:
   /// Constructor
   /// If \li parent is null, ctkRangeWidget will be a top-leve widget
   /// \note The \li parent can be set later using QWidget::setParent()
-  explicit ctkRangeWidget(QWidget* parent = 0);
+  explicit ctkRangeWidget(QWidget* parent = nullptr);
   
   /// Destructor
-  virtual ~ctkRangeWidget();
+  ~ctkRangeWidget() override ;
 
   ///
   /// This property holds the sliders and spinbox minimum value.
@@ -243,7 +243,7 @@ protected Q_SLOTS:
   virtual void onValueProxyModified();
 
 protected:
-  virtual bool eventFilter(QObject *obj, QEvent *event);
+  bool eventFilter(QObject *obj, QEvent *event) override ;
 
   /// can be used to change the slider by a custom one
   virtual void setSlider(ctkDoubleRangeSlider* slider);

--- a/Libs/Widgets/ctkScreenshotDialog.h
+++ b/Libs/Widgets/ctkScreenshotDialog.h
@@ -52,8 +52,8 @@ class CTK_WIDGETS_EXPORT ctkScreenshotDialog : public QDialog
 
 public:
   typedef QDialog Superclass;
-  ctkScreenshotDialog(QWidget* parent = 0);
-  virtual ~ctkScreenshotDialog();
+  ctkScreenshotDialog(QWidget* parent = nullptr);
+  ~ctkScreenshotDialog() override;
 
   /// Get widget to grab content from. If no widget is set, no screenshot will
   /// be taken.

--- a/Libs/Widgets/ctkSearchBox.h
+++ b/Libs/Widgets/ctkSearchBox.h
@@ -67,8 +67,8 @@ public:
   /// Superclass typedef
   typedef QLineEdit Superclass;
 
-  ctkSearchBox(QWidget *parent = 0);
-  virtual ~ctkSearchBox();
+  ctkSearchBox(QWidget *parent = nullptr);
+  ~ctkSearchBox() override ;
 
 #if QT_VERSION < 0x040700
   QString placeholderText()const;
@@ -97,10 +97,10 @@ protected Q_SLOTS:
   void updateClearButtonState();
 
 protected:
-  virtual void paintEvent(QPaintEvent*);
-  virtual void mousePressEvent(QMouseEvent* event);
-  virtual void mouseMoveEvent(QMouseEvent *event);
-  virtual void resizeEvent(QResizeEvent * event);
+  void paintEvent(QPaintEvent*) override ;
+  void mousePressEvent(QMouseEvent* event) override ;
+  void mouseMoveEvent(QMouseEvent *event) override ;
+  void resizeEvent(QResizeEvent * event) override ;
 
   QScopedPointer<ctkSearchBoxPrivate> d_ptr;
 

--- a/Libs/Widgets/ctkSettings.h
+++ b/Libs/Widgets/ctkSettings.h
@@ -77,24 +77,24 @@ public:
   ctkSettings(
     const QString& organization,
     const QString& application,
-    QObject* parent = 0);
+    QObject* parent = nullptr);
   /// \see QSettings::QSettings(QSettings::Scope ,const QString& ,const QString& , QObject* )
   ctkSettings(
     QSettings::Scope scope,
     const QString& organization,
     const QString& application = QString(),
-    QObject* parent = 0);
+    QObject* parent = nullptr);
   /// \see QSettings::QSettings(QSettings::Format ,QSettings::Scope ,const QString& ,const QString& , QObject* )
   ctkSettings(
     QSettings::Format format,
     QSettings::Scope scope,
     const QString& organization,
     const QString& application = QString(),
-    QObject* parent = 0);
+    QObject* parent = nullptr);
   /// \see QSettings::QSettings(const QString& , QSettings::Format , QObject* )
-  ctkSettings(const QString& fileName, QSettings::Format format, QObject* parent = 0);
+  ctkSettings(const QString& fileName, QSettings::Format format, QObject* parent = nullptr);
   /// \see QSettings::QSettings(QObject*)
-  ctkSettings(QObject* parent = 0);
+  ctkSettings(QObject* parent = nullptr);
 
   /// Saves the position, size and layout of the QMainWindow
   Q_INVOKABLE void saveState(const QMainWindow& window, const QString& key);

--- a/Libs/Widgets/ctkSettingsDialog.h
+++ b/Libs/Widgets/ctkSettingsDialog.h
@@ -58,10 +58,10 @@ public:
   typedef QDialog Superclass;
 
   /// Constructor
-  explicit ctkSettingsDialog(QWidget* parent = 0);
+  explicit ctkSettingsDialog(QWidget* parent = nullptr);
 
   /// Destructor
-  virtual ~ctkSettingsDialog();
+  ~ctkSettingsDialog() override;
 
   QSettings* settings()const;
   void setSettings(QSettings* settings);
@@ -74,21 +74,21 @@ public:
   /// This adds the specified settings panel to the dialog. The panel's
   /// QWidget::windowTitle property is used as the panel name as shown in the
   /// panels list.
-  Q_INVOKABLE void addPanel(ctkSettingsPanel* panel, ctkSettingsPanel* parentPanel = 0);
+  Q_INVOKABLE void addPanel(ctkSettingsPanel* panel, ctkSettingsPanel* parentPanel = nullptr);
 
   /// \copybrief addPanel
   ///
   /// This convenience overload allows the caller to specify the panel name
   /// that will be used in the panels list.
   Q_INVOKABLE void addPanel(const QString& label, ctkSettingsPanel* panel,
-                            ctkSettingsPanel* parentPanel = 0);
+                            ctkSettingsPanel* parentPanel = nullptr);
 
   /// \copybrief addPanel
   ///
   /// This convenience overload allows the caller to specify the panel name
   /// that will be used in the panels list, as well as an icon for the panel.
   Q_INVOKABLE void addPanel(const QString& label, const QIcon& icon,
-                            ctkSettingsPanel* panel, ctkSettingsPanel* parentPanel = 0);
+                            ctkSettingsPanel* panel, ctkSettingsPanel* parentPanel = nullptr);
 
   bool resetButton()const;
   void setResetButton(bool show);
@@ -113,8 +113,8 @@ public Q_SLOTS:
   /// the QSettings that were not made through ctkSettingsPanel.
   void reloadSettings();
 
-  virtual void accept();
-  virtual void reject();
+  void accept() override;
+  void reject() override;
 
   /// Resize the left panel based on the panels titles.
   void adjustTreeWidgetToContents();
@@ -132,7 +132,7 @@ protected Q_SLOTS:
   void onDialogButtonClicked(QAbstractButton* button);
 
 protected:
-  virtual bool event(QEvent *);
+  bool event(QEvent *) override;
 
 protected:
   QScopedPointer<ctkSettingsDialogPrivate> d_ptr;

--- a/Libs/Widgets/ctkSettingsPanel.h
+++ b/Libs/Widgets/ctkSettingsPanel.h
@@ -45,10 +45,10 @@ public:
   typedef QWidget Superclass;
 
   /// Constructor
-  explicit ctkSettingsPanel(QWidget* parent = 0);
+  explicit ctkSettingsPanel(QWidget* parent = nullptr);
 
   /// Destructor
-  virtual ~ctkSettingsPanel();
+  ~ctkSettingsPanel() override ;
 
   QSettings* settings()const;
   void setSettings(QSettings* settings);
@@ -84,7 +84,7 @@ public:
                         const char* propertySignal,
                         const QString& settingLabel = QString(),
                         SettingOptions options = OptionNone,
-                        QSettings * settings = 0);
+                        QSettings * settings = nullptr);
 
   /// \copybrief registerProperty
   /// \overload
@@ -93,7 +93,7 @@ public:
                                     const QByteArray& propertySignal,
                                     const QString& settingLabel = QString(),
                                     SettingOptions options = OptionNone,
-                                    QSettings * settings = 0);
+                                    QSettings * settings = nullptr);
 
   /// Set the setting to the property defined by the key.
   /// The old value can be restored using resetSettings()

--- a/Libs/Widgets/ctkSignalMapper.h
+++ b/Libs/Widgets/ctkSignalMapper.h
@@ -35,7 +35,7 @@ class CTK_WIDGETS_EXPORT ctkSignalMapper: public QSignalMapper
   Q_OBJECT
   
 public:
-  ctkSignalMapper(QObject* newParent = 0);
+  ctkSignalMapper(QObject* newParent = nullptr);
   
 public Q_SLOTS:
   /// ctkSignalMapper exposes the map(QAction*) slot to be conveniently

--- a/Libs/Widgets/ctkSliderWidget.h
+++ b/Libs/Widgets/ctkSliderWidget.h
@@ -93,8 +93,8 @@ public:
   typedef QWidget Superclass;
 
   /// Constructors
-  explicit ctkSliderWidget(QWidget* parent = 0);
-  virtual ~ctkSliderWidget();
+  explicit ctkSliderWidget(QWidget* parent = nullptr);
+  ~ctkSliderWidget() override ;
 
   /// 
   /// This property holds the sliders and spinbox minimum value.
@@ -304,7 +304,7 @@ protected Q_SLOTS:
   virtual void onValueProxyModified();
 
 protected:
-  virtual bool eventFilter(QObject *obj, QEvent *event);
+  bool eventFilter(QObject *obj, QEvent *event) override;
   
 protected:
   QScopedPointer<ctkSliderWidgetPrivate> d_ptr;

--- a/Libs/Widgets/ctkThumbnailLabel.h
+++ b/Libs/Widgets/ctkThumbnailLabel.h
@@ -61,8 +61,8 @@ class CTK_WIDGETS_EXPORT ctkThumbnailLabel : public QWidget
   Q_PROPERTY(QColor selectedColor READ selectedColor WRITE setSelectedColor)
 public:
   typedef QWidget Superclass;
-  explicit ctkThumbnailLabel(QWidget* parent=0);
-  virtual ~ctkThumbnailLabel();
+  explicit ctkThumbnailLabel(QWidget* parent=nullptr);
+  ~ctkThumbnailLabel() override;
 
   void setText(const QString& text);
   QString text()const;
@@ -82,18 +82,18 @@ public:
   void setSelectedColor(const QColor& color);
   QColor selectedColor()const;
 
-  virtual QSize minimumSizeHint()const;
-  virtual QSize sizeHint()const;
-  virtual int heightForWidth(int width)const;
+  QSize minimumSizeHint()const override;
+  QSize sizeHint()const override;
+  int heightForWidth(int width)const override;
 
 protected:
   QScopedPointer<ctkThumbnailLabelPrivate> d_ptr;
 
-  virtual void paintEvent(QPaintEvent* event);
-  virtual void mousePressEvent(QMouseEvent* event);
-  virtual void mouseDoubleClickEvent(QMouseEvent* event);
+  void paintEvent(QPaintEvent* event) override;
+  void mousePressEvent(QMouseEvent* event) override;
+  void mouseDoubleClickEvent(QMouseEvent* event) override;
 
-  virtual void resizeEvent(QResizeEvent* event);
+  void resizeEvent(QResizeEvent* event) override;
 
 private:
   Q_DECLARE_PRIVATE(ctkThumbnailLabel);

--- a/Libs/Widgets/ctkToolTipTrapper.h
+++ b/Libs/Widgets/ctkToolTipTrapper.h
@@ -75,11 +75,11 @@ class CTK_WIDGETS_EXPORT ctkToolTipTrapper : public QObject
 public:
   typedef QObject Superclass;
   /// Constructs a ToolTip trapper which is a child of objectParent
-  explicit ctkToolTipTrapper(QObject* objectParent = 0);
+  explicit ctkToolTipTrapper(QObject* objectParent = nullptr);
   explicit ctkToolTipTrapper(bool toolTipsTrapped,
                              bool toolTipsWordWordWrapped,
-                             QObject* objectParent = 0);
-  virtual ~ctkToolTipTrapper();
+                             QObject* objectParent = nullptr);
+  ~ctkToolTipTrapper() override;
 
   /// Returns true if the tooltips are trapped to prevent them from appearing.
   bool toolTipsTrapped()const;
@@ -89,7 +89,7 @@ public:
 
   /// Automatically called when the tooltips are trapped or word wrapped.
   /// You shouldn't have to call it manually.
-  bool eventFilter(QObject* watched, QEvent* event);
+  bool eventFilter(QObject* watched, QEvent* event) override;
 
 public Q_SLOTS:
   /// If true, installs the eventFilter on the application if it isn't already

--- a/Libs/Widgets/ctkTransferFunction.h
+++ b/Libs/Widgets/ctkTransferFunction.h
@@ -67,7 +67,7 @@ struct CTK_WIDGETS_EXPORT ctkControlPoint
 /// \ingroup Widgets
 struct CTK_WIDGETS_EXPORT ctkBezierControlPoint : public ctkControlPoint
 {
-  virtual ~ctkBezierControlPoint();
+  ~ctkBezierControlPoint() override;
   ctkPoint P1;
   ctkPoint P2;
 };
@@ -76,7 +76,7 @@ struct CTK_WIDGETS_EXPORT ctkBezierControlPoint : public ctkControlPoint
 /// \ingroup Widgets
 struct CTK_WIDGETS_EXPORT ctkNonLinearControlPoint : public ctkControlPoint
 {
-  virtual ~ctkNonLinearControlPoint();
+  ~ctkNonLinearControlPoint() override;
   QList<ctkPoint> SubPoints;
 };
 
@@ -86,8 +86,8 @@ class CTK_WIDGETS_EXPORT ctkTransferFunction: public QObject
 {
   Q_OBJECT
 public:
-  ctkTransferFunction(QObject* parent = 0);
-  virtual ~ctkTransferFunction();
+  ctkTransferFunction(QObject* parent = nullptr);
+  ~ctkTransferFunction() override;
 
   virtual ctkControlPoint* controlPoint(int index)const = 0;
   inline QVariant value(int index)const;

--- a/Libs/Widgets/ctkTransferFunctionBarsItem.h
+++ b/Libs/Widgets/ctkTransferFunctionBarsItem.h
@@ -40,10 +40,10 @@ class CTK_WIDGETS_EXPORT ctkTransferFunctionBarsItem: public ctkTransferFunction
   Q_PROPERTY(qreal barWidth READ barWidth WRITE setBarWidth)
   Q_PROPERTY(QColor barColor READ barColor WRITE setBarColor)
 public:
-  ctkTransferFunctionBarsItem(QGraphicsItem* parent = 0);
+  ctkTransferFunctionBarsItem(QGraphicsItem* parent = nullptr);
   ctkTransferFunctionBarsItem(ctkTransferFunction* transferFunc,
-                              QGraphicsItem* parent = 0);
-  virtual ~ctkTransferFunctionBarsItem();
+                              QGraphicsItem* parent = nullptr);
+  ~ctkTransferFunctionBarsItem() override;
 
   void setBarWidth(qreal newBarWidth);
   qreal barWidth()const;
@@ -57,7 +57,7 @@ public:
     UseLog = 1,
     AutoLog =2
   };
-  virtual void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = 0);
+  void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = nullptr) override;
 protected:
   QScopedPointer<ctkTransferFunctionBarsItemPrivate> d_ptr;
 

--- a/Libs/Widgets/ctkTransferFunctionGradientItem.h
+++ b/Libs/Widgets/ctkTransferFunctionGradientItem.h
@@ -40,12 +40,12 @@ class CTK_WIDGETS_EXPORT ctkTransferFunctionGradientItem: public ctkTransferFunc
   Q_PROPERTY(bool mask READ mask WRITE setMask)
 
 public:
-  ctkTransferFunctionGradientItem(QGraphicsItem* parent = 0);
+  ctkTransferFunctionGradientItem(QGraphicsItem* parent = nullptr);
   ctkTransferFunctionGradientItem(ctkTransferFunction* transferFunction, 
-                                  QGraphicsItem* parent = 0);
-  virtual ~ctkTransferFunctionGradientItem();
+                                  QGraphicsItem* parent = nullptr);
+  ~ctkTransferFunctionGradientItem() override;
 
-  virtual void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = 0);
+  void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = nullptr) override;
 
   bool mask()const;
   void setMask(bool mask);

--- a/Libs/Widgets/ctkTransferFunctionItem.h
+++ b/Libs/Widgets/ctkTransferFunctionItem.h
@@ -40,10 +40,10 @@ class CTK_WIDGETS_EXPORT ctkTransferFunctionItem: public QGraphicsObject
   Q_OBJECT
   Q_PROPERTY(QRectF rect READ rect WRITE setRect)
 public:
-  ctkTransferFunctionItem(QGraphicsItem* parent = 0);
+  ctkTransferFunctionItem(QGraphicsItem* parent = nullptr);
   ctkTransferFunctionItem(ctkTransferFunction* transferFunction, 
-                                  QGraphicsItem* parent = 0);
-  virtual ~ctkTransferFunctionItem();
+                                  QGraphicsItem* parent = nullptr);
+  ~ctkTransferFunctionItem() override;
 
   Q_INVOKABLE void setTransferFunction(ctkTransferFunction* transferFunction);
   ctkTransferFunction* transferFunction()const;
@@ -62,7 +62,7 @@ public:
   QPointF transferFunction2ScreenCoordinates( qreal x, qreal y);
   QPointF screen2TransferFunctionCoordinates( qreal x, qreal y);
 */
-  virtual QRectF boundingRect()const;
+  QRectF boundingRect()const override;
 protected:
   //qreal y(const QVariant& value)const;
   //inline qreal y(const ctkPoint& point)const;
@@ -72,7 +72,7 @@ protected:
 
   //QList<ctkPoint> bezierParams(ctkControlPoint* start, ctkControlPoint* end)const;
   //QList<ctkPoint> nonLinearPoints(ctkControlPoint* start, ctkControlPoint* end)const;
-  virtual QVariant itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant& value);
+  QVariant itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant& value) override;
 protected:
   QScopedPointer<ctkTransferFunctionItemPrivate> d_ptr;
 

--- a/Libs/Widgets/ctkTransferFunctionScene.h
+++ b/Libs/Widgets/ctkTransferFunctionScene.h
@@ -41,8 +41,8 @@ class CTK_WIDGETS_EXPORT ctkTransferFunctionScene: public QGraphicsScene
   Q_OBJECT
 
 public:
-  ctkTransferFunctionScene(QObject* parent = 0);
-  virtual ~ctkTransferFunctionScene();
+  ctkTransferFunctionScene(QObject* parent = nullptr);
+  ~ctkTransferFunctionScene() override;
 
 protected:
   QScopedPointer<ctkTransferFunctionScenePrivate> d_ptr;

--- a/Libs/Widgets/ctkTransferFunctionView.h
+++ b/Libs/Widgets/ctkTransferFunctionView.h
@@ -37,10 +37,10 @@ class CTK_WIDGETS_EXPORT ctkTransferFunctionView: public QGraphicsView
 {
   Q_OBJECT;
 public:
-  ctkTransferFunctionView(QWidget* parent = 0);
-  virtual ~ctkTransferFunctionView();
+  ctkTransferFunctionView(QWidget* parent = nullptr);
+  ~ctkTransferFunctionView() override;
 protected:
-  virtual void resizeEvent(QResizeEvent * event);
+  void resizeEvent(QResizeEvent * event) override;
   /*
   virtual void dragEnterEvent ( QDragEnterEvent * event );
   virtual void mousePressEvent ( QMouseEvent * event );

--- a/Libs/Widgets/ctkTreeComboBox.h
+++ b/Libs/Widgets/ctkTreeComboBox.h
@@ -55,15 +55,15 @@ class CTK_WIDGETS_EXPORT ctkTreeComboBox : public QComboBox
   Q_PROPERTY(int visibleModelColumn READ visibleModelColumn WRITE setVisibleModelColumn)
 public:
   typedef QComboBox Superclass;
-  explicit ctkTreeComboBox(QWidget* parent = 0);
-  virtual ~ctkTreeComboBox();
+  explicit ctkTreeComboBox(QWidget* parent = nullptr);
+  ~ctkTreeComboBox() override;
 
   int visibleModelColumn()const;
   void setVisibleModelColumn(int index);
 
-  virtual bool eventFilter(QObject* object, QEvent* event);
-  virtual void showPopup();
-  virtual void hidePopup();
+  bool eventFilter(QObject* object, QEvent* event) override;
+  void showPopup() override;
+  void hidePopup() override;
   
   /// ctkTreeComboBox uses a QTreeView for its model view. treeView() is a
   /// utility function that cast QComboBox::view() into a QTreeView.
@@ -71,7 +71,7 @@ public:
   QTreeView* treeView()const;
 
 protected:
-  virtual void paintEvent(QPaintEvent*);
+  void paintEvent(QPaintEvent*) override;
   
 protected Q_SLOTS:
   void resizePopup();


### PR DESCRIPTION
Check Slicer wiki for more information about how clang-tidy was run:
https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide#C.2B.2B11:_Update_source_code_to_use_nullptr

This files where automatically fixed when running clang-tidy in Slicer.

I am discarding this and other third-party changes, but opening this PR as a reference.