### PR TITLE
BUG: Fix merging display table fields containing commas

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorAbstractRule.h
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorAbstractRule.h
@@ -150,8 +150,7 @@ public:
       }
       return;
     }
-    QStringList initialValueSplit=initialFields[fieldName].split(",");
-    if (initialValueSplit.contains(newFields[fieldName]))
+    if (initialFields[fieldName].contains(newFields[fieldName]))
     {
       // the field is already contained in the list, so no need to add it
       mergedFields[fieldName]=initialFields[fieldName];
@@ -160,7 +159,7 @@ public:
     // need to concatenate the new value to the initial
     mergedFields[fieldName]=initialFields[fieldName]+", "+newFields[fieldName];
   }
-   
+
 };
 
 #endif


### PR DESCRIPTION
If a series description (or other field that is merged with mergeConcatenate) contained a comma, then it was concatenated even if it was the same. For example "first, second" was not found in the split fields because they were "first" and "second". Fixed by simply searching for the new value in the unsplit initial value.

There might be issues with this too, for example if if there are series descriptions like "first", "second", and also "first, second", but in that case seeing only "first, second" is acceptable.