### PR TITLE
ENH: Add direct access to widget items in ctkMatrixWidget

### DIFF
--- a/Libs/Widgets/ctkMatrixWidget.cpp
+++ b/Libs/Widgets/ctkMatrixWidget.cpp
@@ -506,3 +506,11 @@ void ctkMatrixWidget::setValues(const QVector<double> & vector)
     this->emit matrixChanged();
     }
 }
+
+// --------------------------------------------------------------------------
+QTableWidgetItem* ctkMatrixWidget::widgetItem(int i, int j)
+{
+  Q_D(ctkMatrixWidget);
+  QTableWidgetItem* item = d->Table->item(i, j);
+  return item;
+}

--- a/Libs/Widgets/ctkMatrixWidget.h
+++ b/Libs/Widgets/ctkMatrixWidget.h
@@ -31,6 +31,7 @@
 #include "ctkWidgetsExport.h"
 
 class ctkMatrixWidgetPrivate;
+class QTableWidgetItem;
 
 /// \ingroup Widgets
 ///
@@ -82,6 +83,12 @@ public:
   /// that is less than the minimum or greater than the maximum.
   Q_INVOKABLE double value(int i, int j)const;
   Q_INVOKABLE void setValue(int i, int j, double value);
+
+  ///
+  /// Provides low-level access to widget item of each matrix element.
+  /// This may be used for customizing display or behavior of specific
+  /// matrix elements.
+  Q_INVOKABLE QTableWidgetItem* widgetItem(int i, int j);
 
   ///
   /// Utility function to set/get all the values of the matrix at once.


### PR DESCRIPTION
This allows customizing display of individual matrix elements, for example making last row of a homogeneous transformation matrix read-only.