### PR TITLE
COMP: fix extension configure error with CMake 3.15.2

### DIFF
--- a/CMake/ctkMacroCompilePythonScript.cmake
+++ b/CMake/ctkMacroCompilePythonScript.cmake
@@ -152,7 +152,7 @@ function(_ctk_add_compile_python_directories_target target)
     find_package(PythonLibs REQUIRED)
 
     # Extract python lib path
-    get_filename_component(PYTHON_LIBRARY_PATH ${PYTHON_LIBRARY} PATH)
+    get_filename_component(PYTHON_LIBRARY_PATH "${PYTHON_LIBRARY}" PATH)
 
     # Configure cmake script associated with the custom command
     # required to properly update the library path with PYTHON_LIBRARY_PATH


### PR DESCRIPTION
```text
CMake Error at C:/a/Sw/CTK/CMake/ctkMacroCompilePythonScript.cmake:155 (get_filename_component):
  get_filename_component unknown component
  C:/a/Sw/python-install/libs/python36.lib
Call Stack (most recent call first):
  C:/a/Sw/CTK/CMake/ctkMacroCompilePythonScript.cmake:183 (_ctk_add_compile_python_directories_target)
  C:/a/Sw/CTK/CMake/ctkMacroCompilePythonScript.cmake:101 (ctkFunctionAddCompilePythonScriptTargets)
  C:/Dev/Slicer/CMake/SlicerMacroBuildScriptedModule.cmake:100 (ctkMacroCompilePythonScript)
  FistulaLocalizer/CMakeLists.txt:14 (slicerMacroBuildScriptedModule)
```
`PYTHON_LIBRARY: optimized;C:/a/Sw/python-install/libs/python36.lib;debug;C:/a/Sw//python-install/libs/python36.lib`