### PR TITLE
BUG: Fix DICOM image size computation

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorDefaultRule.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorDefaultRule.cpp
@@ -62,6 +62,8 @@ QStringList ctkDICOMDisplayedFieldGeneratorDefaultRule::getRequiredDICOMTags()
   requiredTags << dicomTagToString(DCM_AcquisitionNumber);
   requiredTags << dicomTagToString(DCM_EchoNumbers);
   requiredTags << dicomTagToString(DCM_TemporalPositionIdentifier);   
+  requiredTags << dicomTagToString(DCM_Rows);
+  requiredTags << dicomTagToString(DCM_Columns);
 
   return requiredTags;
 }


### PR DESCRIPTION
The row and column DICOM tags were sometimes not precached in time for the displayed fields to contain the image size. This makes sure that these tags are always precached.