### PR TITLE
BUG: Attempt to fix crash when opening database created with old schema

### DIFF
--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMIndexerTest1.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMIndexerTest1.cpp
@@ -40,19 +40,12 @@ int ctkDICOMIndexerTest1( int argc, char * argv [] )
   // just check if it doesn't crash
   // Create block to test batch indexing using indexingBatch helper class.
   {
-    ctkDICOMIndexer::ScopedIndexing indexingBatch(indexer, database);
-    indexer.addDirectory(database, QString());
+    indexer.addDirectory(&database, QString());
     // might work (if there are some DCM images in temp
-    indexer.addDirectory(database, QDir::tempPath());
+    indexer.addDirectory(&database, QDir::tempPath());
     // give an invalid destination name
-    indexer.addDirectory(database, QDir::tempPath(), QDir::tempPath() + "/@#$%^&*{}[]");
+    indexer.addDirectory(&database, QDir::tempPath(), true);
   }
-
-  // make sure it doesn't crash
-  indexer.refreshDatabase(database, QString());
-
-  // make sure it doesn't crash
-  indexer.refreshDatabase(database, QDir::tempPath());
 
   // ensure all concurrent inserts are complete
   indexer.waitForImportFinished();

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -161,6 +161,7 @@ public:
   QString LastError;
   QSqlDatabase Database;
   QMap<QString, QString> LoadedHeader;
+  bool DisplayedFieldsTableAvailable;
 
   ctkDICOMAbstractThumbnailGenerator* ThumbnailGenerator;
 
@@ -211,6 +212,7 @@ ctkDICOMDatabasePrivate::ctkDICOMDatabasePrivate(ctkDICOMDatabase& o): q_ptr(&o)
   this->ThumbnailGenerator = NULL;
   this->LoggedExecVerbose = false;
   this->TagCacheVerified = false;
+  this->DisplayedFieldsTableAvailable = false;
   this->resetLastInsertedValues();
 }
 
@@ -1526,6 +1528,9 @@ void ctkDICOMDatabasePrivate::setNumberOfStudiesToPatientDisplayedFields(QMap<QS
 }
 
 //------------------------------------------------------------------------------
+CTK_GET_CPP(ctkDICOMDatabase, bool, isDisplayedFieldsTableAvailable, DisplayedFieldsTableAvailable);
+
+//------------------------------------------------------------------------------
 // ctkDICOMDatabase methods
 //------------------------------------------------------------------------------
 
@@ -1594,6 +1599,8 @@ void ctkDICOMDatabase::openDatabase(const QString databaseFile, const QString& c
     }
   }
   d->resetLastInsertedValues();
+
+  d->DisplayedFieldsTableAvailable = d->Database.tables().contains("ColumnDisplayProperties");
 
   if (!isInMemory())
   {

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -243,6 +243,10 @@ public:
   /// number of studies in a patient).
   Q_INVOKABLE void updateDisplayedFields();
 
+  /// Get if displayed fields are defined. It returns false for databases that were created with an old schema
+  /// that did not contain ColumnDisplayProperties table.
+  Q_INVOKABLE bool isDisplayedFieldsTableAvailable() const;
+
   /// Reset cached item IDs to make sure previous
   /// inserts do not interfere with upcoming insert operations.
   /// Typically, it should be call just before a batch of files

--- a/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
@@ -160,7 +160,8 @@ void ctkDICOMTableViewPrivate::showFilterActiveWarning(bool showWarning)
 //----------------------------------------------------------------------------
 void ctkDICOMTableViewPrivate::applyColumnProperties()
 {
-  if (!this->dicomDatabase || !this->dicomDatabase->isOpen())
+  if (!this->dicomDatabase || !this->dicomDatabase->isOpen()
+    || !this->dicomDatabase->isDisplayedFieldsTableAvailable())
   {
     return;
   }
@@ -416,6 +417,12 @@ void ctkDICOMTableView::onDatabaseOpened()
 {
   Q_D(ctkDICOMTableView);
   this->setQuery();
+  if (!d->dicomDatabase || !d->dicomDatabase->isDisplayedFieldsTableAvailable())
+  {
+    // invalid or outdated database schema
+    this->setEnabled(false);
+    return;
+  }
   d->applyColumnProperties();
   this->setEnabled(true);
 }


### PR DESCRIPTION
On some builds, application crashed when opening old databases. Could not reproduce it on applications built on developer computer.
Added check for presence of displayed fields table (isDisplayedFieldsTableAvailable) and if the table is missing then table view is not attempted to be populated with data.