### PR TITLE
Add ctkErrorLogAbstractModel to CTKCore library

### DIFF
--- a/Libs/Core/CMakeLists.txt
+++ b/Libs/Core/CMakeLists.txt
@@ -44,6 +44,8 @@ set(KIT_SRCS
   ctkDependencyGraph.h
   ctkErrorLogAbstractMessageHandler.cpp
   ctkErrorLogAbstractMessageHandler.h
+  ctkErrorLogAbstractModel.cpp
+  ctkErrorLogAbstractModel.h
   ctkErrorLogContext.h
   ctkErrorLogFDMessageHandler.cpp
   ctkErrorLogFDMessageHandler.h
@@ -99,6 +101,7 @@ set(KIT_MOC_SRCS
   ctkCallback.h
   ctkCommandLineParser.h
   ctkErrorLogAbstractMessageHandler.h
+  ctkErrorLogAbstractModel.h
   ctkErrorLogFDMessageHandler_p.h
   ctkErrorLogLevel.h
   ctkErrorLogQtMessageHandler.h

--- a/Libs/Core/ctkErrorLogAbstractModel.cpp
+++ b/Libs/Core/ctkErrorLogAbstractModel.cpp
@@ -1,0 +1,560 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+// Qt includes
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QDebug>
+#include <QFile>
+#include <QMetaEnum>
+#include <QMetaType>
+#include <QMutexLocker>
+#include <QPointer>
+#include <QStringList>
+#include <QThread>
+
+// CTK includes
+#include "ctkErrorLogContext.h"
+#include "ctkErrorLogAbstractModel.h"
+#include "ctkErrorLogAbstractMessageHandler.h"
+#include "ctkFileLogger.h"
+
+
+// --------------------------------------------------------------------------
+// ctkErrorLogAbstractModelPrivate
+
+// --------------------------------------------------------------------------
+class ctkErrorLogAbstractModelPrivate
+{
+  Q_DECLARE_PUBLIC(ctkErrorLogAbstractModel);
+protected:
+  ctkErrorLogAbstractModel* const q_ptr;
+public:
+  ctkErrorLogAbstractModelPrivate(ctkErrorLogAbstractModel& object);
+  ~ctkErrorLogAbstractModelPrivate();
+
+  void init(QAbstractItemModel* itemModel);
+
+  void setMessageHandlerConnection(ctkErrorLogAbstractMessageHandler * msgHandler, bool asynchronous);
+
+  QAbstractItemModel* ItemModel;
+
+  QHash<QString, ctkErrorLogAbstractMessageHandler*> RegisteredHandlers;
+
+  ctkErrorLogLevel::LogLevels CurrentLogLevelFilter;
+
+  bool LogEntryGrouping;
+  bool AsynchronousLogging;
+  bool AddingEntry;
+
+  ctkErrorLogLevel ErrorLogLevel;
+
+  ctkErrorLogTerminalOutput StdErrTerminalOutput;
+  ctkErrorLogTerminalOutput StdOutTerminalOutput;
+
+  ctkFileLogger FileLogger;
+  QString FileLoggingPattern;
+};
+
+// --------------------------------------------------------------------------
+// ctkErrorLogAbstractModelPrivate methods
+
+// --------------------------------------------------------------------------
+ctkErrorLogAbstractModelPrivate::ctkErrorLogAbstractModelPrivate(ctkErrorLogAbstractModel& object)
+  : q_ptr(&object)
+{
+  qRegisterMetaType<ctkErrorLogContext>("ctkErrorLogContext");
+  this->LogEntryGrouping = false;
+  this->AsynchronousLogging = true;
+  this->AddingEntry = false;
+  this->FileLogger.setEnabled(false);
+  this->FileLoggingPattern = "[%{level}][%{origin}] %{timestamp} [%{category}] (%{file}:%{line}) - %{msg}";
+}
+
+// --------------------------------------------------------------------------
+ctkErrorLogAbstractModelPrivate::~ctkErrorLogAbstractModelPrivate()
+{
+  foreach(const QString& handlerName, this->RegisteredHandlers.keys())
+    {
+    ctkErrorLogAbstractMessageHandler * msgHandler =
+        this->RegisteredHandlers.value(handlerName);
+    Q_ASSERT(msgHandler);
+    msgHandler->setEnabled(false);
+    delete msgHandler;
+    }
+}
+
+// --------------------------------------------------------------------------
+void ctkErrorLogAbstractModelPrivate::init(QAbstractItemModel* itemModel)
+{
+  Q_Q(ctkErrorLogAbstractModel);
+  itemModel->setParent(q);
+  q->setDynamicSortFilter(true);
+  //
+  // WARNING - Using a QSortFilterProxyModel slows down the insertion of rows by a factor 10
+  //
+  q->setSourceModel(itemModel);
+  q->setFilterKeyColumn(ctkErrorLogAbstractModel::LogLevelColumn);
+
+  this->ItemModel = itemModel;
+}
+
+// --------------------------------------------------------------------------
+void ctkErrorLogAbstractModelPrivate::setMessageHandlerConnection(
+    ctkErrorLogAbstractMessageHandler * msgHandler, bool asynchronous)
+{
+  Q_Q(ctkErrorLogAbstractModel);
+
+  msgHandler->disconnect();
+
+  QObject::connect(msgHandler,
+        SIGNAL(messageHandled(QDateTime,QString,ctkErrorLogLevel::LogLevel,QString,ctkErrorLogContext,QString)),
+        q, SLOT(addEntry(QDateTime,QString,ctkErrorLogLevel::LogLevel,QString,ctkErrorLogContext,QString)),
+        asynchronous ? Qt::QueuedConnection : Qt::BlockingQueuedConnection);
+}
+
+// --------------------------------------------------------------------------
+// ctkErrorLogAbstractModel methods
+
+//------------------------------------------------------------------------------
+ctkErrorLogAbstractModel::ctkErrorLogAbstractModel(QAbstractItemModel* itemModel, QObject * parentObject)
+  : Superclass(parentObject)
+  , d_ptr(new ctkErrorLogAbstractModelPrivate(*this))
+{
+  Q_D(ctkErrorLogAbstractModel);
+
+  d->init(itemModel);
+}
+
+//------------------------------------------------------------------------------
+ctkErrorLogAbstractModel::~ctkErrorLogAbstractModel()
+{
+}
+
+//------------------------------------------------------------------------------
+bool ctkErrorLogAbstractModel::registerMsgHandler(ctkErrorLogAbstractMessageHandler * msgHandler)
+{
+  Q_D(ctkErrorLogAbstractModel);
+  if (!msgHandler)
+    {
+    return false;
+    }
+  if (d->RegisteredHandlers.keys().contains(msgHandler->handlerName()))
+    {
+    return false;
+    }
+
+  d->setMessageHandlerConnection(msgHandler, d->AsynchronousLogging);
+
+  msgHandler->setTerminalOutput(ctkErrorLogTerminalOutput::StandardError, &d->StdErrTerminalOutput);
+  msgHandler->setTerminalOutput(ctkErrorLogTerminalOutput::StandardOutput, &d->StdOutTerminalOutput);
+
+  d->RegisteredHandlers.insert(msgHandler->handlerName(), msgHandler);
+  return true;
+}
+
+//------------------------------------------------------------------------------
+QStringList ctkErrorLogAbstractModel::msgHandlerNames()const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  return d->RegisteredHandlers.keys();
+}
+
+//------------------------------------------------------------------------------
+bool ctkErrorLogAbstractModel::msgHandlerEnabled(const QString& handlerName) const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  if (!d->RegisteredHandlers.keys().contains(handlerName))
+    {
+    return false;
+    }
+  return d->RegisteredHandlers.value(handlerName)->enabled();
+}
+
+//------------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::setMsgHandlerEnabled(const QString& handlerName, bool enabled)
+{
+  Q_D(ctkErrorLogAbstractModel);
+  if (!d->RegisteredHandlers.keys().contains(handlerName))
+    {
+//    qCritical() << "Failed to enable/disable message handler " << handlerName
+//                << "-  Handler not registered !";
+    return;
+    }
+  d->RegisteredHandlers.value(handlerName)->setEnabled(enabled);
+}
+
+//------------------------------------------------------------------------------
+QStringList ctkErrorLogAbstractModel::msgHandlerEnabled() const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  QStringList msgHandlers;
+  foreach(const QString& handlerName, d->RegisteredHandlers.keys())
+    {
+    if (d->RegisteredHandlers.value(handlerName)->enabled())
+      {
+      msgHandlers << handlerName;
+      }
+    }
+  return msgHandlers;
+}
+
+//------------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::setMsgHandlerEnabled(const QStringList& handlerNames)
+{
+  foreach(const QString& handlerName, handlerNames)
+    {
+    this->setMsgHandlerEnabled(handlerName, true);
+    }
+}
+
+//------------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::enableAllMsgHandler()
+{
+  this->setAllMsgHandlerEnabled(true);
+}
+
+//------------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::disableAllMsgHandler()
+{
+  this->setAllMsgHandlerEnabled(false);
+}
+
+//------------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::setAllMsgHandlerEnabled(bool enabled)
+{
+  Q_D(ctkErrorLogAbstractModel);
+  foreach(const QString& msgHandlerName, d->RegisteredHandlers.keys())
+    {
+    this->setMsgHandlerEnabled(msgHandlerName, enabled);
+    }
+}
+
+//------------------------------------------------------------------------------
+ctkErrorLogTerminalOutput::TerminalOutputs ctkErrorLogAbstractModel::terminalOutputs()const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  ctkErrorLogTerminalOutput::TerminalOutputs currentTerminalOutputs;
+  currentTerminalOutputs |= d->StdErrTerminalOutput.enabled() ? ctkErrorLogTerminalOutput::StandardError : ctkErrorLogTerminalOutput::None;
+  currentTerminalOutputs |= d->StdOutTerminalOutput.enabled() ? ctkErrorLogTerminalOutput::StandardOutput : ctkErrorLogTerminalOutput::None;
+  return currentTerminalOutputs;
+}
+
+//------------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::setTerminalOutputs(
+    const ctkErrorLogTerminalOutput::TerminalOutputs& terminalOutput)
+{
+  Q_D(ctkErrorLogAbstractModel);
+  d->StdErrTerminalOutput.setEnabled(terminalOutput & ctkErrorLogTerminalOutput::StandardOutput);
+  d->StdOutTerminalOutput.setEnabled(terminalOutput & ctkErrorLogTerminalOutput::StandardError);
+}
+
+//------------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::addEntry(const QDateTime& currentDateTime, const QString& threadId,
+                                ctkErrorLogLevel::LogLevel logLevel,
+                                const QString& origin, const ctkErrorLogContext &context, const QString &text)
+{
+  Q_D(ctkErrorLogAbstractModel);
+
+  if (d->AddingEntry)
+    {
+    return;
+    }
+
+  d->AddingEntry = true;
+
+  QString timeFormat("dd.MM.yyyy hh:mm:ss");
+
+  bool groupEntry = false;
+  if (d->LogEntryGrouping)
+    {
+    int lastRowIndex = d->ItemModel->rowCount() - 1;
+
+    QString lastRowThreadId = this->logEntryData(lastRowIndex, Self::ThreadIdColumn).toString();
+    bool threadIdMatched = threadId == lastRowThreadId;
+
+    QString lastRowLogLevel = this->logEntryData(lastRowIndex, Self::LogLevelColumn).toString();
+    bool logLevelMatched = d->ErrorLogLevel(logLevel) == lastRowLogLevel;
+
+    QString lastRowOrigin = this->logEntryData(lastRowIndex, Self::OriginColumn).toString();
+    bool originMatched = origin == lastRowOrigin;
+
+    QDateTime lastRowDateTime =
+        QDateTime::fromString(this->logEntryData(lastRowIndex, Self::TimeColumn).toString(), timeFormat);
+    int groupingIntervalInMsecs = 1000;
+    bool withinGroupingInterval = lastRowDateTime.time().msecsTo(currentDateTime.time()) <= groupingIntervalInMsecs;
+
+    groupEntry = threadIdMatched && logLevelMatched && originMatched && withinGroupingInterval;
+    }
+
+  if (!groupEntry)
+    {
+    this->addModelEntry(
+      currentDateTime.toString(timeFormat), threadId, d->ErrorLogLevel(logLevel), origin, text);
+    }
+  else
+    {
+    // Retrieve description associated with last row
+    QModelIndex lastRowDescriptionIndex =
+        d->ItemModel->index(d->ItemModel->rowCount() - 1, ctkErrorLogAbstractModel::DescriptionColumn);
+
+    QStringList updatedDescription;
+    updatedDescription << lastRowDescriptionIndex.data(ctkErrorLogAbstractModel::DescriptionTextRole).toString();
+    updatedDescription << text;
+
+    d->ItemModel->setData(lastRowDescriptionIndex, updatedDescription.join("\n"),
+                                 ctkErrorLogAbstractModel::DescriptionTextRole);
+
+    // Append '...' to displayText if needed
+    QString displayText = lastRowDescriptionIndex.data().toString();
+    if (!displayText.endsWith("..."))
+      {
+      d->ItemModel->setData(lastRowDescriptionIndex, displayText.append("..."), Qt::DisplayRole);
+      }
+    }
+
+  d->AddingEntry = false;
+
+  QString fileLogText = d->FileLoggingPattern;
+  fileLogText.replace("%{level}", d->ErrorLogLevel(logLevel).toUpper());
+  fileLogText.replace("%{timestamp}", currentDateTime.toString(timeFormat));
+  fileLogText.replace("%{origin}", origin);
+  fileLogText.replace("%{pid}", QString("%1").arg(QCoreApplication::applicationPid()));
+  fileLogText.replace("%{threadid}", threadId);
+  fileLogText.replace("%{function}", context.Function);
+  fileLogText.replace("%{line}", QString("%1").arg(context.Line));
+  fileLogText.replace("%{file}", context.File);
+  fileLogText.replace("%{category}", context.Category);
+  fileLogText.replace("%{msg}", context.Message);
+  d->FileLogger.logMessage(fileLogText.trimmed());
+
+  emit this->entryAdded(logLevel);
+}
+
+//------------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::clear()
+{
+  Q_D(ctkErrorLogAbstractModel);
+  d->ItemModel->removeRows(0, d->ItemModel->rowCount());
+}
+
+//------------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::filterEntry(const ctkErrorLogLevel::LogLevels& logLevel,
+                                   bool disableFilter)
+{
+  Q_D(ctkErrorLogAbstractModel);
+
+  QStringList patterns;
+  if (!this->filterRegExp().pattern().isEmpty())
+    {
+    patterns << this->filterRegExp().pattern().split("|");
+    }
+  patterns.removeAll(d->ErrorLogLevel(ctkErrorLogLevel::None));
+
+//  foreach(QString s, patterns)
+//    {
+//    std::cout << "pattern:" << qPrintable(s) << std::endl;
+//    }
+
+  QMetaEnum logLevelEnum = d->ErrorLogLevel.metaObject()->enumerator(0);
+  Q_ASSERT(QString("LogLevel").compare(logLevelEnum.name()) == 0);
+
+  // Loop over enum values and append associated name to 'patterns' if
+  // it has been specified within 'logLevel'
+  for (int i = 1; i < logLevelEnum.keyCount(); ++i)
+    {
+    int aLogLevel = logLevelEnum.value(i);
+    if (logLevel & aLogLevel)
+      {
+      QString logLevelAsString = d->ErrorLogLevel(static_cast<ctkErrorLogLevel::LogLevel>(aLogLevel));
+      if (!disableFilter)
+        {
+        patterns << logLevelAsString;
+        d->CurrentLogLevelFilter |= static_cast<ctkErrorLogLevel::LogLevels>(aLogLevel);
+        }
+      else
+        {
+        patterns.removeAll(logLevelAsString);
+        d->CurrentLogLevelFilter ^= static_cast<ctkErrorLogLevel::LogLevels>(aLogLevel);
+        }
+      }
+    }
+
+  if (patterns.isEmpty())
+    {
+    // If there are no patterns, let's filter with the None level so that
+    // all entries are filtered out.
+    patterns << d->ErrorLogLevel(ctkErrorLogLevel::None);
+    }
+
+  bool filterChanged = true;
+  QStringList currentPatterns = this->filterRegExp().pattern().split("|");
+  if (currentPatterns.count() == patterns.count())
+    {
+    foreach(const QString& p, patterns)
+      {
+      currentPatterns.removeAll(p);
+      }
+    filterChanged = currentPatterns.count() > 0;
+    }
+
+  this->setFilterRegExp(patterns.join("|"));
+
+  if (filterChanged)
+    {
+    emit this->logLevelFilterChanged();
+    }
+}
+
+//------------------------------------------------------------------------------
+ctkErrorLogLevel::LogLevels ctkErrorLogAbstractModel::logLevelFilter()const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  QMetaEnum logLevelEnum = d->ErrorLogLevel.metaObject()->enumerator(0);
+  Q_ASSERT(QString("LogLevel").compare(logLevelEnum.name()) == 0);
+
+  ctkErrorLogLevel::LogLevels filter = ctkErrorLogLevel::Unknown;
+  foreach(const QString& filterAsString, this->filterRegExp().pattern().split("|"))
+    {
+    filter |= static_cast<ctkErrorLogLevel::LogLevels>(logLevelEnum.keyToValue(filterAsString.toLatin1()));
+    }
+  return filter;
+}
+
+//------------------------------------------------------------------------------
+bool ctkErrorLogAbstractModel::logEntryGrouping()const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  return d->LogEntryGrouping;
+}
+
+//------------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::setLogEntryGrouping(bool value)
+{
+  Q_D(ctkErrorLogAbstractModel);
+  d->LogEntryGrouping = value;
+}
+
+//------------------------------------------------------------------------------
+bool ctkErrorLogAbstractModel::asynchronousLogging()const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  return d->AsynchronousLogging;
+}
+
+//------------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::setAsynchronousLogging(bool value)
+{
+  Q_D(ctkErrorLogAbstractModel);
+  if (d->AsynchronousLogging == value)
+    {
+    return;
+    }
+
+  foreach(const QString& handlerName, d->RegisteredHandlers.keys())
+    {
+    d->setMessageHandlerConnection(
+          d->RegisteredHandlers.value(handlerName), value);
+    }
+
+  d->AsynchronousLogging = value;
+}
+
+// --------------------------------------------------------------------------
+QString ctkErrorLogAbstractModel::filePath()const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  return d->FileLogger.filePath();
+}
+
+// --------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::setFilePath(const QString& filePath)
+{
+  Q_D(ctkErrorLogAbstractModel);
+  return d->FileLogger.setFilePath(filePath);
+}
+
+// --------------------------------------------------------------------------
+int ctkErrorLogAbstractModel::numberOfFilesToKeep()const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  return d->FileLogger.numberOfFilesToKeep();
+}
+
+// --------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::setNumberOfFilesToKeep(int value)
+{
+  Q_D(ctkErrorLogAbstractModel);
+  return d->FileLogger.setNumberOfFilesToKeep(value);
+}
+
+// --------------------------------------------------------------------------
+bool ctkErrorLogAbstractModel::fileLoggingEnabled()const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  return d->FileLogger.enabled();
+}
+
+// --------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::setFileLoggingEnabled(bool value)
+{
+  Q_D(ctkErrorLogAbstractModel);
+  d->FileLogger.setEnabled(value);
+}
+
+// --------------------------------------------------------------------------
+QString ctkErrorLogAbstractModel::fileLoggingPattern()const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  return d->FileLoggingPattern;
+}
+
+// --------------------------------------------------------------------------
+void ctkErrorLogAbstractModel::setFileLoggingPattern(const QString& value)
+{
+  Q_D(ctkErrorLogAbstractModel);
+  d->FileLoggingPattern = value;
+}
+
+// --------------------------------------------------------------------------
+QVariant ctkErrorLogAbstractModel::logEntryData(int row, int column, int role) const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  if (column < 0 || column > Self::MaxColumn
+      || row < 0 || row > this->logEntryCount())
+    {
+    return QVariant();
+    }
+  QModelIndex rowDescriptionIndex = d->ItemModel->index(row, column);
+  return rowDescriptionIndex.data(role);
+}
+
+// --------------------------------------------------------------------------
+QString ctkErrorLogAbstractModel::logEntryDescription(int row) const
+{
+  return this->logEntryData(row, Self::DescriptionColumn, Self::DescriptionTextRole).toString();
+}
+
+// --------------------------------------------------------------------------
+int ctkErrorLogAbstractModel::logEntryCount()const
+{
+  Q_D(const ctkErrorLogAbstractModel);
+  return d->ItemModel->rowCount();
+}

