### PR TITLE
ENH: Allow updating DICOM database into different folder; Allow appli…

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMCorePythonQtDecorators.h
+++ b/Libs/DICOM/Core/ctkDICOMCorePythonQtDecorators.h
@@ -72,6 +72,16 @@ public Q_SLOTS:
     {
     return ctk::dicomLogLevelAsString();
     }
+
+  QString static_ctk_dicomDabataseSettingsKey()
+    {
+    return ctk::dicomDabataseSettingsKey();
+    }
+
+  void static_ctk_setDICOMDabataseSettingsKey(QString key)
+    {
+    ctk::setDICOMDabataseSettingsKey(key);
+    }
 };
 
 //-----------------------------------------------------------------------------

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -69,33 +69,29 @@ public:
   const QString lastError() const;
   const QString databaseFilename() const;
 
-  ///
-  /// Returns the absolute path of the database directory
-  /// (where the database file resides in) in OS-prefered path format.
+  static const char* defaultSchemaFile() { return ":/dicom/dicom-schema.sql"; };
+
+  /// Return the absolute path of the database directory
+  /// (where the database file resides in) in OS-preferred path format.
   /// @return Absolute path to database directory
   const QString databaseDirectory() const;
 
-  ///
   /// Should be checked after trying to open the database
   /// @Returns true if database is open
   bool isOpen() const;
 
-  ///
-  /// Returns whether the database only resides in memory, i.e. the
+  /// Return whether the database only resides in memory, i.e. the
   /// SQLITE DB is not written to stored to disk and DICOM objects are not
   /// stored to the file system.
   /// @return True if in memory mode, false otherwise.
   bool isInMemory() const;
 
-  ///
-  /// set thumbnail generator object
+  /// Set thumbnail generator object
   Q_INVOKABLE void setThumbnailGenerator(ctkDICOMAbstractThumbnailGenerator* generator);
-  ///
-  /// get thumbnail genrator object
+  /// Get thumbnail generator object
   Q_INVOKABLE ctkDICOMAbstractThumbnailGenerator* thumbnailGenerator();
 
-  ///
-  /// open the SQLite database in @param databaseFile . If the file does not
+  /// Open the SQLite database in @param databaseFile . If the file does not
   /// exist, a new database is created and initialized with the
   /// default schema
   ///
@@ -111,28 +107,41 @@ public:
   Q_INVOKABLE virtual void openDatabase(const QString databaseFile,
                                         const QString& connectionName = "");
 
-  ///
-  /// close the database. It must not be used afterwards.
+  /// Close the database. It must not be used afterwards.
   Q_INVOKABLE void closeDatabase();
-  ///
-  /// delete all data and (re-)initialize the database.
-  Q_INVOKABLE bool initializeDatabase(const char* schemaFile = ":/dicom/dicom-schema.sql");
 
-  /// updates the database schema and reinserts all existing files
-  Q_INVOKABLE bool updateSchema(const char* schemaFile = ":/dicom/dicom-schema.sql");
+  /// Delete all data and (re-)initialize the database.
+  Q_INVOKABLE bool initializeDatabase(const char* schemaFile = ctkDICOMDatabase::defaultSchemaFile());
 
-  /// updates the database schema only if the versions don't match
-  /// Returns true if schema was updated
-  Q_INVOKABLE bool updateSchemaIfNeeded(const char* schemaFile = ":/dicom/dicom-schema.sql");
+  /// Update the database schema and reinserts all existing files
+  /// \param schemaFile SQL file containing schema definition
+  /// \param newDatabaseDir Path of new database directory for the updated database.
+  ///        Null by default, meaning directory will remain the same
+  ///        Note: Need to switch database folders "on the fly", so that copying the
+  ///        database can be done simply via createBackupFileList and the following insertions
+  /// \return true if schema was updated
+  Q_INVOKABLE bool updateSchema(
+    const char* schemaFile = ctkDICOMDatabase::defaultSchemaFile(),
+    const char* newDatabaseDir = nullptr);
 
-  /// returns the schema version needed by the current version of this code
+  /// Update the database schema only if the versions don't match
+  /// \param schemaFile SQL file containing schema definition
+  /// \param newDatabaseDir Path of new database directory for the updated database.
+  ///        Null by default, meaning directory will remain the same
+  ///        Note: Need to switch database folders "on the fly", so that copying the
+  ///        database can be done simply via createBackupFileList and the following insertions
+  /// \return true if schema was updated
+  Q_INVOKABLE bool updateSchemaIfNeeded(
+    const char* schemaFile = ctkDICOMDatabase::defaultSchemaFile(),
+    const char* newDatabaseDir = nullptr);
+
+  /// Return the schema version needed by the current version of this code
   Q_INVOKABLE QString schemaVersion();
 
