### PR TITLE
BUG: Fix unexpected camera position change in ctkVTKRenderView::lookFromAxis

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp
@@ -494,32 +494,32 @@ void ctkVTKRenderView::lookFromAxis(const ctkAxesWidget::Axis& axis, double fov)
     }
   vtkCamera * camera = d->Renderer->GetActiveCamera();
   Q_ASSERT(camera);
-  double widefov = fov*3;
+  double cameraDistance = camera->GetDistance();
   double* focalPoint = camera->GetFocalPoint();
   switch (axis)
     {
     case ctkAxesWidget::Right:
-      camera->SetPosition(focalPoint[0]+widefov, focalPoint[1], focalPoint[2]);
+      camera->SetPosition(focalPoint[0]+cameraDistance, focalPoint[1], focalPoint[2]);
       camera->SetViewUp(0, 0, 1);
       break;
     case ctkAxesWidget::Left:
-      camera->SetPosition(focalPoint[0]-widefov, focalPoint[1], focalPoint[2]);
+      camera->SetPosition(focalPoint[0]-cameraDistance, focalPoint[1], focalPoint[2]);
       camera->SetViewUp(0, 0, 1);
       break;
     case ctkAxesWidget::Anterior:
-      camera->SetPosition(focalPoint[0], focalPoint[1]+widefov, focalPoint[2]);
+      camera->SetPosition(focalPoint[0], focalPoint[1]+cameraDistance, focalPoint[2]);
       camera->SetViewUp(0, 0, 1);
       break;
     case ctkAxesWidget::Posterior:
-      camera->SetPosition(focalPoint[0], focalPoint[1]-widefov, focalPoint[2]);
+      camera->SetPosition(focalPoint[0], focalPoint[1]-cameraDistance, focalPoint[2]);
       camera->SetViewUp(0, 0, 1);
       break;
     case ctkAxesWidget::Superior:
-      camera->SetPosition(focalPoint[0], focalPoint[1], focalPoint[2]+widefov);
+      camera->SetPosition(focalPoint[0], focalPoint[1], focalPoint[2]+cameraDistance);
       camera->SetViewUp(0, 1, 0);
       break;
     case ctkAxesWidget::Inferior:
-      camera->SetPosition(focalPoint[0], focalPoint[1], focalPoint[2]-widefov);
+      camera->SetPosition(focalPoint[0], focalPoint[1], focalPoint[2]-cameraDistance);
       camera->SetViewUp(0, 1, 0);
       break;
     case ctkAxesWidget::None:


### PR DESCRIPTION
When user requested view from a selected axis, the camera distance from the focal point was changed, too. This distance change caused unexpected field of view change (in perspective projection mode) and unexpected lighting change (in parallel projection mode, see https://discourse.slicer.org/t/shading-changes-with-default-orientation-buttons-at-different-zooms/8907/7).

Changed the behavior to keep the distance from the focal point constant and just change the direction we look from.