--- a/Libs/Core/ctkErrorLogAbstractModel.h
+++ b/Libs/Core/ctkErrorLogAbstractModel.h
@@ -1,0 +1,162 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+#ifndef __ctkErrorLogAbstractModel_h
+#define __ctkErrorLogAbstractModel_h
+
+// Qt includes
+#include <QSortFilterProxyModel>
+
+// CTK includes
+#include "ctkCoreExport.h"
+#include "ctkErrorLogLevel.h"
+#include "ctkErrorLogTerminalOutput.h"
+
+//------------------------------------------------------------------------------
+class ctkErrorLogAbstractMessageHandler;
+class ctkErrorLogAbstractModelPrivate;
+struct ctkErrorLogContext;
+
+//------------------------------------------------------------------------------
+/// \ingroup Widgets
+class CTK_CORE_EXPORT ctkErrorLogAbstractModel : public QSortFilterProxyModel
+{
+  Q_OBJECT
+  Q_PROPERTY(bool logEntryGrouping READ logEntryGrouping WRITE setLogEntryGrouping)
+  Q_PROPERTY(ctkErrorLogTerminalOutput::TerminalOutputs terminalOutputs READ terminalOutputs WRITE setTerminalOutputs)
+  Q_PROPERTY(bool asynchronousLogging READ asynchronousLogging WRITE  setAsynchronousLogging)
+  Q_PROPERTY(QString filePath READ filePath WRITE  setFilePath)
+  Q_PROPERTY(int numberOfFilesToKeep READ numberOfFilesToKeep WRITE  setNumberOfFilesToKeep)
+  Q_PROPERTY(bool fileLoggingEnabled READ fileLoggingEnabled WRITE  setFileLoggingEnabled)
+  Q_PROPERTY(QString fileLoggingPattern READ fileLoggingPattern WRITE setFileLoggingPattern)
+public:
+  typedef QSortFilterProxyModel Superclass;
+  typedef ctkErrorLogAbstractModel Self;
+  explicit ctkErrorLogAbstractModel(QAbstractItemModel* itemModel, QObject* parentObject = 0);
+  virtual ~ctkErrorLogAbstractModel();
+
+  enum ColumnsIds
+    {
+    TimeColumn = 0,
+    ThreadIdColumn,
+    LogLevelColumn,
+    OriginColumn,
+    DescriptionColumn,
+    MaxColumn = DescriptionColumn
+    };
+
+  enum ItemDataRole{
+    DescriptionTextRole = Qt::UserRole + 1
+    };
+
+  /// Register a message handler.
+  bool registerMsgHandler(ctkErrorLogAbstractMessageHandler * msgHandler);
+
+  QStringList msgHandlerNames()const;
+
+  /// Return True if the handler identified by \a handlerName is enabled
+  bool msgHandlerEnabled(const QString& handlerName) const;
+
+  /// Enable a specific handler given its name
+  void setMsgHandlerEnabled(const QString& handlerName, bool enabled);
+
+  /// Return names of the enabled message handlers
+  QStringList msgHandlerEnabled()const;
+
+  /// Enable handler identified by their names
+  void setMsgHandlerEnabled(const QStringList& handlerNames);
+
+  void enableAllMsgHandler();
+  void disableAllMsgHandler();
+  void setAllMsgHandlerEnabled(bool enabled);
+
+  /// Return if messages are both printed into the terminal and added to ctkErrorLogAbstractModel.
+  /// \note If TerminalOutput::None is returned, message will only be added to the model.
+  ctkErrorLogTerminalOutput::TerminalOutputs terminalOutputs()const;
+
+  /// Set terminal output mode
+  /// \sa terminalOutputs()
+  /// \sa TerminalOutput
+  void setTerminalOutputs(const ctkErrorLogTerminalOutput::TerminalOutputs& terminalOutput);
+
+  ctkErrorLogLevel::LogLevels logLevelFilter()const;
+
+  void filterEntry(const ctkErrorLogLevel::LogLevels& logLevel = ctkErrorLogLevel::Unknown, bool disableFilter = false);
+
+  bool logEntryGrouping()const;
+  void setLogEntryGrouping(bool value);
+
+  bool asynchronousLogging()const;
+  void setAsynchronousLogging(bool value);
+
+  QString filePath()const;
+  void setFilePath(const QString& filePath);
+
+  int numberOfFilesToKeep()const;
+  void setNumberOfFilesToKeep(int value);
+
+  bool fileLoggingEnabled()const;
+  void setFileLoggingEnabled(bool value);
+
+  QString fileLoggingPattern()const;
+  void setFileLoggingPattern(const QString& value);
+
+  /// Return log entry information associated with \a row and \a column.
+  /// \internal
+  QVariant logEntryData(int row,
+                        int column = ctkErrorLogAbstractModel::DescriptionColumn,
+                        int role = Qt::DisplayRole) const;
+
+  /// Return log entry information associated with Description column.
+  /// \sa ctkErrorLogAbstractModel::DescriptionColumn, logEntryData()
+  Q_INVOKABLE QString logEntryDescription(int row) const;
+
+  /// Return current number of log entries.
+  /// \sa clear()
+  Q_INVOKABLE int logEntryCount() const;
+
+public Q_SLOTS:
+
+  /// Remove all log entries from model
+  void clear();
+
+  /// \sa logEntryGrouping(), asynchronousLogging()
+  void addEntry(const QDateTime& currentDateTime, const QString& threadId,
+                ctkErrorLogLevel::LogLevel logLevel, const QString& origin,
+                const ctkErrorLogContext &context, const QString& text);
+
+Q_SIGNALS:
+  void logLevelFilterChanged();
+
+  /// \sa addEntry()
+  void entryAdded(ctkErrorLogLevel::LogLevel logLevel);
+
+protected:
+  QScopedPointer<ctkErrorLogAbstractModelPrivate> d_ptr;
+
+  virtual void addModelEntry(const QString& currentDateTime, const QString& threadId,
+                             const QString& logLevel, const QString& origin, const QString& descriptionText) = 0;
+
+private:
+  Q_DECLARE_PRIVATE(ctkErrorLogAbstractModel)
+  Q_DISABLE_COPY(ctkErrorLogAbstractModel)
+};
+
+#endif

