### PR TITLE
ENH: Emit signals from ctkTransferFunctionItem for mouse events

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKColorTransferFunction.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKColorTransferFunction.h
@@ -38,6 +38,11 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKColorTransferFunction: public c
 {
   Q_OBJECT;
   QVTK_OBJECT;
+  Q_PROPERTY(int count READ count)
+  Q_PROPERTY(bool editable READ isEditable)
+  Q_PROPERTY(bool discrete READ isDiscrete)
+  Q_PROPERTY(QVariant minValue READ minValue)
+  Q_PROPERTY(QVariant maxValue READ maxValue)
 public:
   /// Please note that ctkVTKColorTransferFunction methods only work only if
   /// colorTransferFunction is set.
@@ -48,26 +53,26 @@ public:
   
   /// Please note that controlPoint methods only works if you have at least one
   /// ControlPoint.
-  virtual ctkControlPoint* controlPoint(int index)const;
-  virtual QVariant value(qreal pos)const;
+  Q_INVOKABLE virtual ctkControlPoint* controlPoint(int index)const;
+  Q_INVOKABLE virtual QVariant value(qreal pos)const;
   virtual int count()const;
   virtual bool isDiscrete()const;
   virtual bool isEditable()const;
 
-  virtual void range(qreal& minRange, qreal& maxRange)const;
+  Q_INVOKABLE virtual void range(qreal& minRange, qreal& maxRange)const;
   virtual QVariant minValue()const;
   virtual QVariant maxValue()const;
 
-  virtual int insertControlPoint(const ctkControlPoint& cp);
-  virtual int insertControlPoint(qreal pos);
+  Q_INVOKABLE virtual int insertControlPoint(const ctkControlPoint& cp);
+  Q_INVOKABLE virtual int insertControlPoint(qreal pos);
 
-  virtual void setControlPointPos(int index, qreal pos);
-  virtual void setControlPointValue(int index, const QVariant& value);
+  Q_INVOKABLE virtual void setControlPointPos(int index, qreal pos);
+  Q_INVOKABLE virtual void setControlPointValue(int index, const QVariant& value);
 
-  virtual void removeControlPoint( qreal pos );
+  Q_INVOKABLE virtual void removeControlPoint( qreal pos );
 
-  void setColorTransferFunction(vtkColorTransferFunction* colorTransferFunction);
-  vtkColorTransferFunction* colorTransferFunction()const;
+  Q_INVOKABLE void setColorTransferFunction(vtkColorTransferFunction* colorTransferFunction);
+  Q_INVOKABLE vtkColorTransferFunction* colorTransferFunction()const;
 protected:
   QScopedPointer<ctkVTKColorTransferFunctionPrivate> d_ptr;
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKPiecewiseFunction.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKPiecewiseFunction.cpp
@@ -35,6 +35,12 @@ public:
   vtkSmartPointer<vtkPiecewiseFunction> PiecewiseFunction;
 };
 
+ctkVTKPiecewiseFunction::ctkVTKPiecewiseFunction(QObject* parentObject)
+  :ctkTransferFunction(parentObject)
+  , d_ptr(new ctkVTKPiecewiseFunctionPrivate)
+{
+}
+
 //-----------------------------------------------------------------------------
 ctkVTKPiecewiseFunction::ctkVTKPiecewiseFunction(vtkPiecewiseFunction* piecewiseFunction,
                                                          QObject* parentObject)

--- a/Libs/Visualization/VTK/Widgets/ctkVTKPiecewiseFunction.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKPiecewiseFunction.h
@@ -38,31 +38,38 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKPiecewiseFunction: public ctkTr
 {
   Q_OBJECT;
   QVTK_OBJECT;
+  Q_PROPERTY(int count READ count)
+  Q_PROPERTY(bool editable READ isEditable)
+  Q_PROPERTY(bool discrete READ isDiscrete)
+  Q_PROPERTY(QVariant minValue READ minValue)
+  Q_PROPERTY(QVariant maxValue READ maxValue)
+
 public:
+  ctkVTKPiecewiseFunction(QObject* parent = 0);
   ctkVTKPiecewiseFunction(vtkPiecewiseFunction* piecewiserFunction,
                               QObject* parent = 0);
   virtual ~ctkVTKPiecewiseFunction();
 
-  virtual ctkControlPoint* controlPoint(int index)const;
-  virtual QVariant value(qreal pos)const;
+  Q_INVOKABLE virtual ctkControlPoint* controlPoint(int index)const;
+  Q_INVOKABLE virtual QVariant value(qreal pos)const;
   virtual int count()const;
   virtual bool isDiscrete()const;
   virtual bool isEditable()const;
 
-  virtual void range(qreal& minRange, qreal& maxRange)const;
+  Q_INVOKABLE virtual void range(qreal& minRange, qreal& maxRange)const;
   virtual QVariant minValue()const;
   virtual QVariant maxValue()const;
 
-  virtual int insertControlPoint(const ctkControlPoint& cp);
-  virtual int insertControlPoint(qreal pos);
+  Q_INVOKABLE virtual int insertControlPoint(const ctkControlPoint& cp);
+  Q_INVOKABLE virtual int insertControlPoint(qreal pos);
 
-  virtual void setControlPointPos(int index, qreal pos);
-  virtual void setControlPointValue(int index, const QVariant& value);
+  Q_INVOKABLE virtual void setControlPointPos(int index, qreal pos);
+  Q_INVOKABLE virtual void setControlPointValue(int index, const QVariant& value);
 
-  virtual void removeControlPoint( qreal pos );
+  Q_INVOKABLE virtual void removeControlPoint( qreal pos );
 
-  void setPiecewiseFunction(vtkPiecewiseFunction* piecewiseFunction);
-  vtkPiecewiseFunction* piecewiseFunction()const;
+  Q_INVOKABLE void setPiecewiseFunction(vtkPiecewiseFunction* piecewiseFunction);
+  Q_INVOKABLE vtkPiecewiseFunction* piecewiseFunction()const;
 protected:
   QScopedPointer<ctkVTKPiecewiseFunctionPrivate> d_ptr;
 

--- a/Libs/Widgets/ctkTransferFunction.h
+++ b/Libs/Widgets/ctkTransferFunction.h
@@ -117,7 +117,7 @@ public:
   /// more changes to ctkControlPoint.
   virtual void setControlPointValue(int index, const QVariant& value)=0;
 
-  ctkTransferFunctionRepresentation* representation()const;
+  Q_INVOKABLE ctkTransferFunctionRepresentation* representation()const;
 Q_SIGNALS:
   void changed();
 protected:

--- a/Libs/Widgets/ctkTransferFunctionBarsItem.cpp
+++ b/Libs/Widgets/ctkTransferFunctionBarsItem.cpp
@@ -123,6 +123,20 @@ QColor ctkTransferFunctionBarsItem::barColor()const
 }
 
 //-----------------------------------------------------------------------------