-  /// returns the schema version for the currently open database
+  /// Return the schema version for the currently open database
   /// in order to support schema updating
   Q_INVOKABLE QString schemaVersionLoaded();
 
-  ///
   /// \brief database accessors
   Q_INVOKABLE QStringList patients ();
   Q_INVOKABLE QStringList studiesForPatient (const QString patientUID);
@@ -151,8 +160,7 @@ public:
   Q_INVOKABLE QDateTime insertDateTimeForInstance (const QString fileName);
 
   Q_INVOKABLE QStringList allFiles ();
-  ///
-  /// \brief load the header from a file and allow access to elements
+  /// \brief Load the header from a file and allow access to elements
   /// @param sopInstanceUID A string with the uid for a given instance
   ///                       (corresponding file will be found via database)
   /// @param fileName Full path to a dicom file to load.
@@ -162,8 +170,7 @@ public:
   Q_INVOKABLE QStringList headerKeys ();
   Q_INVOKABLE QString headerValue (const QString key);
 
-  ///
-  /// \brief application-defined tags of interest
+  /// \brief Application-defined tags of interest
   /// This list of tags is added to the internal tag cache during import
   /// operations.  The list should be prepared by the application as
   /// a hint to the database that these tags are likely to be accessed
@@ -221,15 +228,13 @@ public:
   /// Check if file is already in database and up-to-date
   Q_INVOKABLE bool fileExistsAndUpToDate(const QString& filePath);
 
-  /// remove the series from the database, including images and
-  /// thumbnails
+  /// Remove the series from the database, including images and thumbnails
   Q_INVOKABLE bool removeSeries(const QString& seriesInstanceUID);
   Q_INVOKABLE bool removeStudy(const QString& studyInstanceUID);
   Q_INVOKABLE bool removePatient(const QString& patientID);
   Q_INVOKABLE bool cleanup();
 
-  ///
-  /// \brief access element values for given instance
+  /// \brief Access element values for given instance
   /// @param sopInstanceUID A string with the uid for a given instance
   ///                       (corresponding file will be found via database)
   /// @param fileName Full path to a dicom file to load.
@@ -244,8 +249,7 @@ public:
   Q_INVOKABLE bool tagToGroupElement (const QString tag, unsigned short& group, unsigned short& element);
   Q_INVOKABLE QString groupElementToTag (const unsigned short& group, const unsigned short& element);
 
-  ///
-  /// \brief store values of previously requested instance elements
+  /// \brief Store values of previously requested instance elements
   /// These are meant to be internal methods used by the instanceValue and fileValue
   /// methods, but they can be used by calling classes to populate or access
   /// instance tag values as needed.

--- a/Libs/DICOM/Core/ctkDICOMUtil.cpp
+++ b/Libs/DICOM/Core/ctkDICOMUtil.cpp
@@ -27,6 +27,12 @@
 // DCMTK includes
 #include <dcmtk/oflog/oflog.h>
 
+/// Settings key for DICOM database folder (for example a version-specific settings file)
+/// This is useful if the user wants to use the old database with the older version application.
+/// Note: This is a static variable instead of a property, because it is needed at the time of construction,
+///       and additional constructors are apparently not Python-wrapped.
+static QString DICOMDabataseSettingsKey = "DatabaseDirectory";
+
 //------------------------------------------------------------------------------
 void ctk::setDICOMLogLevel(ctkErrorLogLevel::LogLevel level)
 {
@@ -66,4 +72,16 @@ ctkErrorLogLevel::LogLevel ctk::dicomLogLevel()
 QString ctk::dicomLogLevelAsString()
 {
   return ctkErrorLogLevel::logLevelAsString(ctk::dicomLogLevel());
+}
+
+//------------------------------------------------------------------------------
+void ctk::setDICOMDabataseSettingsKey(QString key)
+{
+  DICOMDabataseSettingsKey = key;
+}
+
+//------------------------------------------------------------------------------
+QString ctk::dicomDabataseSettingsKey()
+{
+  return DICOMDabataseSettingsKey;
 }

--- a/Libs/DICOM/Core/ctkDICOMUtil.h
+++ b/Libs/DICOM/Core/ctkDICOMUtil.h
@@ -33,6 +33,10 @@ ctkErrorLogLevel::LogLevel CTK_DICOM_CORE_EXPORT dicomLogLevel();
 
 QString CTK_DICOM_CORE_EXPORT dicomLogLevelAsString();
 
+void CTK_DICOM_CORE_EXPORT setDICOMDabataseSettingsKey(QString key);
+
+QString CTK_DICOM_CORE_EXPORT dicomDabataseSettingsKey();
+
 } // end of ctk namespace
 
 #endif