--- a/Libs/Widgets/ctkErrorLogModel.cpp
+++ b/Libs/Widgets/ctkErrorLogModel.cpp
@@ -19,22 +19,10 @@
 =========================================================================*/
 
 // Qt includes
-#include <QCoreApplication>
-#include <QDateTime>
-#include <QDebug>
-#include <QFile>
-#include <QMetaEnum>
-#include <QMetaType>
-#include <QMutexLocker>
-#include <QPointer>
 #include <QStandardItem>
-#include <QThread>
 
 // CTK includes
-#include "ctkErrorLogContext.h"
 #include "ctkErrorLogModel.h"
-#include "ctkErrorLogAbstractMessageHandler.h"
-#include "ctkFileLogger.h"
 
 
 // --------------------------------------------------------------------------
@@ -49,28 +37,6 @@ protected:
 public:
   ctkErrorLogModelPrivate(ctkErrorLogModel& object);
   ~ctkErrorLogModelPrivate();
-
-  void init();
-
-  void setMessageHandlerConnection(ctkErrorLogAbstractMessageHandler * msgHandler, bool asynchronous);
-
-  QStandardItemModel StandardItemModel;
-
-  QHash<QString, ctkErrorLogAbstractMessageHandler*> RegisteredHandlers;
-
-  ctkErrorLogLevel::LogLevels CurrentLogLevelFilter;
-
-  bool LogEntryGrouping;
-  bool AsynchronousLogging;
-  bool AddingEntry;
-
-  ctkErrorLogLevel ErrorLogLevel;
-
-  ctkErrorLogTerminalOutput StdErrTerminalOutput;
-  ctkErrorLogTerminalOutput StdOutTerminalOutput;
-
-  ctkFileLogger FileLogger;
-  QString FileLoggingPattern;
 };
 
 // --------------------------------------------------------------------------
