### PR TITLE
ENH: Reduce memory usage of DICOM indexer

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMItem.cpp
+++ b/Libs/DICOM/Core/ctkDICOMItem.cpp
@@ -261,6 +261,13 @@ OFCondition ctkDICOMItem::findAndGetOFString(const DcmTag& tag, OFString& value,
   return GetDcmItem().findAndGetOFString(tag, value, pos, searchIntoSub);
 }
 
+bool ctkDICOMItem::TagExists(const DcmTag& tag) const
+{
+  EnsureDcmDataSetIsInitialized();
+  // this one const_cast allows us to declare quite a lot of methods nicely with const
+  return GetDcmItem().tagExists(tag, true);
+}
+
 bool ctkDICOMItem::CheckCondition(const OFCondition& condition)
 {
   if ( condition.bad() )

--- a/Libs/DICOM/Core/ctkDICOMItem.h
+++ b/Libs/DICOM/Core/ctkDICOMItem.h
@@ -169,6 +169,13 @@ public:
     static bool CheckCondition(const OFCondition&);
 
     ///
+    /// \brief Check if an element with the given attribute tag exists in the dataset
+    ///
+    /// @param key tag key to be searched
+    /// @return true if tag found, false otherwise
+    bool TagExists(const DcmTag& tag) const;
+
+    ///
     /// \brief Get-methods for for all subtypes of DcmByteString
     ///
     QString          GetAllElementValuesAsString( const DcmTag& tag ) const;

--- a/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
@@ -554,7 +554,7 @@ void ctkDICOMTableView::setQuery(const QStringList &uids)
   Q_D(ctkDICOMTableView);
   QString query = ("select distinct %1.* from Patients, Series, Studies where "
                    "Patients.UID = Studies.PatientsUID and Studies.StudyInstanceUID = Series.StudyInstanceUID");
-
+  int columnCountBefore = d->dicomSQLModel.columnCount();
   if (!uids.empty() && d->queryForeignKey.length() != 0)
   {
     query += " and %1."+d->queryForeignKey+" in ( '";
@@ -573,9 +573,15 @@ void ctkDICOMTableView::setQuery(const QStringList &uids)
       ++i;
     }
   }
-  if (d->dicomDatabase != 0 && d->dicomDatabase->isOpen())
+  if (d->dicomDatabase != 0 && d->dicomDatabase->isOpen()
+    && (d->queryForeignKey.isEmpty() || !uids.empty()) )
   {
     d->dicomSQLModel.setQuery(query.arg(d->queryTableName()), d->dicomDatabase->database());
+    if (columnCountBefore==0)
+    {
+      // columns have not been initialized yet
+      d->applyColumnProperties();
+    }
   }
   else
   {


### PR DESCRIPTION
Allow defining cached tags that are not stored in the DICOM tag cache by value. This prevents excessive memory usage and file reading for tags that are not appropriate to store in the tag cache (such as pixel data) but it is still possible to query if the tag is present.

Force updating the database after a certain number of files are parsed. This limits the total memory usage, which could grew big when hundreds of thousands of files were parsed in one batch.

Do not show all series when the browser is initially shown, as this can take significant amount of time when a large database is loaded.