--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.h
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.h
@@ -65,6 +65,7 @@ class CTK_DICOM_WIDGETS_EXPORT ctkDICOMBrowser : public QWidget
   Q_PROPERTY(bool displayImportSummary READ displayImportSummary WRITE setDisplayImportSummary)
   Q_PROPERTY(ctkDICOMBrowser::ImportDirectoryMode ImportDirectoryMode READ importDirectoryMode WRITE setImportDirectoryMode)
   Q_PROPERTY(SchemaUpdateOption schemaUpdateOption READ schemaUpdateOption WRITE setSchemaUpdateOption)
+  Q_PROPERTY(bool schemaUpdateAutoCreateDirectory READ schemaUpdateAutoCreateDirectory WRITE setShemaUpdateAutoCreateDirectory)
   Q_PROPERTY(bool confirmRemove READ confirmRemove WRITE setConfirmRemove)
 
 public:
@@ -90,8 +91,10 @@ public:
   /// If the schema version of the loaded database does not match the one supported, then
   /// based on \sa schemaUpdateOption update the database, don't update, or ask the user.
   /// Provides a dialog box for progress if updating.
-  /// \return Flag determining whether new database has been set. In that case prevent circular calls.
-  Q_INVOKABLE bool updateDatabaseSchemaIfNeeded();
+  /// Setting the updated database happens in \sa setDatabaseDirectory
+  /// \return Directory path of the updated folder (it might be a different folder).
+  ///         Empty string if new database has not been set.
+  Q_INVOKABLE QString updateDatabaseSchemaIfNeeded();
 
   Q_INVOKABLE ctkDICOMDatabase* database();
 
@@ -101,9 +104,14 @@ public:
   /// Since the summary dialog is modal, we give the option of disabling it for batch modes or testing.
   void setDisplayImportSummary(bool);
   bool displayImportSummary();
-  /// Option to show dialog to confirm removal from the database (Remove action).
+  /// Option to show dialog to confirm removal from the database (Remove action). Off by default.
   void setConfirmRemove(bool);
   bool confirmRemove();
+  /// Option to determine whether the new database folder is automatically created or set by the user in a popup.
+  /// Automatically created folder will be ../[CurrentDatabaseFolderName]-[NewSchemaVersion]. Off by default.
+  void setShemaUpdateAutoCreateDirectory(bool);
+  bool schemaUpdateAutoCreateDirectory();
+
   /// Accessors to status of last directory import operation
   int patientsAddedDuringImport();
   int studiesAddedDuringImport();
@@ -136,7 +144,7 @@ public:
   /// Get schema update option (whether to update automatically). Default is always update
   /// \sa setSchemaUpdateOption
   ctkDICOMBrowser::SchemaUpdateOption schemaUpdateOption()const;
-  
+
   /// \brief Return instance of import dialog.
   ///
   /// \internal
@@ -224,7 +232,6 @@ protected:
     bool confirmDeleteSelectedUIDs(QStringList uids);
 
 protected Q_SLOTS:
-
     /// \brief Import directories
     ///
     /// This is used when user selected one or multiple


### PR DESCRIPTION
…cation to define database settings key

- When user updates the database, a directory selector is shown where the location of the updated database can be selected. This allows keeping the original database untouched
- Custom DICOM database settings key can be now defined. It is useful if we want to store different database directory paths for different schema versions. If the application does not specify a key, then the previously used key is used as default
- Collateral changes:
  - When updating a database, the file names are collected and returned as a string list, instead of writing it into the database. This is needed because the database may be different (we save the file names from the old database and write it out to a different database)
  - Added functions to specify the custom database settings key in ctkDICOMUtil. It is needed to be specified here, because ctkDICOMBrowser uses the settings key during construction before doing the update. Additional constructors are not wrapped in python, so it is needed to be stored externally.

https://discourse.slicer.org/t/dicom-database-re-indexing-between-preview-and-4-10-2/7592