@@ -80,52 +46,11 @@ public:
 ctkErrorLogModelPrivate::ctkErrorLogModelPrivate(ctkErrorLogModel& object)
   : q_ptr(&object)
 {
-  qRegisterMetaType<ctkErrorLogContext>("ctkErrorLogContext");
-  this->StandardItemModel.setColumnCount(ctkErrorLogModel::MaxColumn);
-  this->LogEntryGrouping = false;
-  this->AsynchronousLogging = true;
-  this->AddingEntry = false;
-  this->FileLogger.setEnabled(false);
-  this->FileLoggingPattern = "[%{level}][%{origin}] %{timestamp} [%{category}] (%{file}:%{line}) - %{msg}";
 }
 
 // --------------------------------------------------------------------------
 ctkErrorLogModelPrivate::~ctkErrorLogModelPrivate()
 {
-  foreach(const QString& handlerName, this->RegisteredHandlers.keys())
-    {
-    ctkErrorLogAbstractMessageHandler * msgHandler =
-        this->RegisteredHandlers.value(handlerName);
-    Q_ASSERT(msgHandler);
-    msgHandler->setEnabled(false);
-    delete msgHandler;
-    }
-}
-
-// --------------------------------------------------------------------------
-void ctkErrorLogModelPrivate::init()
-{
-  Q_Q(ctkErrorLogModel);
-  q->setDynamicSortFilter(true);
-  //
-  // WARNING - Using a QSortFilterProxyModel slows down the insertion of rows by a factor 10
-  //
-  q->setSourceModel(&this->StandardItemModel);
-  q->setFilterKeyColumn(ctkErrorLogModel::LogLevelColumn);
-}
-
-// --------------------------------------------------------------------------
-void ctkErrorLogModelPrivate::setMessageHandlerConnection(
-    ctkErrorLogAbstractMessageHandler * msgHandler, bool asynchronous)
-{
-  Q_Q(ctkErrorLogModel);
-
-  msgHandler->disconnect();
-
-  QObject::connect(msgHandler,
-        SIGNAL(messageHandled(QDateTime,QString,ctkErrorLogLevel::LogLevel,QString,ctkErrorLogContext,QString)),
-        q, SLOT(addEntry(QDateTime,QString,ctkErrorLogLevel::LogLevel,QString,ctkErrorLogContext,QString)),
-        asynchronous ? Qt::QueuedConnection : Qt::BlockingQueuedConnection);
 }
 
 // --------------------------------------------------------------------------