+ctkTransferFunctionBarsItem::LogMode ctkTransferFunctionBarsItem::logMode() const
+{
+  Q_D(const ctkTransferFunctionBarsItem);
+  return d->LogMode;
+}
+
+//-----------------------------------------------------------------------------
+void ctkTransferFunctionBarsItem::setLogMode(const LogMode logMode)
+{
+  Q_D(ctkTransferFunctionBarsItem);
+  d->LogMode = logMode;
+}
+
+//-----------------------------------------------------------------------------
 void ctkTransferFunctionBarsItem::paint(
   QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget)
 {

--- a/Libs/Widgets/ctkTransferFunctionBarsItem.h
+++ b/Libs/Widgets/ctkTransferFunctionBarsItem.h
@@ -37,8 +37,10 @@ class ctkTransferFunctionBarsItemPrivate;
 class CTK_WIDGETS_EXPORT ctkTransferFunctionBarsItem: public ctkTransferFunctionItem
 {
   Q_OBJECT
+  Q_ENUMS(LogMode)
   Q_PROPERTY(qreal barWidth READ barWidth WRITE setBarWidth)
   Q_PROPERTY(QColor barColor READ barColor WRITE setBarColor)
+  Q_PROPERTY(LogMode logMode READ logMode WRITE setLogMode)
 public:
   ctkTransferFunctionBarsItem(QGraphicsItem* parent = 0);
   ctkTransferFunctionBarsItem(ctkTransferFunction* transferFunc,
@@ -57,6 +59,9 @@ public:
     UseLog = 1,
     AutoLog =2
   };
+  LogMode logMode() const;
+  void setLogMode(const LogMode logMode);
+
   virtual void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = 0);
 protected:
   QScopedPointer<ctkTransferFunctionBarsItemPrivate> d_ptr;

--- a/Libs/Widgets/ctkTransferFunctionItem.h
+++ b/Libs/Widgets/ctkTransferFunctionItem.h
@@ -46,7 +46,7 @@ public:
   virtual ~ctkTransferFunctionItem();
 
   Q_INVOKABLE void setTransferFunction(ctkTransferFunction* transferFunction);
-  ctkTransferFunction* transferFunction()const;
+  Q_INVOKABLE ctkTransferFunction* transferFunction()const;
 
   inline void setRect(qreal x, qreal y, qreal width, qreal height);
 

--- a/Libs/Widgets/ctkTransferFunctionRepresentation.h
+++ b/Libs/Widgets/ctkTransferFunctionRepresentation.h
@@ -67,10 +67,10 @@ public:
   QPointF mapPointToScene(const ctkControlPoint* cp)const;
   QPointF mapPointToScene(const ctkPoint& point)const;
 
-  qreal mapXToScene(qreal posX)const;
-  qreal mapYToScene(qreal posY)const;
-  qreal mapXFromScene(qreal ScenePosX)const;
-  qreal mapYFromScene(qreal ScenePosY)const;
+  Q_INVOKABLE qreal mapXToScene(qreal posX)const;
+  Q_INVOKABLE qreal mapYToScene(qreal posY)const;
+  Q_INVOKABLE qreal mapXFromScene(qreal ScenePosX)const;
+  Q_INVOKABLE qreal mapYFromScene(qreal ScenePosY)const;
   inline QPointF mapPointFromScene(const QPointF& point)const;
 
   QList<ctkPoint> bezierParams(ctkControlPoint* start, ctkControlPoint* end) const;


### PR DESCRIPTION
The signals emitted by the ctkTransferFunctionItem provide two values, the function position (x and y values of the function at the location under the mouse), and the button that was pressed.
Additional changes include the wrapping of additional methods in ctkVTKPiecewiseFunction and ctkVTKColorTransferFunction, as well as a function to set the log mode in ctkTransferFunctionBarsItem.