### PR TITLE
ENH: Update PythonQt

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -82,7 +82,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
   ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
 
   if (CTK_QT_VERSION VERSION_GREATER "4")
-    set(revision_tag fae2301264529b4c8c85ee6e285f9605176471f0) # patched-8
+    set(revision_tag dafdb7255b82163329672edebba4f267958c7376) # patched-10
   else()
     set(revision_tag 90c08fb0d523622d2de9e7a91f4ef116a66a8801) # patched-5
   endif()


### PR DESCRIPTION
List of changes:

* The list do not include the changes adding CMake support

```
$ git shortlog f0a6d6abc..c07f09fd --no-merges
Florian Link (54):
      changed to native eol
      allow to set PYTHON_VERSION as env variable fixed wrong library name
      remove variadic functions
      added parsing of rvalue references and skip functions that contain them (provided by erik_lundin@users.sf.net)
      improved slot docs as provided from forum
      changes to the build scripts as provided on the forum (not tested)
      added unix pkg config as provided on forum
      added support for kwargs by supporting QVariantMap kwargs as last argument, refactored from forum
      added convenience evalScript
      fixed unicode code and filename support for Python 3
      added getNativeVariable
      added experimental support for qwebenginewidgets (not yet in QtAll)
      added missing qintptr which is used on QSocketNotifier
      support WId, quintptr and qintptr
      updated wrappers to contain QSocketNotifier and recent generator changes
      go back to QByteArray signal/slots to avoid overload problems with static/non-static
      patch from forum, move QT module dependencies into enabled wrappers
      fixed ref counting of types ignore eggs in importer
      make sure that Python.h is always included first added new PY3K loader removed buggy __pycache__ caching
      added patch from forum (stack unwinding)
      added support for attribute lookup error callback
      reverted usage of _PyImport_FixupBuiltin
      added missing abstract virtual
      removed WindowOkButtonHint and WindowCancelButtonHint, which have been removed from Qt 5.9
      (re-)added support for rejecting enum value using it to reject WindowOkButtonHint and WindowCancelButtonHint
      help generator to work on Qt 5.11.1
      added some missing classes that were added since Qt 5.6
      support Qt 5.11
      new wrappers for Qt 5.11 (no QtWebView wrappers, since QtWebView is not part of Qt 5.11 anymore)
      for compatibility, keep the obsolete or deprecated enum values
      initial GIL support (needs to be enabled via defines)
      add GIL scope to virtual functions
      switched to using macros for scopes
      switched to using macros for scopes
      added support for override re-added virtual functions with abstract base declaration
      re-added removed methods that have not been removed previously
      recreated wrappers against Qt 5.6.3 with GIL macros and override handling
      recreated wrappers for Qt 5.11
      added rvalue assignment and copy constructor to PythonQtObjectPtr added auto-detection if Python object is involved in slot class (and don't release the GIL if that is the case)
      added error on failed load
      if there is not promoter, we can't call the promoted functions static methods can not use this->
      compile thread support by default added PythonQt::setEnableThreadSupport() to enable the thread support (disabled by default) added PythonQtSafeObjectPtr to allow safe GIL-aware storage in QVariant
      fixed linux compilation problem
      reimplemented argument frame caching (previous approach was not thread-safe when GIL is used)
      added missing GIL scope
      fixed problematic self deletion without having the GIL and while iterating the loop
      use C++11 {} initializer for returnValue
      applied patch provided by Uwe Siems
      don't print omitted rvalue methods, we just don't want to wrap them
      enable QThread (it was removed long time ago but makes sense now that PythonQt support multi-threading) removed template function on QQmlEngine
      enable QMutexLocker (but __enter__ and __exit__ don't work yet due to PythonQt class wrapper implementation...)
      fixed QTimer wrapping for Qt 5.12
      applied patch from Uwe Siems (print correct file location in parser)
      removed methods that are not present on all platforms/configurations

Stefan Böhmann (6):
      Create README.md
      Update and cleanup doxygen config file
      Rename the Doxygen configuration file to the default name (doc.cfg -> Doxyfile).
      add git ignore file
      Cleanup README.md and removing redundant README file
      Fix some links in the API documentation

Uwe Siems (2):
      QEvent::ShortcutOverride is also a QKeyEvent
      Add the usable parts of class QLoggingCategory.
```