@@ -133,12 +58,12 @@ void ctkErrorLogModelPrivate::setMessageHandlerConnection(
 
 //------------------------------------------------------------------------------
 ctkErrorLogModel::ctkErrorLogModel(QObject * parentObject)
-  : Superclass(parentObject)
+  : Superclass(new QStandardItemModel(), parentObject)
   , d_ptr(new ctkErrorLogModelPrivate(*this))
 {
-  Q_D(ctkErrorLogModel);
-
-  d->init();
+  QStandardItemModel* itemModel = qobject_cast<QStandardItemModel*>(this->sourceModel());
+  Q_ASSERT(itemModel);
+  itemModel->setColumnCount(ctkErrorLogAbstractModel::MaxColumn);
 }
 
 //------------------------------------------------------------------------------
@@ -147,441 +72,41 @@ ctkErrorLogModel::~ctkErrorLogModel()
 }
 
 //------------------------------------------------------------------------------
-bool ctkErrorLogModel::registerMsgHandler(ctkErrorLogAbstractMessageHandler * msgHandler)
+void ctkErrorLogModel::addModelEntry(const QString& currentDateTime, const QString& threadId,
+                                     const QString& logLevel, const QString& origin, const QString& text)
 {
-  Q_D(ctkErrorLogModel);
-  if (!msgHandler)
-    {
-    return false;
-    }
-  if (d->RegisteredHandlers.keys().contains(msgHandler->handlerName()))
-    {
-    return false;
-    }
+  QList<QStandardItem*> itemList;
 
-  d->setMessageHandlerConnection(msgHandler, d->AsynchronousLogging);
+  // Time item
+  QStandardItem * timeItem = new QStandardItem(currentDateTime);
+  timeItem->setEditable(false);
+  itemList << timeItem;
 
-  msgHandler->setTerminalOutput(ctkErrorLogTerminalOutput::StandardError, &d->StdErrTerminalOutput);
-  msgHandler->setTerminalOutput(ctkErrorLogTerminalOutput::StandardOutput, &d->StdOutTerminalOutput);
+  // ThreadId item
+  QStandardItem * threadIdItem = new QStandardItem(threadId);
+  threadIdItem->setEditable(false);
+  itemList << threadIdItem;
 
-  d->RegisteredHandlers.insert(msgHandler->handlerName(), msgHandler);
-  return true;
+  // LogLevel item
+  QStandardItem * logLevelItem = new QStandardItem(logLevel);
+  logLevelItem->setEditable(false);
+  itemList << logLevelItem;
+
+  // Origin item
+  QStandardItem * originItem = new QStandardItem(origin);
+  originItem->setEditable(false);
+  itemList << originItem;
+
+  // Description item
+  QStandardItem * descriptionItem = new QStandardItem();
+  QString descriptionText(text);
+  descriptionItem->setData(descriptionText.left(160).append((descriptionText.size() > 160) ? "..." : ""), Qt::DisplayRole);
+  descriptionItem->setData(descriptionText, ctkErrorLogModel::DescriptionTextRole);
+  descriptionItem->setEditable(false);
+  itemList << descriptionItem;
+
+  QStandardItemModel* itemModel = qobject_cast<QStandardItemModel*>(this->sourceModel());
+  Q_ASSERT(itemModel);
+  itemModel->invisibleRootItem()->appendRow(itemList);
 }
 
