### PR TITLE
BUG: Python3: Fix initialization of PythonQt module

### DIFF
--- a/CMake/ctkMacroWrapPythonQtModuleInit.cpp.in
+++ b/CMake/ctkMacroWrapPythonQtModuleInit.cpp.in
@@ -100,7 +100,7 @@ void init@TARGET_CONFIG@PythonQt()
     {
     PyErr_SetString(PyExc_ImportError, (char*)"Failed to import PythonQt.@TARGET_CONFIG@");
 #if PY_MAJOR_VERSION >= 3
-    Py_RETURN_NONE;
+    return NULL;
 #else
     return;
 #endif


### PR DESCRIPTION
This commit avoids the error "SystemError: initialization
of CTK<LibName>PythonQt raised unreported exception"
from being reported when no PythonQt wrapper are associated
with <LibName>.

As discussed in [1], " module init functions should
return NULL in order to communicate that an exception
occurred during initialization"

[1] https://github.com/numpy/numpy/pull/10775#issue-176368003