### PR TITLE
BUG: Fix building libraries as static modules

### DIFF
--- a/CMake/LastConfigureStep/CTKGenerateCTKConfig.cmake
+++ b/CMake/LastConfigureStep/CTKGenerateCTKConfig.cmake
@@ -115,7 +115,9 @@ endif()
 # as an external library
 export(TARGETS ${CTK_TARGETS_TO_EXPORT} FILE ${CTK_SUPERBUILD_BINARY_DIR}/CTKExports.cmake)
 
-install(EXPORT CTKExports DESTINATION ${CTK_INSTALL_CMAKE_DIR})
+if(MY_LIBRARY_TYPE STREQUAL "SHARED")
+  install(EXPORT CTKExports DESTINATION ${CTK_INSTALL_CMAKE_DIR})
+endif()
 
 #-----------------------------------------------------------------------------
 # Configure 'CTKConfig.cmake' for a build tree

--- a/CMake/ctkMacroBuildPlugin.cmake
+++ b/CMake/ctkMacroBuildPlugin.cmake
@@ -371,7 +371,7 @@ macro(ctkMacroBuildPlugin)
     PREFIX "lib"
     )
 
-  if(NOT MY_TEST_PLUGIN AND NOT MY_NO_INSTALL)
+  if(NOT MY_TEST_PLUGIN AND NOT MY_NO_INSTALL AND MY_LIBRARY_TYPE STREQUAL "SHARED")
     # Install rules
     install(TARGETS ${lib_name} EXPORT CTKExports
       RUNTIME DESTINATION ${CTK_INSTALL_PLUGIN_DIR} COMPONENT RuntimePlugins

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,12 +65,16 @@ endif()
 # Library mode: SHARED (default) or STATIC
 #
 set(CTK_LIBRARY_MODE "SHARED")
+set(MY_LIBRARY_TYPE "SHARED")
+add_definitions(-DCTK_SHARED)
 
 option(CTK_BUILD_SHARED_LIBS "Build CTK libraries as shared module." ON)
 mark_as_advanced(CTK_BUILD_SHARED_LIBS)
 mark_as_superbuild(CTK_BUILD_SHARED_LIBS)
 if(NOT CTK_BUILD_SHARED_LIBS)
   set(CTK_LIBRARY_MODE "STATIC")
+  set(MY_LIBRARY_TYPE "STATIC")
+  remove_definitions(-DCTK_SHARED)
 endif()
 
 #-----------------------------------------------------------------------------

--- a/Libs/ctkExport.h.in
+++ b/Libs/ctkExport.h.in
@@ -13,19 +13,23 @@
 #include <QtGlobal>
 
 #if defined(Q_OS_WIN) || defined(Q_OS_SYMBIAN)
-#  if defined(@MY_LIBNAME@_EXPORTS)
-#    define @MY_LIBRARY_EXPORT_DIRECTIVE@ Q_DECL_EXPORT
+# if defined(CTK_SHARED)
+#    if defined(@MY_LIBNAME@_EXPORTS)
+#      define @MY_LIBRARY_EXPORT_DIRECTIVE@ Q_DECL_EXPORT
+#    else
+#      define @MY_LIBRARY_EXPORT_DIRECTIVE@ Q_DECL_IMPORT
+#    endif
 #  else
-#    define @MY_LIBRARY_EXPORT_DIRECTIVE@ Q_DECL_IMPORT
+#    define @MY_LIBRARY_EXPORT_DIRECTIVE@
 #  endif
 #endif
 
 #if !defined(@MY_LIBRARY_EXPORT_DIRECTIVE@)
-//#  if defined(CTK_SHARED)
+#  if defined(CTK_SHARED)
 #    define @MY_LIBRARY_EXPORT_DIRECTIVE@ Q_DECL_EXPORT
-//#  else
-//#    define @MY_LIBRARY_EXPORT_DIRECTIVE@
-//#  endif
+#  else
+#    define @MY_LIBRARY_EXPORT_DIRECTIVE@
+#  endif
 #endif
 
 #endif


### PR DESCRIPTION
Static building were not handled - although the CTK_BUILD_SHARED_LIB option is present - and raised inconsistent dll linkage errors when compiling.