-//------------------------------------------------------------------------------
-QStringList ctkErrorLogModel::msgHandlerNames()const
-{
-  Q_D(const ctkErrorLogModel);
-  return d->RegisteredHandlers.keys();
-}
-
-//------------------------------------------------------------------------------
-bool ctkErrorLogModel::msgHandlerEnabled(const QString& handlerName) const
-{
-  Q_D(const ctkErrorLogModel);
-  if (!d->RegisteredHandlers.keys().contains(handlerName))
-    {
-    return false;
-    }
-  return d->RegisteredHandlers.value(handlerName)->enabled();
-}
-
-//------------------------------------------------------------------------------
-void ctkErrorLogModel::setMsgHandlerEnabled(const QString& handlerName, bool enabled)
-{
-  Q_D(ctkErrorLogModel);
-  if (!d->RegisteredHandlers.keys().contains(handlerName))
-    {
-//    qCritical() << "Failed to enable/disable message handler " << handlerName
-//                << "-  Handler not registered !";
-    return;
-    }
-  d->RegisteredHandlers.value(handlerName)->setEnabled(enabled);
-}
-
-//------------------------------------------------------------------------------
-QStringList ctkErrorLogModel::msgHandlerEnabled() const
-{
-  Q_D(const ctkErrorLogModel);
-  QStringList msgHandlers;
-  foreach(const QString& handlerName, d->RegisteredHandlers.keys())
-    {
-    if (d->RegisteredHandlers.value(handlerName)->enabled())
-      {
-      msgHandlers << handlerName;
-      }
-    }
-  return msgHandlers;
-}
-
-//------------------------------------------------------------------------------
-void ctkErrorLogModel::setMsgHandlerEnabled(const QStringList& handlerNames)
-{
-  foreach(const QString& handlerName, handlerNames)
-    {
-    this->setMsgHandlerEnabled(handlerName, true);
-    }
-}
-
-//------------------------------------------------------------------------------
-void ctkErrorLogModel::enableAllMsgHandler()
-{
-  this->setAllMsgHandlerEnabled(true);
-}
-
-//------------------------------------------------------------------------------
-void ctkErrorLogModel::disableAllMsgHandler()
-{
-  this->setAllMsgHandlerEnabled(false);
-}
-
-//------------------------------------------------------------------------------
-void ctkErrorLogModel::setAllMsgHandlerEnabled(bool enabled)
-{
-  Q_D(ctkErrorLogModel);
-  foreach(const QString& msgHandlerName, d->RegisteredHandlers.keys())
-    {
-    this->setMsgHandlerEnabled(msgHandlerName, enabled);
-    }
-}
-
-//------------------------------------------------------------------------------
-ctkErrorLogTerminalOutput::TerminalOutputs ctkErrorLogModel::terminalOutputs()const
-{
-  Q_D(const ctkErrorLogModel);
-  ctkErrorLogTerminalOutput::TerminalOutputs currentTerminalOutputs;
-  currentTerminalOutputs |= d->StdErrTerminalOutput.enabled() ? ctkErrorLogTerminalOutput::StandardError : ctkErrorLogTerminalOutput::None;
-  currentTerminalOutputs |= d->StdOutTerminalOutput.enabled() ? ctkErrorLogTerminalOutput::StandardOutput : ctkErrorLogTerminalOutput::None;
-  return currentTerminalOutputs;
-}
-
-//------------------------------------------------------------------------------
-void ctkErrorLogModel::setTerminalOutputs(
-    const ctkErrorLogTerminalOutput::TerminalOutputs& terminalOutput)
-{
-  Q_D(ctkErrorLogModel);
-  d->StdErrTerminalOutput.setEnabled(terminalOutput & ctkErrorLogTerminalOutput::StandardOutput);
-  d->StdOutTerminalOutput.setEnabled(terminalOutput & ctkErrorLogTerminalOutput::StandardError);
-}
-
-//------------------------------------------------------------------------------
-void ctkErrorLogModel::addEntry(const QDateTime& currentDateTime, const QString& threadId,
-                                ctkErrorLogLevel::LogLevel logLevel,
-                                const QString& origin, const ctkErrorLogContext &context, const QString &text)
-{
-  Q_D(ctkErrorLogModel);
-
-  if (d->AddingEntry)
-    {
-    return;
-    }
-
-  d->AddingEntry = true;
-
-  QString timeFormat("dd.MM.yyyy hh:mm:ss");
-
-  bool groupEntry = false;
-  if (d->LogEntryGrouping)
-    {
-    int lastRowIndex = d->StandardItemModel.rowCount() - 1;
-
-    QString lastRowThreadId = this->logEntryData(lastRowIndex, Self::ThreadIdColumn).toString();
-    bool threadIdMatched = threadId == lastRowThreadId;
-
-    QString lastRowLogLevel = this->logEntryData(lastRowIndex, Self::LogLevelColumn).toString();
-    bool logLevelMatched = d->ErrorLogLevel(logLevel) == lastRowLogLevel;
-
-    QString lastRowOrigin = this->logEntryData(lastRowIndex, Self::OriginColumn).toString();
-    bool originMatched = origin == lastRowOrigin;
-
-    QDateTime lastRowDateTime =
-        QDateTime::fromString(this->logEntryData(lastRowIndex, Self::TimeColumn).toString(), timeFormat);
-    int groupingIntervalInMsecs = 1000;
-    bool withinGroupingInterval = lastRowDateTime.time().msecsTo(currentDateTime.time()) <= groupingIntervalInMsecs;
-
-    groupEntry = threadIdMatched && logLevelMatched && originMatched && withinGroupingInterval;
-    }
-
-  if (!groupEntry)
-    {
-    QList<QStandardItem*> itemList;
-
-    // Time item
-    QStandardItem * timeItem = new QStandardItem(currentDateTime.toString(timeFormat));
-    timeItem->setEditable(false);
-    itemList << timeItem;
-
-    // ThreadId item
-    QStandardItem * threadIdItem = new QStandardItem(threadId);
-    threadIdItem->setEditable(false);
-    itemList << threadIdItem;
-
-    // LogLevel item
-    QStandardItem * logLevelItem = new QStandardItem(d->ErrorLogLevel(logLevel));
-    logLevelItem->setEditable(false);
-    itemList << logLevelItem;
-
-    // Origin item
-    QStandardItem * originItem = new QStandardItem(origin);
-    originItem->setEditable(false);
-    itemList << originItem;
-
-    // Description item
-    QStandardItem * descriptionItem = new QStandardItem();
-    QString descriptionText(text);
-    descriptionItem->setData(descriptionText.left(160).append((descriptionText.size() > 160) ? "..." : ""), Qt::DisplayRole);
-    descriptionItem->setData(descriptionText, ctkErrorLogModel::DescriptionTextRole);
-    descriptionItem->setEditable(false);
-    itemList << descriptionItem;
-
-    d->StandardItemModel.invisibleRootItem()->appendRow(itemList);
-    }
-  else
-    {
-    // Retrieve description associated with last row
-    QModelIndex lastRowDescriptionIndex =
-        d->StandardItemModel.index(d->StandardItemModel.rowCount() - 1, ctkErrorLogModel::DescriptionColumn);
-
-    QStringList updatedDescription;
-    updatedDescription << lastRowDescriptionIndex.data(ctkErrorLogModel::DescriptionTextRole).toString();
-    updatedDescription << text;
-
-    d->StandardItemModel.setData(lastRowDescriptionIndex, updatedDescription.join("\n"),
-                                 ctkErrorLogModel::DescriptionTextRole);
-
-    // Append '...' to displayText if needed
-    QString displayText = lastRowDescriptionIndex.data().toString();
-    if (!displayText.endsWith("..."))
-      {
-      d->StandardItemModel.setData(lastRowDescriptionIndex, displayText.append("..."), Qt::DisplayRole);
-      }
-    }
-
-  d->AddingEntry = false;
-
-  QString fileLogText = d->FileLoggingPattern;
-  fileLogText.replace("%{level}", d->ErrorLogLevel(logLevel).toUpper());
-  fileLogText.replace("%{timestamp}", currentDateTime.toString(timeFormat));
-  fileLogText.replace("%{origin}", origin);
-  fileLogText.replace("%{pid}", QString("%1").arg(QCoreApplication::applicationPid()));
-  fileLogText.replace("%{threadid}", threadId);
-  fileLogText.replace("%{function}", context.Function);
-  fileLogText.replace("%{line}", QString("%1").arg(context.Line));
-  fileLogText.replace("%{file}", context.File);
-  fileLogText.replace("%{category}", context.Category);
-  fileLogText.replace("%{msg}", context.Message);
-  d->FileLogger.logMessage(fileLogText.trimmed());
-
-  emit this->entryAdded(logLevel);
-}
-
-//------------------------------------------------------------------------------
-void ctkErrorLogModel::clear()
-{
-  Q_D(ctkErrorLogModel);
-  d->StandardItemModel.invisibleRootItem()->removeRows(0, d->StandardItemModel.rowCount());
-}
-
-//------------------------------------------------------------------------------
-void ctkErrorLogModel::filterEntry(const ctkErrorLogLevel::LogLevels& logLevel,
-                                   bool disableFilter)
-{
-  Q_D(ctkErrorLogModel);
-
-  QStringList patterns;
-  if (!this->filterRegExp().pattern().isEmpty())
-    {
-    patterns << this->filterRegExp().pattern().split("|");
-    }
-  patterns.removeAll(d->ErrorLogLevel(ctkErrorLogLevel::None));
-
-//  foreach(QString s, patterns)
-//    {
-//    std::cout << "pattern:" << qPrintable(s) << std::endl;
-//    }
-
-  QMetaEnum logLevelEnum = d->ErrorLogLevel.metaObject()->enumerator(0);
-  Q_ASSERT(QString("LogLevel").compare(logLevelEnum.name()) == 0);
-
-  // Loop over enum values and append associated name to 'patterns' if
-  // it has been specified within 'logLevel'
-  for (int i = 1; i < logLevelEnum.keyCount(); ++i)
-    {
-    int aLogLevel = logLevelEnum.value(i);
-    if (logLevel & aLogLevel)
-      {
-      QString logLevelAsString = d->ErrorLogLevel(static_cast<ctkErrorLogLevel::LogLevel>(aLogLevel));
-      if (!disableFilter)
-        {
-        patterns << logLevelAsString;
-        d->CurrentLogLevelFilter |= static_cast<ctkErrorLogLevel::LogLevels>(aLogLevel);
-        }
-      else
-        {
-        patterns.removeAll(logLevelAsString);
-        d->CurrentLogLevelFilter ^= static_cast<ctkErrorLogLevel::LogLevels>(aLogLevel);
-        }
-      }
-    }
-
-  if (patterns.isEmpty())
-    {
-    // If there are no patterns, let's filter with the None level so that
-    // all entries are filtered out.
-    patterns << d->ErrorLogLevel(ctkErrorLogLevel::None);
-    }
-
-  bool filterChanged = true;
-  QStringList currentPatterns = this->filterRegExp().pattern().split("|");
-  if (currentPatterns.count() == patterns.count())
-    {
-    foreach(const QString& p, patterns)
-      {
-      currentPatterns.removeAll(p);
-      }
-    filterChanged = currentPatterns.count() > 0;
-    }
-
-  this->setFilterRegExp(patterns.join("|"));
-
-  if (filterChanged)
-    {
-    emit this->logLevelFilterChanged();
-    }
-}
-
-//------------------------------------------------------------------------------
-ctkErrorLogLevel::LogLevels ctkErrorLogModel::logLevelFilter()const
-{
-  Q_D(const ctkErrorLogModel);
-  QMetaEnum logLevelEnum = d->ErrorLogLevel.metaObject()->enumerator(0);
-  Q_ASSERT(QString("LogLevel").compare(logLevelEnum.name()) == 0);
-
-  ctkErrorLogLevel::LogLevels filter = ctkErrorLogLevel::Unknown;
-  foreach(const QString& filterAsString, this->filterRegExp().pattern().split("|"))
-    {
-    filter |= static_cast<ctkErrorLogLevel::LogLevels>(logLevelEnum.keyToValue(filterAsString.toLatin1()));
-    }
-  return filter;
-}
-
-//------------------------------------------------------------------------------
-bool ctkErrorLogModel::logEntryGrouping()const
-{
-  Q_D(const ctkErrorLogModel);
-  return d->LogEntryGrouping;
-}
-
-//------------------------------------------------------------------------------
-void ctkErrorLogModel::setLogEntryGrouping(bool value)
-{
-  Q_D(ctkErrorLogModel);
-  d->LogEntryGrouping = value;
-}
-
-//------------------------------------------------------------------------------
-bool ctkErrorLogModel::asynchronousLogging()const
-{
-  Q_D(const ctkErrorLogModel);
-  return d->AsynchronousLogging;
-}
-
-//------------------------------------------------------------------------------
-void ctkErrorLogModel::setAsynchronousLogging(bool value)
-{
-  Q_D(ctkErrorLogModel);
-  if (d->AsynchronousLogging == value)
-    {
-    return;
-    }
-
-  foreach(const QString& handlerName, d->RegisteredHandlers.keys())
-    {
-    d->setMessageHandlerConnection(
-          d->RegisteredHandlers.value(handlerName), value);
-    }
-
-  d->AsynchronousLogging = value;
-}
-
-// --------------------------------------------------------------------------
-QString ctkErrorLogModel::filePath()const
-{
-  Q_D(const ctkErrorLogModel);
-  return d->FileLogger.filePath();
-}
-
-// --------------------------------------------------------------------------
-void ctkErrorLogModel::setFilePath(const QString& filePath)
-{
-  Q_D(ctkErrorLogModel);
-  return d->FileLogger.setFilePath(filePath);
-}
-
-// --------------------------------------------------------------------------
-int ctkErrorLogModel::numberOfFilesToKeep()const
-{
-  Q_D(const ctkErrorLogModel);
-  return d->FileLogger.numberOfFilesToKeep();
-}
-
-// --------------------------------------------------------------------------
-void ctkErrorLogModel::setNumberOfFilesToKeep(int value)
-{
-  Q_D(ctkErrorLogModel);
-  return d->FileLogger.setNumberOfFilesToKeep(value);
-}
-
-// --------------------------------------------------------------------------
-bool ctkErrorLogModel::fileLoggingEnabled()const
-{
-  Q_D(const ctkErrorLogModel);
-  return d->FileLogger.enabled();
-}
-
-// --------------------------------------------------------------------------
-void ctkErrorLogModel::setFileLoggingEnabled(bool value)
-{
-  Q_D(ctkErrorLogModel);
-  d->FileLogger.setEnabled(value);
-}
-
-// --------------------------------------------------------------------------
-QString ctkErrorLogModel::fileLoggingPattern()const
-{
-  Q_D(const ctkErrorLogModel);
-  return d->FileLoggingPattern;
-}
-
-// --------------------------------------------------------------------------
-void ctkErrorLogModel::setFileLoggingPattern(const QString& value)
-{
-  Q_D(ctkErrorLogModel);
-  d->FileLoggingPattern = value;
-}
-
-// --------------------------------------------------------------------------
-QVariant ctkErrorLogModel::logEntryData(int row, int column, int role) const
-{
-  Q_D(const ctkErrorLogModel);
-  if (column < 0 || column > Self::MaxColumn
-      || row < 0 || row > this->logEntryCount())
-    {
-    return QVariant();
-    }
-  QModelIndex rowDescriptionIndex = d->StandardItemModel.index(row, column);
-  return rowDescriptionIndex.data(role);
-}
-
-// --------------------------------------------------------------------------
-QString ctkErrorLogModel::logEntryDescription(int row) const
-{
-  return this->logEntryData(row, Self::DescriptionColumn, Self::DescriptionTextRole).toString();
-}
-
-// --------------------------------------------------------------------------
-int ctkErrorLogModel::logEntryCount()const
-{
-  Q_D(const ctkErrorLogModel);
-  return d->StandardItemModel.rowCount();
-}

--- a/Libs/Widgets/ctkErrorLogModel.h
+++ b/Libs/Widgets/ctkErrorLogModel.h
@@ -21,135 +21,29 @@
 #ifndef __ctkErrorLogModel_h
 #define __ctkErrorLogModel_h
 
-// Qt includes
-#include <QSortFilterProxyModel>
-
 // CTK includes
 #include "ctkWidgetsExport.h"
-#include "ctkErrorLogLevel.h"
-#include "ctkErrorLogTerminalOutput.h"
+#include "ctkErrorLogAbstractModel.h"
 
 //------------------------------------------------------------------------------
-class ctkErrorLogAbstractMessageHandler;
 class ctkErrorLogModelPrivate;
-struct ctkErrorLogContext;
 
 //------------------------------------------------------------------------------
 /// \ingroup Widgets
-class CTK_WIDGETS_EXPORT ctkErrorLogModel : public QSortFilterProxyModel
+class CTK_WIDGETS_EXPORT ctkErrorLogModel : public ctkErrorLogAbstractModel
 {
   Q_OBJECT
-  Q_PROPERTY(bool logEntryGrouping READ logEntryGrouping WRITE setLogEntryGrouping)
-  Q_PROPERTY(ctkErrorLogTerminalOutput::TerminalOutputs terminalOutputs READ terminalOutputs WRITE setTerminalOutputs)
-  Q_PROPERTY(bool asynchronousLogging READ asynchronousLogging WRITE  setAsynchronousLogging)
-  Q_PROPERTY(QString filePath READ filePath WRITE  setFilePath)
-  Q_PROPERTY(int numberOfFilesToKeep READ numberOfFilesToKeep WRITE  setNumberOfFilesToKeep)
-  Q_PROPERTY(bool fileLoggingEnabled READ fileLoggingEnabled WRITE  setFileLoggingEnabled)
-  Q_PROPERTY(QString fileLoggingPattern READ fileLoggingPattern WRITE setFileLoggingPattern)
 public:
-  typedef QSortFilterProxyModel Superclass;
+  typedef ctkErrorLogAbstractModel Superclass;
   typedef ctkErrorLogModel Self;
   explicit ctkErrorLogModel(QObject* parentObject = 0);
   virtual ~ctkErrorLogModel();
 
-  enum ColumnsIds
-    {
-    TimeColumn = 0,
-    ThreadIdColumn,
-    LogLevelColumn,
-    OriginColumn,
-    DescriptionColumn,
-    MaxColumn = DescriptionColumn
-    };
-
-  enum ItemDataRole{
-    DescriptionTextRole = Qt::UserRole + 1
-    };
-
-  /// Register a message handler.
-  bool registerMsgHandler(ctkErrorLogAbstractMessageHandler * msgHandler);
-
-  QStringList msgHandlerNames()const;
-
-  /// Return True if the handler identified by \a handlerName is enabled
-  bool msgHandlerEnabled(const QString& handlerName) const;
-
-  /// Enable a specific handler given its name
-  void setMsgHandlerEnabled(const QString& handlerName, bool enabled);
-
-  /// Return names of the enabled message handlers
-  QStringList msgHandlerEnabled()const;
-
-  /// Enable handler identified by their names
-  void setMsgHandlerEnabled(const QStringList& handlerNames);
-
-  void enableAllMsgHandler();
-  void disableAllMsgHandler();
-  void setAllMsgHandlerEnabled(bool enabled);
-
-  /// Return if messages are both printed into the terminal and added to ctkErrorLogModel.
-  /// \note If TerminalOutput::None is returned, message will only be added to the model.
-  ctkErrorLogTerminalOutput::TerminalOutputs terminalOutputs()const;
-
-  /// Set terminal output mode
-  /// \sa terminalOutputs()
-  /// \sa TerminalOutput
-  void setTerminalOutputs(const ctkErrorLogTerminalOutput::TerminalOutputs& terminalOutput);
-
-  ctkErrorLogLevel::LogLevels logLevelFilter()const;
-
-  void filterEntry(const ctkErrorLogLevel::LogLevels& logLevel = ctkErrorLogLevel::Unknown, bool disableFilter = false);
-
-  bool logEntryGrouping()const;
-  void setLogEntryGrouping(bool value);
-
-  bool asynchronousLogging()const;
-  void setAsynchronousLogging(bool value);
-
-  QString filePath()const;
-  void setFilePath(const QString& filePath);
-
-  int numberOfFilesToKeep()const;
-  void setNumberOfFilesToKeep(int value);
-
-  bool fileLoggingEnabled()const;
-  void setFileLoggingEnabled(bool value);
-
-  QString fileLoggingPattern()const;
-  void setFileLoggingPattern(const QString& value);
-
-  /// Return log entry information associated with \a row and \a column.
-  /// \internal
-  QVariant logEntryData(int row,
-                        int column = ctkErrorLogModel::DescriptionColumn,
-                        int role = Qt::DisplayRole) const;
-
-  /// Return log entry information associated with Description column.
-  /// \sa ctkErrorLogModel::DescriptionColumn, logEntryData()
-  Q_INVOKABLE QString logEntryDescription(int row) const;
-
-  /// Return current number of log entries.
-  /// \sa clear()
-  Q_INVOKABLE int logEntryCount() const;
-
-public Q_SLOTS:
-
-  /// Remove all log entries from model
-  void clear();
-
-  /// \sa logEntryGrouping(), asynchronousLogging()
-  void addEntry(const QDateTime& currentDateTime, const QString& threadId,
-                ctkErrorLogLevel::LogLevel logLevel, const QString& origin,
-                const ctkErrorLogContext &context, const QString& text);
-
-Q_SIGNALS:
-  void logLevelFilterChanged();
-
-  /// \sa addEntry()
-  void entryAdded(ctkErrorLogLevel::LogLevel logLevel);
-
 protected:
   QScopedPointer<ctkErrorLogModelPrivate> d_ptr;
+
+  virtual void addModelEntry(const QString& currentDateTime, const QString& threadId,
+                             const QString& logLevel, const QString& origin, const QString& text);
 
 private:
   Q_DECLARE_PRIVATE(ctkErrorLogModel)

--- a/Libs/Widgets/ctkErrorLogWidget.cpp
+++ b/Libs/Widgets/ctkErrorLogWidget.cpp
@@ -107,17 +107,17 @@ ctkErrorLogWidget::~ctkErrorLogWidget()
 }
 
 //------------------------------------------------------------------------------
-ctkErrorLogModel* ctkErrorLogWidget::errorLogModel()const
+ctkErrorLogAbstractModel* ctkErrorLogWidget::errorLogModel()const
 {
   Q_D(const ctkErrorLogWidget);
   QAbstractItemModel* model = d->ErrorLogTableView->model();
-  ctkErrorLogModel * errorLogModel = qobject_cast<ctkErrorLogModel*>(model);
+  ctkErrorLogAbstractModel * errorLogModel = qobject_cast<ctkErrorLogAbstractModel*>(model);
   Q_ASSERT(model ? errorLogModel != 0 : true);
   return errorLogModel;
 }
 
 //------------------------------------------------------------------------------
-void ctkErrorLogWidget::setErrorLogModel(ctkErrorLogModel * newErrorLogModel)
+void ctkErrorLogWidget::setErrorLogModel(ctkErrorLogAbstractModel * newErrorLogModel)
 {
   Q_D(ctkErrorLogWidget);
 

--- a/Libs/Widgets/ctkErrorLogWidget.h
+++ b/Libs/Widgets/ctkErrorLogWidget.h
@@ -27,7 +27,7 @@
 // CTK includes
 #include "ctkWidgetsExport.h"
 
-class ctkErrorLogModel;
+class ctkErrorLogAbstractModel;
 class ctkErrorLogWidgetPrivate;
 class QAbstractButton;
 class QItemSelection;
@@ -42,8 +42,8 @@ public:
   explicit ctkErrorLogWidget(QWidget* parentWidget = 0);
   virtual ~ctkErrorLogWidget();
 
-  ctkErrorLogModel* errorLogModel()const;
-  Q_INVOKABLE void setErrorLogModel(ctkErrorLogModel * newErrorLogModel);
+  ctkErrorLogAbstractModel* errorLogModel()const;
+  Q_INVOKABLE void setErrorLogModel(ctkErrorLogAbstractModel * newErrorLogModel);
 
   /// Hide table column identified by /a columnId.
   /// \sa ctkErrorLogModel::ColumnsIds


### PR DESCRIPTION
This commit was motivated to support use of the log model from
qSlicerCoreApplication. This is needed to ensure messages are appended
to the log file during the unloading of modules following the call to
"factoryManager()->unloadModules()" from within the qSlicerCoreApplicationPrivate
destructor.

It is a follow up of f49c19a82 (move Widget dependent classes from Core
to Widgets. See #278)