### PR TITLE
ENH: Make applications use UTF-8 code page

### DIFF
--- a/Applications/Testing/Cpp/CMakeLists.txt
+++ b/Applications/Testing/Cpp/CMakeLists.txt
@@ -29,7 +29,7 @@ if(CTK_APP_ctkDICOMQuery AND CTK_APP_ctkDICOMRetrieve)
   #
   # Add Tests
   #
-  add_executable(ctkDICOMApplicationTest1 ctkDICOMApplicationTest1.cpp)
+  ctk_add_executable_utf8(ctkDICOMApplicationTest1 ctkDICOMApplicationTest1.cpp)
   if(CTK_QT_VERSION VERSION_LESS "5")
     target_link_libraries(ctkDICOMApplicationTest1 ${QT_LIBRARIES})
   else()
@@ -50,4 +50,3 @@ if(CTK_APP_ctkDICOMQuery AND CTK_APP_ctkDICOMRetrieve)
                ${ctkDICOMRetrieve_STORE_DIR}
                )
 endif()
-

--- a/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerProgressWidget.cpp
+++ b/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerProgressWidget.cpp
@@ -21,6 +21,8 @@
 
 #include <ctkCmdLineModuleFuture.h>
 
+#include <QStyle>
+
 #include "ctkCmdLineModuleExplorerProgressWidget.h"
 #include "ui_ctkCmdLineModuleExplorerProgressWidget.h"
 

--- a/Applications/ctkDICOM/Testing/Cpp/CMakeLists.txt
+++ b/Applications/ctkDICOM/Testing/Cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ REMOVE (TestsToRun ${KIT}CppTests.cpp)
 # The following macro will read the target libraries from the file '<KIT_SOURCE_DIR>/target_libraries.cmake'
 ctkFunctionGetTargetLibraries(KIT_target_libraries ${${KIT}_SOURCE_DIR})
 
-add_executable(${KIT}CppTests ${Tests})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 target_link_libraries(${KIT}CppTests ${KIT_target_libraries})
 
 #

--- a/Applications/ctkDICOM/ctkDICOMMain.cpp
+++ b/Applications/ctkDICOM/ctkDICOMMain.cpp
@@ -64,8 +64,9 @@ int main(int argc, char** argv)
   if ( settings.value("DatabaseDirectory", "") == "" )
   {
     databaseDirectory = QString("./ctkDICOM-Database");
-    std::cerr << "No DatabaseDirectory on command line or in settings.  Using \"" << databaseDirectory.toLatin1().data() << "\".\n";
-  } else
+    std::cerr << "No DatabaseDirectory on command line or in settings.  Using \"" << qPrintable(databaseDirectory) << "\".\n";
+  }
+  else
   {
     databaseDirectory = settings.value("DatabaseDirectory", "").toString();
   }
@@ -75,7 +76,7 @@ int main(int argc, char** argv)
   {
     if ( !qdir.mkpath(databaseDirectory) )
     {
-      std::cerr << "Could not create database directory \"" << databaseDirectory.toLatin1().data() << "\".\n";
+      std::cerr << "Could not create database directory \"" << qPrintable(databaseDirectory) << "\".\n";
       return EXIT_FAILURE;
     }
   }

--- a/Applications/ctkDICOM2/Testing/Cpp/CMakeLists.txt
+++ b/Applications/ctkDICOM2/Testing/Cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ REMOVE (TestsToRun ${KIT}CppTests.cpp)
 # The following macro will read the target libraries from the file '<KIT_SOURCE_DIR>/target_libraries.cmake'
 ctkFunctionGetTargetLibraries(KIT_target_libraries ${${KIT}_SOURCE_DIR})
 
-add_executable(${KIT}CppTests ${Tests})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 target_link_libraries(${KIT}CppTests ${KIT_target_libraries})
 
 #

--- a/Applications/ctkDICOMDemoSCU/Testing/Cpp/CMakeLists.txt
+++ b/Applications/ctkDICOMDemoSCU/Testing/Cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ REMOVE (TestsToRun ${KIT}CppTests.cpp)
 # The following macro will read the target libraries from the file '<KIT_SOURCE_DIR>/target_libraries.cmake'
 ctkFunctionGetTargetLibraries(KIT_target_libraries ${${KIT}_SOURCE_DIR})
 
-add_executable(${KIT}CppTests ${Tests})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 target_link_libraries(${KIT}CppTests ${KIT_target_libraries})
 
 #

--- a/Applications/ctkDICOMHost/Testing/Cpp/CMakeLists.txt
+++ b/Applications/ctkDICOMHost/Testing/Cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ REMOVE (TestsToRun ${KIT}CppTests.cpp)
 # The following macro will read the target libraries from the file 'target_libraries.cmake'
 ctkFunctionGetTargetLibraries(KIT_target_libraries)
 
-ADD_EXECUTABLE(${KIT}CppTests ${Tests})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 TARGET_LINK_LIBRARIES(${KIT}CppTests ${KIT_target_libraries} ${QT_LIBRARIES})
 
 SET( KIT_TESTS ${CPP_TEST_PATH}/${KIT}CppTests)

--- a/Applications/ctkDICOMHost/ctkDICOMHostMain.cpp
+++ b/Applications/ctkDICOMHost/ctkDICOMHostMain.cpp
@@ -136,7 +136,7 @@ int main(int argc, char** argv)
   if ( settings.value("DatabaseDirectory", "") == "" )
   {
     databaseDirectory = QString("./ctkDICOM-Database");
-    std::cerr << "No DatabaseDirectory on command line or in settings.  Using \"" << databaseDirectory.toLatin1().data() << "\".\n";
+    std::cerr << "No DatabaseDirectory on command line or in settings.  Using \"" << qPrintable(databaseDirectory) << "\".\n";
   } else
   {
     databaseDirectory = settings.value("DatabaseDirectory", "").toString();
@@ -147,7 +147,7 @@ int main(int argc, char** argv)
   {
     if ( !qdir.mkpath(databaseDirectory) )
     {
-      std::cerr << "Could not create database directory \"" << databaseDirectory.toLatin1().data() << "\".\n";
+      std::cerr << "Could not create database directory \"" << qPrintable(databaseDirectory) << "\".\n";
       return EXIT_FAILURE;
     }
   }

--- a/Applications/ctkDICOMIndexer/Testing/Cpp/CMakeLists.txt
+++ b/Applications/ctkDICOMIndexer/Testing/Cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ REMOVE (TestsToRun ${KIT}CppTests.cpp)
 # The following macro will read the target libraries from the file '<KIT_SOURCE_DIR>/target_libraries.cmake'
 ctkFunctionGetTargetLibraries(KIT_target_libraries ${${KIT}_SOURCE_DIR})
 
-add_executable(${KIT}CppTests ${Tests})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 target_link_libraries(${KIT}CppTests ${KIT_target_libraries})
 
 #

--- a/Applications/ctkDICOMQueryRetrieve/Testing/Cpp/CMakeLists.txt
+++ b/Applications/ctkDICOMQueryRetrieve/Testing/Cpp/CMakeLists.txt
@@ -10,10 +10,9 @@ REMOVE (TestsToRun ${KIT}CppTests.cpp)
 # The following macro will read the target libraries from the file '<KIT_SOURCE_DIR>/target_libraries.cmake'
 ctkFunctionGetTargetLibraries(KIT_target_libraries ${${KIT}_SOURCE_DIR})
 
-add_executable(${KIT}CppTests ${Tests})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 target_link_libraries(${KIT}CppTests ${KIT_target_libraries})
 
 #
 # Add Tests
 #
-

--- a/Applications/ctkDICOMQueryRetrieve/ctkDICOMQueryRetrieveMain.cpp
+++ b/Applications/ctkDICOMQueryRetrieve/ctkDICOMQueryRetrieveMain.cpp
@@ -64,7 +64,7 @@ int main(int argc, char** argv)
   if ( settings.value("DatabaseDirectory", "") == "" )
   {
     databaseDirectory = QString("./ctkDICOM-Database");
-    std::cerr << "No DatabaseDirectory on command line or in settings.  Using \"" << databaseDirectory.toLatin1().data() << "\".\n";
+    std::cerr << "No DatabaseDirectory on command line or in settings.  Using \"" << qPrintable(databaseDirectory) << "\".\n";
   } else
   {
     databaseDirectory = settings.value("DatabaseDirectory", "").toString();
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
   {
     if ( !qdir.mkpath(databaseDirectory) )
     {
-      std::cerr << "Could not create database directory \"" << databaseDirectory.toLatin1().data() << "\".\n";
+      std::cerr << "Could not create database directory \"" << qPrintable(databaseDirectory) << "\".\n";
       return EXIT_FAILURE;
     }
   }

--- a/CMake/WindowsApplicationUseUtf8.manifest
+++ b/CMake/WindowsApplicationUseUtf8.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/CMake/ctkFunctionAddExecutableUtf8.cmake
+++ b/CMake/ctkFunctionAddExecutableUtf8.cmake
@@ -1,0 +1,21 @@
+#! Usage:
+#! \code
+#! ctk_add_executable_utf8(args)
+#! \endcode
+#!
+#! This macro adds an executable that uses UTF-8 code page.
+#!
+#! Linux and Mac OSX already uses this code page by default but on Windows
+#! it has to be set explicitly, by using a manifest file.
+#!
+#! \ingroup CMakeUtilities
+
+function(ctk_add_executable_utf8)
+
+if(WIN32)
+  add_executable(${ARGN} ${CTK_CMAKE_DIR}/WindowsApplicationUseUtf8.manifest)
+else()
+  add_executable(${ARGN})
+endif()
+
+endfunction()

--- a/CMake/ctkFunctionCompileSnippets.cmake
+++ b/CMake/ctkFunctionCompileSnippets.cmake
@@ -23,9 +23,9 @@ function(ctkFunctionCompileSnippets snippet_path)
   foreach(main_cpp_file ${main_cpp_list})
     # get the directory containing the main.cpp file
     get_filename_component(main_cpp_dir "${main_cpp_file}" PATH)
-    
+
     set(snippet_src_files )
-    
+
     # If there exists a "files.cmake" file in the snippet directory,
     # include it and assume it sets the variable "snippet_src_files"
     # to a list of source files for the snippet.
@@ -44,12 +44,12 @@ function(ctkFunctionCompileSnippets snippet_path)
       # glob all files in the directory and add them to the snippet src list
       file(GLOB_RECURSE snippet_src_files "${main_cpp_dir}/*")
     endif()
-    
+
     # Uset the top-level directory name as the executable name
     string(REPLACE "/" ";" main_cpp_dir_tokens "${main_cpp_dir}")
     list(GET main_cpp_dir_tokens -1 snippet_exec_name)
     set(snippet_target_name "Snippet-${snippet_exec_name}")
-    add_executable(${snippet_target_name} ${snippet_src_files})
+    ctk_add_executable_utf8(${snippet_target_name} ${snippet_src_files})
     if(ARGN)
       target_link_libraries(${snippet_target_name} ${ARGN})
     endif()
@@ -59,7 +59,7 @@ function(ctkFunctionCompileSnippets snippet_path)
       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/snippets"
       OUTPUT_NAME ${snippet_exec_name}
     )
-    
+
   endforeach()
 
 endfunction()

--- a/CMake/ctkLinkerAsNeededFlagCheck/CMakeLists.txt
+++ b/CMake/ctkLinkerAsNeededFlagCheck/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(A SHARED A.cpp)
 add_library(B SHARED B.cpp)
-add_executable(C C.cpp)
+ctk_add_executable_utf8(C C.cpp)
 target_link_libraries(C B A)

--- a/CMake/ctkMacroBuildApp.cmake
+++ b/CMake/ctkMacroBuildApp.cmake
@@ -120,7 +120,7 @@ macro(ctkMacroBuildApp)
     )
 
   # Create executable
-  add_executable(${proj_name}
+  ctk_add_executable_utf8(${proj_name}
     ${MY_SRCS}
     ${MY_MOC_CPP}
     ${MY_UI_CPP}
@@ -151,5 +151,3 @@ macro(ctkMacroBuildApp)
   endif()
 
 endmacro()
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ foreach(file
   CMake/ctkMacroListFilter.cmake
   CMake/ctkMacroOptionUtils.cmake
   CMake/ctkMacroBuildLib.cmake
+  CMake/ctkFunctionAddExecutableUtf8.cmake
   CMake/ctkFunctionExtractOptimizedLibrary.cmake
   CMake/ctkMacroBuildLibWrapper.cmake
   CMake/ctkMacroBuildPlugin.cmake

--- a/Libs/CommandLineModules/Core/Testing/Cpp/CMakeLists.txt
+++ b/Libs/CommandLineModules/Core/Testing/Cpp/CMakeLists.txt
@@ -46,7 +46,7 @@ else()
   endif()
   QT4_ADD_RESOURCES(Tests_RESOURCES_SRCS ${Tests_RESOURCES})
 endif()
-add_executable(${KIT}CppTests ${Tests} ${Tests_SRCS} ${Tests_MOC_CPP} ${Tests_UI_CPP} ${Tests_RESOURCES_SRCS})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests} ${Tests_SRCS} ${Tests_MOC_CPP} ${Tests_UI_CPP} ${Tests_RESOURCES_SRCS})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME} ${CTK_BASE_LIBRARIES})
 
 if(CTK_QT_VERSION VERSION_GREATER "4")

--- a/Libs/CommandLineModules/Frontend/QtGui/Testing/Cpp/CMakeLists.txt
+++ b/Libs/CommandLineModules/Frontend/QtGui/Testing/Cpp/CMakeLists.txt
@@ -49,7 +49,7 @@ else()
   QT4_ADD_RESOURCES(Tests_RESOURCES_SRCS ${Tests_RESOURCES})
 endif()
 
-add_executable(${KIT}CppTests ${Tests} ${Tests_SRCS} ${Tests_MOC_CPP} ${Tests_UI_CPP} ${Tests_RESOURCES_SRCS})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests} ${Tests_SRCS} ${Tests_MOC_CPP} ${Tests_UI_CPP} ${Tests_RESOURCES_SRCS})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME} ${CTK_BASE_LIBRARIES})
 
 if(CTK_QT_VERSION VERSION_GREATER "4")

--- a/Libs/CommandLineModules/Testing/Cpp/CMakeLists.txt
+++ b/Libs/CommandLineModules/Testing/Cpp/CMakeLists.txt
@@ -92,7 +92,7 @@ else()
   QT4_ADD_RESOURCES(Tests_RESOURCES_SRCS ${Tests_RESOURCES})
 endif()
 
-add_executable(${KIT}CppTests ${Tests} ${Tests_SRCS} ${Tests_MOC_CPP} ${Tests_UI_CPP} ${Tests_RESOURCES_SRCS})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests} ${Tests_SRCS} ${Tests_MOC_CPP} ${Tests_UI_CPP} ${Tests_RESOURCES_SRCS})
 target_link_libraries(${KIT}CppTests ${_additional_link_libraries})
 add_dependencies(${KIT}CppTests ctkCmdLineTestModules)
 

--- a/Libs/CommandLineModules/Testing/Modules/CMakeLists.txt
+++ b/Libs/CommandLineModules/Testing/Modules/CMakeLists.txt
@@ -11,7 +11,7 @@ function(ctkFunctionCreateCmdLineModule name)
     qt5_add_resources(_src_files ctkCmdLineModule${name}.qrc)
   endif()
 
-  add_executable(ctkCmdLineModule${name} ${_src_files})
+  ctk_add_executable_utf8(ctkCmdLineModule${name} ${_src_files})
   if(CTK_QT_VERSION VERSION_LESS "5")
     target_link_libraries(ctkCmdLineModule${name} CTKCore ${QT_LIBRARIES})
   else()

--- a/Libs/Core/CMake/TestBFD/CMakeLists.txt
+++ b/Libs/Core/CMake/TestBFD/CMakeLists.txt
@@ -10,5 +10,5 @@ endif()
 unset(BFD_LIBRARY CACHE)
 find_library(BFD_LIBRARY ${BFD_LIBRARY_NAME})
 
-add_executable(TestBFD TestBFD.cpp)
+ctk_add_executable_utf8(TestBFD TestBFD.cpp)
 target_link_libraries(TestBFD ${BFD_LIBRARY})

--- a/Libs/Core/Testing/Cpp/CMakeLists.txt
+++ b/Libs/Core/Testing/Cpp/CMakeLists.txt
@@ -35,6 +35,7 @@ set(KITTests_SRCS
   ctkLoggerTest1.cpp
   ctkModelTesterTest1.cpp
   ctkModelTesterTest2.cpp
+  ctkUtf8Test1.cpp
   ctkUtilsCopyDirRecursivelyTest1.cpp
   ctkUtilsQtHandleToStringTest1.cpp
   ctkUtilsTest.cpp
@@ -107,7 +108,7 @@ else()
 endif()
 
 if(HAVE_BFD)
-  add_executable(ctkBinaryFileDescriptorTestHelper ctkBinaryFileDescriptorTestHelper.cpp)
+  ctk_add_executable_utf8(ctkBinaryFileDescriptorTestHelper ctkBinaryFileDescriptorTestHelper.cpp)
 endif()
 
 if(MSVC)
@@ -117,7 +118,7 @@ endif()
 #
 # Test executable
 #
-add_executable(${KIT}CppTests ${Tests} ${Tests_Helpers_SRCS} ${Tests_Helpers_MOC_CPP})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests} ${Tests_Helpers_SRCS} ${Tests_Helpers_MOC_CPP})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME} ${CTK_BASE_LIBRARIES} CTKDummyPlugin)
 
 if(CTK_QT_VERSION VERSION_GREATER "4")

--- a/Libs/Core/Testing/Cpp/ctkErrorLogModelFileLoggingTest1.cpp
+++ b/Libs/Core/Testing/Cpp/ctkErrorLogModelFileLoggingTest1.cpp
@@ -90,13 +90,13 @@ int ctkErrorLogModelFileLoggingTest1(int argc, char * argv [])
 
   // Qt messages
   QString qtMessage0("This is a qDebug message");
-  qDebug().nospace() << qPrintable(qtMessage0);
+  qDebug().nospace() << qUtf8Printable(qtMessage0);
 
   QString qtMessage1("This is a qWarning message");
-  qWarning().nospace() << qPrintable(qtMessage1);
+  qWarning().nospace() << qUtf8Printable(qtMessage1);
 
   QString qtMessage2("This is a qCritical message");
-  qCritical().nospace() << qPrintable(qtMessage2);
+  qCritical().nospace() << qUtf8Printable(qtMessage2);
 
   // Stream messages
   QString streamMessage0("This is a Cout message");

--- a/Libs/Core/Testing/Cpp/ctkUtf8Test1.cpp
+++ b/Libs/Core/Testing/Cpp/ctkUtf8Test1.cpp
@@ -1,0 +1,117 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+
+#ifdef _WIN32
+#include "Windows.h"
+#endif
+
+#include <iostream>
+#include <fstream>
+
+// Helper function to get Windows version
+#ifdef _WIN32
+typedef LONG NTSTATUS, * PNTSTATUS;
+#define STATUS_SUCCESS (0x00000000)
+typedef NTSTATUS(WINAPI* RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
+RTL_OSVERSIONINFOW GetRealOSVersion()
+{
+  HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
+  if (hMod)
+  {
+    RtlGetVersionPtr fxPtr = (RtlGetVersionPtr)::GetProcAddress(hMod, "RtlGetVersion");
+    if (fxPtr != nullptr)
+    {
+      RTL_OSVERSIONINFOW rovi = { 0 };
+      rovi.dwOSVersionInfoSize = sizeof(rovi);
+      if (STATUS_SUCCESS == fxPtr(&rovi))
+      {
+        return rovi;
+      }
+    }
+  }
+  RTL_OSVERSIONINFOW rovi = { 0 };
+  return rovi;
+}
+#endif
+
+int ctkUtf8Test1(int argc, char* argv[])
+{
+
+#ifdef _WIN32
+  // Check current windows version before proceeding
+  RTL_OSVERSIONINFOW rovi = GetRealOSVersion();
+  std::cout << "Windows version: " << rovi.dwMajorVersion << "." << rovi.dwMinorVersion << " build " << rovi.dwBuildNumber << std::endl;
+  if (rovi.dwBuildNumber < 18362)
+  {
+    std::cout << "This Windows version does not support UTF-8 as active code page in application (minimum build number is 18362). Further testing is skipped." << std::endl;
+    return 0;
+  }
+
+  // Check that active code page is UTF-8 on Windows
+  UINT activeCodePage = GetACP();
+  std::cout << "Active code page: " << activeCodePage << std::endl;
+  if (activeCodePage != CP_UTF8)
+  {
+    std::cerr << "Error: active code page is " << activeCodePage << ", expected " << CP_UTF8 << " (UTF-8)" << std::endl;
+    return 1;
+  }
+#endif
+
+  // Check that we can create a file wit utf8 filename using standard file API
+  std::string filenameUtf8 = u8"alpha(\u03b1).txt";
+  std::ofstream outputFileStream;
+  outputFileStream.open(filenameUtf8);
+  if (!outputFileStream.is_open())
+  {
+    std::cerr << "Failed to open file for writing: " << filenameUtf8.c_str() << std::endl;
+    return 1;
+  }
+  outputFileStream << "some text" << std::endl;
+  outputFileStream.close();
+
+  // Test if file is created successfully
+  // We use special wide character API on Windows to ensure we properly check for the existence of the file
+  // regardless of active code page.
+#if _WIN32
+  std::wstring filenameW;
+  filenameW += L"alpha(";
+  filenameW.push_back((wchar_t)(0x03B1));
+  filenameW += L").txt";
+  FILE* tmp = _wfopen(filenameW.c_str(), L"r");
+#else
+  FILE* tmp = fopen(filenameUtf8.c_str(), "r");
+#endif
+  if (!tmp)
+  {
+    std::cerr << "Expected file does not exist: " << filenameUtf8.c_str() << std::endl;
+    return 1;
+  }
+  fclose(tmp);
+
+  // Delete the temporary file
+#if _WIN32
+  _wunlink(filenameW.c_str());
+#else
+  unlink(utf8_str.c_str());
+#endif
+
+  return 0;
+}

--- a/Libs/Core/ctkBinaryFileDescriptor.cpp
+++ b/Libs/Core/ctkBinaryFileDescriptor.cpp
@@ -176,7 +176,7 @@ bool ctkBinaryFileDescriptor::load()
   Q_D(ctkBinaryFileDescriptor);
   
   bfd_init();
-  bfd * abfd = bfd_openr(d->FileName.toLatin1(), NULL);
+  bfd * abfd = bfd_openr(d->FileName.toUtf8(), NULL);
   if (!abfd)
     {
     return false;

--- a/Libs/Core/ctkLogger.cpp
+++ b/Libs/Core/ctkLogger.cpp
@@ -62,7 +62,7 @@ void ctkLogger::debug(const QString& s)
 {
   //Q_D(ctkLogger);
   //d->Logger->debug(s);
-  qDebug().nospace() << qPrintable(s);
+  qDebug().nospace() << qUtf8Printable(s);
 }
 
 //-----------------------------------------------------------------------------
@@ -70,7 +70,7 @@ void ctkLogger::info(const QString& s)
 {
   //Q_D(ctkLogger);
   //d->Logger->info(s);
-  qDebug().nospace() << qPrintable(s);
+  qDebug().nospace() << qUtf8Printable(s);
 }
 
 //-----------------------------------------------------------------------------
@@ -78,7 +78,7 @@ void ctkLogger::trace(const QString& s)
 {
   //Q_D(ctkLogger);
   //d->Logger->trace(s);
-  qDebug().nospace() << qPrintable(s);
+  qDebug().nospace() << qUtf8Printable(s);
 }
 
 //-----------------------------------------------------------------------------
@@ -86,7 +86,7 @@ void ctkLogger::warn(const QString& s)
 {
   //Q_D(ctkLogger);
   //d->Logger->warn(s);
-  qWarning().nospace() << qPrintable(s);
+  qWarning().nospace() << qUtf8Printable(s);
 }
 
 //-----------------------------------------------------------------------------
@@ -94,7 +94,7 @@ void ctkLogger::error(const QString& s)
 {
   //Q_D(ctkLogger);
   //d->Logger->error(s);
-  qCritical().nospace() << qPrintable(s);
+  qCritical().nospace() << qUtf8Printable(s);
 }
 
 //-----------------------------------------------------------------------------
@@ -102,7 +102,7 @@ void ctkLogger::fatal(const QString& s)
 {
   //Q_D(ctkLogger);
   //d->Logger->fatal(s);
-  qCritical().nospace() << qPrintable(s);
+  qCritical().nospace() << qUtf8Printable(s);
 }
 
 ////-----------------------------------------------------------------------------

--- a/Libs/Core/ctkUtils.cpp
+++ b/Libs/Core/ctkUtils.cpp
@@ -48,7 +48,7 @@ void ctk::qListToSTLVector(const QStringList& list,
     {
     // Allocate memory
     char* str = new char[list[i].size()+1];
-    strcpy(str, list[i].toLatin1());
+    strcpy(str, list[i].toUtf8());
     vector[i] = str;
     }
 }

--- a/Libs/DICOM/Core/Testing/Cpp/CMakeLists.txt
+++ b/Libs/DICOM/Core/Testing/Cpp/CMakeLists.txt
@@ -26,7 +26,7 @@ REMOVE (TestsToRun ${KIT}CppTests.cpp)
 
 set(LIBRARY_NAME ${PROJECT_NAME})
 
-add_executable(${KIT}CppTests ${Tests})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME})
 
 #

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -872,7 +872,7 @@ bool ctkDICOMDatabasePrivate::storeThumbnailFile(const QString& originalFilePath
     return true;
   }
   QDir(q->databaseDirectory() + "/thumbs/").mkpath(studySeriesDirectory);
-  DicomImage dcmImage(QDir::toNativeSeparators(originalFilePath).toLatin1());
+  DicomImage dcmImage(QDir::toNativeSeparators(originalFilePath).toUtf8());
   return this->ThumbnailGenerator->generateThumbnail(&dcmImage, thumbnailPath);
 }
 
@@ -1033,7 +1033,7 @@ void ctkDICOMDatabase::insert(const QList<ctkDICOMDatabase::IndexingResult>& ind
   {
     const ctkDICOMItem& dataset = *indexingResult.dataset.data();
     QString filePath = indexingResult.filePath;
-    bool generateThumbnail = false;
+    bool generateThumbnail = false; // thumbnail will be generated when needed, don't slow down import with that
     bool storeFile = indexingResult.copyFile;
 
     // Check to see if the file has already been loaded
@@ -2142,7 +2142,7 @@ void ctkDICOMDatabase::loadFileHeader (QString fileName)
   Q_D(ctkDICOMDatabase);
   d->LoadedHeader.clear();
   DcmFileFormat fileFormat;
-  OFCondition status = fileFormat.loadFile(fileName.toLatin1().data());
+  OFCondition status = fileFormat.loadFile(fileName.toUtf8().data());
   if (status.good())
   {
     DcmDataset *dataset = fileFormat.getDataset();

--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorDefaultRule.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorDefaultRule.cpp
@@ -143,7 +143,7 @@ void ctkDICOMDisplayedFieldGeneratorDefaultRule::mergeDisplayedFieldsForInstance
 //------------------------------------------------------------------------------
 QString ctkDICOMDisplayedFieldGeneratorDefaultRule::humanReadablePatientName(QString dicomPatientName)
 {
-  OFString dicomName(dicomPatientName.toLatin1().constData());
+  OFString dicomName(dicomPatientName.toUtf8().constData());
   OFString formattedName;
   OFString lastName, firstName, middleName, namePrefix, nameSuffix;
   OFCondition l_error = DcmPersonName::getNameComponentsFromString(

--- a/Libs/DICOM/Core/ctkDICOMItem.cpp
+++ b/Libs/DICOM/Core/ctkDICOMItem.cpp
@@ -116,7 +116,7 @@ void ctkDICOMItem::InitializeFromFile(const QString& filename,
   DcmDataset *dataset;
 
   DcmFileFormat fileformat;
-  OFCondition status = fileformat.loadFile(filename.toLatin1().data(), readXfer, groupLength, maxReadLength, readMode);
+  OFCondition status = fileformat.loadFile(filename.toUtf8().data(), readXfer, groupLength, maxReadLength, readMode);
   dataset = fileformat.getAndRemoveDataset();
 
   if (!status.good())
@@ -1006,12 +1006,12 @@ bool ctkDICOMItem::SaveToFile(const QString& filePath) const
 {
   Q_D(const ctkDICOMItem);
 
-  if (! dynamic_cast<DcmDataset*>(d->m_DcmItem) )
+  if (!dynamic_cast<DcmDataset*>(d->m_DcmItem))
   {
     return false;
   }
-  DcmFileFormat* fileformat = new DcmFileFormat ( dynamic_cast<DcmDataset*>(d->m_DcmItem) );
-  OFCondition status = fileformat->saveFile ( qPrintable(QDir::toNativeSeparators( filePath)) );
+  DcmFileFormat* fileformat = new DcmFileFormat(dynamic_cast<DcmDataset*>(d->m_DcmItem));
+  OFCondition status = fileformat->saveFile(QDir::toNativeSeparators(filePath).toUtf8().data());
   delete fileformat;
   return status.good();
 }

--- a/Libs/DICOM/Widgets/Testing/Cpp/CMakeLists.txt
+++ b/Libs/DICOM/Widgets/Testing/Cpp/CMakeLists.txt
@@ -41,7 +41,7 @@ REMOVE (TestsToRun ${KIT}CppTests.cpp)
 
 set(LIBRARY_NAME ${PROJECT_NAME})
 
-add_executable(${KIT}CppTests ${Tests})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME} ${CTK_BASE_LIBRARIES} ${CTK_QT_TEST_LIBRARY})
 
 #

--- a/Libs/DICOM/Widgets/ctkDICOMAppWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMAppWidget.h
@@ -97,12 +97,8 @@ public Q_SLOTS:
   /// an import (i.e. for testing or to support drag-and-drop)
   void onImportDirectory(QString directory);
 
-  /// slots to capture status updates from the database during an 
-  /// import operation
-  void onPatientAdded(int, QString, QString, QString);
-  void onStudyAdded(QString);
-  void onSeriesAdded(QString);
-  void onInstanceAdded(QString);
+  /// Save number of added patients, studies, series, images
+  void setIndexingResult(int, int, int, int);
 
 Q_SIGNALS:
   /// Emited when directory is changed

--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
@@ -1319,7 +1319,9 @@ void ctkDICOMBrowser::exportSeries(QString dirPath, QStringList uids)
     destinationDir += sep;
 
     // make sure only ascii characters are in the directory path
-    destinationDir = destinationDir.toLatin1();
+    // (while special characters may be used on an internal hard disk, it may not be possible
+    // to use special characters on file systems of an external drive or network storage)
+    destinationDir = QString::fromLatin1(destinationDir.toLatin1());
     // replace any question marks that were used as replacements for non ascii
     // characters with underscore
     destinationDir.replace("?", "_");
@@ -1367,6 +1369,8 @@ void ctkDICOMBrowser::exportSeries(QString dirPath, QStringList uids)
 
       // replace non ASCII characters
       destinationFileName = destinationFileName.toLatin1();
+      // (it is safer to avoid special characters in case the files are
+      // to be more compatible with exported to external drive or network storage)
       // replace any question marks that were used as replacements for non ascii
       // characters with underscore
       destinationFileName.replace("?", "_");

--- a/Libs/DICOM/Widgets/ctkDICOMObjectModel.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMObjectModel.cpp
@@ -263,7 +263,7 @@ void ctkDICOMObjectModel::setFile(const QString &fileName)
 {
   Q_D(ctkDICOMObjectModel);
 
-  OFCondition status = d->fileFormat.loadFile( fileName.toLatin1().data());
+  OFCondition status = d->fileFormat.loadFile( fileName.toUtf8().data());
   if( !status.good() )
     {
     // TODO: Through an error message.

--- a/Libs/ImageProcessing/ITK/Core/Testing/Cpp/CMakeLists.txt
+++ b/Libs/ImageProcessing/ITK/Core/Testing/Cpp/CMakeLists.txt
@@ -55,7 +55,7 @@ set(LIBRARY_NAME ${PROJECT_NAME})
 include_directories(${CMAKE_SOURCE_DIR}/Libs/Widgets)
 include_directories(${CMAKE_BINARY_DIR}/Libs/Widgets)
 
-add_executable(${KIT}CppTests ${Tests} ${KIT_HELPER_SRCS})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests} ${KIT_HELPER_SRCS})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME} ${CTK_BASE_LIBRARIES} CTKWidgets)
 
 #
@@ -73,4 +73,3 @@ if(EXISTS "${CTKData_DIR}")
   set(baseline_relative_location "Libs/ImageProcessing/ITK/Core")
   #SIMPLE_TEST(Foo ${baseline_relative_location}/${TESTNAME}.png)
 endif()
-

--- a/Libs/PluginFramework/Testing/FrameworkTestPlugins/app_test/CMakeLists.txt
+++ b/Libs/PluginFramework/Testing/FrameworkTestPlugins/app_test/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 
 set(test_executable ${fw_lib}AppTests)
 
-add_executable(${test_executable} ${SRCS} ${MY_MOC_CXX})
+ctk_add_executable_utf8(${test_executable} ${SRCS} ${MY_MOC_CXX})
 target_link_libraries(${test_executable}
   ${fw_lib}
 )

--- a/Libs/PluginFramework/Testing/org.commontk.pluginfwtest.perf/CMakeLists.txt
+++ b/Libs/PluginFramework/Testing/org.commontk.pluginfwtest.perf/CMakeLists.txt
@@ -46,7 +46,7 @@ set(SRCS
 
 set(test_executable ${PROJECT_NAME}CppTests)
 
-add_executable(${test_executable} ${SRCS})
+ctk_add_executable_utf8(${test_executable} ${SRCS})
 target_link_libraries(${test_executable}
   ${fw_lib}
   ${fwtestutil_lib}

--- a/Libs/PluginFramework/Testing/org.commontk.pluginfwtest/CMakeLists.txt
+++ b/Libs/PluginFramework/Testing/org.commontk.pluginfwtest/CMakeLists.txt
@@ -53,7 +53,7 @@ set(MY_MOC_CXX )
 
 set(test_executable ${fw_lib}CppTests)
 
-add_executable(${test_executable} ${SRCS} ${MY_MOC_CXX})
+ctk_add_executable_utf8(${test_executable} ${SRCS} ${MY_MOC_CXX})
 target_link_libraries(${test_executable}
   ${fw_lib}
   ${fwtestutil_lib}

--- a/Libs/Scripting/Python/Core/Testing/Cpp/CMakeLists.txt
+++ b/Libs/Scripting/Python/Core/Testing/Cpp/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
     )
 endif()
 
-add_executable(${KIT}CppTests ${Tests})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME} ${CTK_BASE_LIBRARIES} ${CTK_QT_TEST_LIBRARY})
 
 #

--- a/Libs/Scripting/Python/Widgets/Testing/Cpp/CMakeLists.txt
+++ b/Libs/Scripting/Python/Widgets/Testing/Cpp/CMakeLists.txt
@@ -10,7 +10,7 @@ REMOVE (TestsToRun ${KIT}CppTests.cpp)
 
 set(LIBRARY_NAME ${PROJECT_NAME})
 
-add_executable(${KIT}CppTests ${Tests})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME} ${CTK_BASE_LIBRARIES})
 
 #

--- a/Libs/Visualization/VTK/Core/Testing/Cpp/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Core/Testing/Cpp/CMakeLists.txt
@@ -62,7 +62,7 @@ REMOVE (TestsToRun ${KIT}CppTests.cpp)
 
 set(LIBRARY_NAME ${PROJECT_NAME})
 
-add_executable(${KIT}CppTests ${Tests} ${KIT_HELPER_SRCS})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests} ${KIT_HELPER_SRCS})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME} ${CTK_BASE_LIBRARIES})
 
 #
@@ -80,4 +80,3 @@ if(EXISTS "${CTKData_DIR}")
   set(baseline_relative_location "Libs/Visualization/VTK/Core")
   SIMPLE_TEST_WITH_DATA( vtkLightBoxRendererManagerTest1 ${baseline_relative_location}/vtkLightBoxRendererManagerTest1.png)
 endif()
-

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/CMakeLists.txt
@@ -131,7 +131,7 @@ else()
   QT4_ADD_RESOURCES(Tests_RESOURCES_SRCS ${Tests_RESOURCES})
 endif()
 
-add_executable(${KIT}CppTests ${Tests} ${TEST_MOC_CPP} ${TEST_UI_CPP} ${Tests_RESOURCES_SRCS})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests} ${TEST_MOC_CPP} ${TEST_UI_CPP} ${Tests_RESOURCES_SRCS})
 if(${VTK_VERSION_MAJOR} GREATER 5)
   set(VTK_CHARTS_LIB vtkChartsCore)
 else()

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMagnifyViewTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMagnifyViewTest2.cpp
@@ -234,7 +234,7 @@ int ctkVTKMagnifyViewTest2(int argc, char * argv [] )
 
   // Instanciate an image reader
   vtkSmartPointer<vtkImageReader2> imageReader;
-  imageReader.TakeReference(imageFactory->CreateImageReader2(imageFilename.toLatin1()));
+  imageReader.TakeReference(imageFactory->CreateImageReader2(imageFilename.toUtf8()));
   if (!imageReader)
     {
     std::cerr << "Failed to instanciate image reader using: "
@@ -243,7 +243,7 @@ int ctkVTKMagnifyViewTest2(int argc, char * argv [] )
     }
 
   // Read image
-  imageReader->SetFileName(imageFilename.toLatin1());
+  imageReader->SetFileName(imageFilename.toUtf8());
   imageReader->Update();
 #if (VTK_MAJOR_VERSION <= 5)
   vtkImageData* image = imageReader->GetOutput();

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest2.cpp
@@ -83,7 +83,7 @@ int ctkVTKSliceViewTest2(int argc, char * argv [] )
 
   // Instanciate an image reader
   vtkSmartPointer<vtkImageReader2> imageReader;
-  imageReader.TakeReference(imageFactory->CreateImageReader2(imageFilename.toLatin1()));
+  imageReader.TakeReference(imageFactory->CreateImageReader2(imageFilename.toUtf8()));
   if (!imageReader)
     {
     std::cerr << "Failed to instanciate image reader using: " 
@@ -92,7 +92,7 @@ int ctkVTKSliceViewTest2(int argc, char * argv [] )
     }
 
   // Read image
-  imageReader->SetFileName(imageFilename.toLatin1());
+  imageReader->SetFileName(imageFilename.toUtf8());
 #if (VTK_MAJOR_VERSION <= 5)
   imageReader->Update();
   vtkImageData* image = imageReader->GetOutput();

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
@@ -340,14 +340,14 @@ void ctkVTKAbstractView::setCornerAnnotationText(const QString& text)
 {
   Q_D(ctkVTKAbstractView);
   d->CornerAnnotation->ClearAllTexts();
-  d->CornerAnnotation->SetText(2, text.toLatin1());
+  d->CornerAnnotation->SetText(2, text.toUtf8());
 }
 
 //----------------------------------------------------------------------------
 QString ctkVTKAbstractView::cornerAnnotationText() const
 {
   Q_D(const ctkVTKAbstractView);
-  return QLatin1String(d->CornerAnnotation->GetText(2));
+  return QString::fromUtf8(d->CornerAnnotation->GetText(2));
 }
 
 //----------------------------------------------------------------------------
@@ -510,7 +510,7 @@ void ctkVTKAbstractView::updateFPS()
   double lastRenderTime = renderer ? renderer->GetLastRenderTimeInSeconds() : 0.;
   QString fpsString = tr("FPS: %1(%2s)").arg(d->FPS).arg(lastRenderTime);
   d->FPS = 0;
-  d->CornerAnnotation->SetText(1, fpsString.toLatin1());
+  d->CornerAnnotation->SetText(1, fpsString.toUtf8());
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
@@ -193,7 +193,7 @@ ctkVTKChartView::~ctkVTKChartView()
 void ctkVTKChartView::setTitle(const QString& newTitle)
 {
   Q_D(ctkVTKChartView);
-  d->Chart->SetTitle(newTitle.toLatin1().data());
+  d->Chart->SetTitle(newTitle.toUtf8().data());
 }
 
 // ----------------------------------------------------------------------------

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDataSetModel.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDataSetModel.cpp
@@ -453,7 +453,7 @@ void ctkVTKDataSetModel::updateArrayFromItem(vtkAbstractArray* array, QStandardI
 {
   if (item->column() == 0)
     {
-    array->SetName(item->text().toLatin1());
+    array->SetName(item->text().toUtf8());
     }
 }
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarBarWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarBarWidget.cpp
@@ -248,7 +248,7 @@ void ctkVTKScalarBarWidget::setTitle(const QString& title)
     {
     return;
     }
-  actor->SetTitle(title.toLatin1());
+  actor->SetTitle(title.toUtf8());
 }
 
 //-----------------------------------------------------------------------------
@@ -268,7 +268,7 @@ void ctkVTKScalarBarWidget::setLabelsFormat(const QString& format)
     {
     return;
     }
-  actor->SetLabelFormat(format.toLatin1());
+  actor->SetLabelFormat(format.toUtf8());
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Widgets/Testing/Cpp/CMakeLists.txt
+++ b/Libs/Widgets/Testing/Cpp/CMakeLists.txt
@@ -248,7 +248,7 @@ else()
   QT4_ADD_RESOURCES(Tests_RESOURCES_SRCS ${Tests_RESOURCES})
 endif()
 
-add_executable(${KIT}CppTests ${Tests} ${Tests_SRCS} ${Tests_MOC_CPP} ${Tests_UI_CPP} ${Tests_RESOURCES_SRCS})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests} ${Tests_SRCS} ${Tests_MOC_CPP} ${Tests_UI_CPP} ${Tests_RESOURCES_SRCS})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME})
 
 if(CTK_QT_VERSION VERSION_GREATER "4")

--- a/Libs/Widgets/Testing/Cpp/ctkErrorLogModelEntryGroupingTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkErrorLogModelEntryGroupingTest1.cpp
@@ -58,19 +58,19 @@ int ctkErrorLogModelEntryGroupingTest1(int argc, char * argv [])
     model.setLogEntryGrouping(true);
 
     QString qtMessage0("This is a qDebug message - 1");
-    qDebug().nospace() << qPrintable(qtMessage0);
+    qDebug().nospace() << qUtf8Printable(qtMessage0);
 
     QString qtMessage0b("This is a qDebug message - 2");
-    qDebug().nospace() << qPrintable(qtMessage0b);
+    qDebug().nospace() << qUtf8Printable(qtMessage0b);
 
     QString qtMessage1("This is a qWarning message");
-    qWarning().nospace() << qPrintable(qtMessage1);
+    qWarning().nospace() << qUtf8Printable(qtMessage1);
 
     QString qtMessage2("This is a qCritical message - 1");
-    qCritical().nospace() << qPrintable(qtMessage2);
+    qCritical().nospace() << qUtf8Printable(qtMessage2);
 
     QString qtMessage2b("This is a qCritical message - 2");
-    qCritical().nospace() << qPrintable(qtMessage2b);
+    qCritical().nospace() << qUtf8Printable(qtMessage2b);
 
     // Give enough time to the ErrorLogModel to consider the queued messages.
     processEvents(1000);

--- a/Libs/Widgets/Testing/Cpp/ctkErrorLogModelTerminalOutputTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkErrorLogModelTerminalOutputTest1.cpp
@@ -155,18 +155,18 @@ int ctkErrorLogModelTerminalOutputTest1(int argc, char * argv [])
     fprintf(stdout, "%s\n", qPrintable(fdMessage0));
     fflush(stdout);
 
-    qDebug().nospace() << qPrintable(qtMessage0);
+    qDebug().nospace() << qUtf8Printable(qtMessage0);
 
     std::cerr << qPrintable(stdMessage0) << std::endl;
 
-    qWarning().nospace() << qPrintable(qtMessage1);
+    qWarning().nospace() << qUtf8Printable(qtMessage1);
 
     fprintf(stderr, "%s\n", qPrintable(fdMessage1));
     fflush(stderr);
 
     std::cout << qPrintable(stdMessage1) << std::endl;
 
-    qCritical().nospace() << qPrintable(qtMessage2);
+    qCritical().nospace() << qUtf8Printable(qtMessage2);
 
     // Give enough time to the ErrorLogModel to consider the queued messages.
     processEvents(1000);

--- a/Libs/Widgets/Testing/Cpp/ctkErrorLogModelTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkErrorLogModelTest1.cpp
@@ -87,13 +87,13 @@ int ctkErrorLogModelTest1(int argc, char * argv [])
         }
 
       QString qtMessage0("This is a qDebug message");
-      qDebug().nospace() << qPrintable(qtMessage0);
+      qDebug().nospace() << qUtf8Printable(qtMessage0);
 
       QString qtMessage1("This is a qWarning message");
-      qWarning().nospace() << qPrintable(qtMessage1);
+      qWarning().nospace() << qUtf8Printable(qtMessage1);
 
       QString qtMessage2("This is a qCritical message");
-      qCritical().nospace() << qPrintable(qtMessage2);
+      qCritical().nospace() << qUtf8Printable(qtMessage2);
 
       // Give enough time to the ErrorLogModel to consider the queued messages.
       processEvents(1000);

--- a/Libs/Widgets/Testing/Cpp/ctkErrorLogQtMessageHandlerWithThreadsTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkErrorLogQtMessageHandlerWithThreadsTest1.cpp
@@ -46,9 +46,9 @@ public:
     QString msg = QString("counterIdx:%1 - %2 - Message from thread: %3\n")
         .arg(counterIdx).arg(dateTime.toString()).arg(threadId);
 
-    qDebug().nospace() << qPrintable(msg);
-    qWarning().nospace() << qPrintable(msg);
-    qCritical().nospace() << qPrintable(msg);
+    qDebug().nospace() << qUtf8Printable(msg);
+    qWarning().nospace() << qUtf8Printable(msg);
+    qCritical().nospace() << qUtf8Printable(msg);
   }
 };
 

--- a/Libs/Widgets/Testing/Cpp/ctkSliderWidgetTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSliderWidgetTest1.cpp
@@ -73,7 +73,7 @@ int ctkSliderWidgetTest1(int argc, char * argv [] )
       !qFuzzyCompare(sliderSpinBox.value(), 80.5678))
     {
     std::cerr << "ctkSliderWidget::setPrefix failed."
-              << sliderSpinBox.prefix().toLatin1().data() << " "
+              << qPrintable(sliderSpinBox.prefix()) << " "
               << sliderSpinBox.value() << std::endl;
     return EXIT_FAILURE;
     }
@@ -84,7 +84,7 @@ int ctkSliderWidgetTest1(int argc, char * argv [] )
       !qFuzzyCompare(sliderSpinBox.value(), 80.5678))
     {
     std::cerr << "ctkSliderWidget::setSuffix failed."
-              << sliderSpinBox.suffix().toLatin1().data() << " "
+              << qPrintable(sliderSpinBox.suffix()) << " "
               << sliderSpinBox.value() << std::endl;
     return EXIT_FAILURE;
     }

--- a/Libs/XNAT/Core/Testing/CMakeLists.txt
+++ b/Libs/XNAT/Core/Testing/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
   qt5_wrap_cpp(KITTests_MOC_CPP ${KITTests_MOC_SRCS})
 endif()
 
-add_executable(${KIT}CppTests ${Tests} ${KITTests_SRCS} ${KITTests_MOC_SRCS} ${KITTests_MOC_CPP})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests} ${KITTests_SRCS} ${KITTests_MOC_SRCS} ${KITTests_MOC_CPP})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME} ${CTK_BASE_LIBRARIES})
 
 if(CTK_QT_VERSION VERSION_GREATER "4")

--- a/Plugins/org.commontk.configadmin/Testing/Cpp/CMakeLists.txt
+++ b/Plugins/org.commontk.configadmin/Testing/Cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ set(my_includes)
 ctkFunctionGetIncludeDirs(my_includes ${test_executable})
 include_directories(${my_includes})
 
-add_executable(${test_executable} ${SRCS} ${MY_MOC_CXX})
+ctk_add_executable_utf8(${test_executable} ${SRCS} ${MY_MOC_CXX})
 target_link_libraries(${test_executable}
   ${${test_executable}_DEPENDENCIES}
 )

--- a/Plugins/org.commontk.dah.cmdlinemoduleapp/ctkCommandLineModuleAppLogic.cpp
+++ b/Plugins/org.commontk.dah.cmdlinemoduleapp/ctkCommandLineModuleAppLogic.cpp
@@ -276,7 +276,7 @@ void ctkCommandLineModuleAppLogic::onLoadDataClicked()
     if(QFileInfo(filename).exists())
     {
       try {
-        DicomImage dcmtkImage(filename.toLatin1().data());
+        DicomImage dcmtkImage(filename.toUtf8().data());
         ctkDICOMImage ctkImage(&dcmtkImage);
 
         QPixmap pixmap = QPixmap::fromImage(ctkImage.frame(0),Qt::AvoidDither);

--- a/Plugins/org.commontk.dah.core/Testing/Cpp/CMakeLists.txt
+++ b/Plugins/org.commontk.dah.core/Testing/Cpp/CMakeLists.txt
@@ -10,7 +10,7 @@ REMOVE (TestsToRun ${KIT}CppTests.cxx)
 
 set(LIBRARY_NAME ${PROJECT_NAME})
 
-add_executable(${KIT}CppTests ${Tests})
+ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 target_link_libraries(${KIT}CppTests ${LIBRARY_NAME})
 
 #

--- a/Plugins/org.commontk.dah.core/ctkSimpleSoapClient.cpp
+++ b/Plugins/org.commontk.dah.core/ctkSimpleSoapClient.cpp
@@ -132,7 +132,7 @@ const QtSoapType & ctkSimpleSoapClient::submitSoapRequest(const QString& methodN
   if (response.isFault())
     {
     qCritical() << "ctkSimpleSoapClient: server error (response.IsFault())";
-    CTK_SOAP_LOG_LOWLEVEL( << response.faultString().toString().toLatin1().constData() << endl );
+    CTK_SOAP_LOG_LOWLEVEL( << qPrintable(response.faultString().toString()) << endl );
     CTK_SOAP_LOG_LOWLEVEL( << response.toXmlString() );
     return response.returnValue();
     //    throw ctkRuntimeException("ctkSimpleSoapClient: server error (response.IsFault())");

--- a/Plugins/org.commontk.dah.exampleapp/ctkExampleDicomAppLogic.cpp
+++ b/Plugins/org.commontk.dah.exampleapp/ctkExampleDicomAppLogic.cpp
@@ -252,7 +252,7 @@ void ctkExampleDicomAppLogic::onLoadDataClicked()
     if(QFileInfo(filename).exists())
     {
       try {
-        DicomImage dcmtkImage(filename.toLatin1().data());
+        DicomImage dcmtkImage(filename.toUtf8().data());
         ctkDICOMImage ctkImage(&dcmtkImage);
 
         QPixmap pixmap = QPixmap::fromImage(ctkImage.frame(0),Qt::AvoidDither);

--- a/Plugins/org.commontk.eventadmin/Testing/Cpp/CMakeLists.txt
+++ b/Plugins/org.commontk.eventadmin/Testing/Cpp/CMakeLists.txt
@@ -18,7 +18,7 @@ set(my_includes)
 ctkFunctionGetIncludeDirs(my_includes ${test_executable})
 include_directories(${my_includes})
 
-add_executable(${test_executable} ctkEventAdminImplTestMain.cpp)
+ctk_add_executable_utf8(${test_executable} ctkEventAdminImplTestMain.cpp)
 target_link_libraries(${test_executable}
   ${${test_executable}_DEPENDENCIES}
 )
@@ -38,7 +38,7 @@ set(${test_executable}_DEPENDENCIES ${fw_lib} ${fwtestutil_lib})
 #ctkFunctionGetIncludeDirs(my_includes ${test_executable})
 #include_directories(${my_includes})
 
-add_executable(${test_executable} ctkEventAdminImplPerfTestMain.cpp)
+ctk_add_executable_utf8(${test_executable} ctkEventAdminImplPerfTestMain.cpp)
 target_link_libraries(${test_executable}
   ${${test_executable}_DEPENDENCIES}
 )

--- a/Plugins/org.commontk.eventbus/Testing/Cpp/CMakeLists.txt
+++ b/Plugins/org.commontk.eventbus/Testing/Cpp/CMakeLists.txt
@@ -74,7 +74,7 @@ set(test_executable ${PROJECT_NAME}CppTests)
 
 ctkMacroInitproject(1)
 
-add_executable(${test_executable} ${PROJECT_SRCS})
+ctk_add_executable_utf8(${test_executable} ${PROJECT_SRCS})
 target_link_libraries(${test_executable} ${PROJECT_LIBS})
 
 add_test(${PROJECT_NAME}Tests ${CPP_TEST_PATH}/${test_executable})

--- a/Plugins/org.commontk.eventbus/Testing/Cpp/ctkNetworkConnectorQtSoapTest.cpp
+++ b/Plugins/org.commontk.eventbus/Testing/Cpp/ctkNetworkConnectorQtSoapTest.cpp
@@ -161,7 +161,7 @@ void ctkNetworkConnectorQtSoapTest::ctkNetworkConnectorQtSoapCommunictionPassing
     // compare results
     QtSoapType *soapTypeResult = m_NetWorkConnectorQtSoap->response();
     if(soapTypeResult)
-    qDebug("%s", soapTypeResult->toString().toLatin1().constData());
+    qDebug("%s", soapTypeResult->toString().toUtf8().constData());
 }
 
 void ctkNetworkConnectorQtSoapTest::ctkNetworkConnectorQtSoapCommunictionPassingStringOnAxisServiceTest() {
@@ -205,7 +205,7 @@ void ctkNetworkConnectorQtSoapTest::ctkNetworkConnectorQtSoapCommunictionPassing
     // compare results
     QtSoapType *soapTypeResult = m_NetWorkConnectorQtSoap->response();
     if(soapTypeResult)
-    qDebug("%s", soapTypeResult->toString().toLatin1().constData());
+    qDebug("%s", soapTypeResult->toString().toUtf8().constData());
 }
 
 void ctkNetworkConnectorQtSoapTest::ctkNetworkConnectorQtSoapCommunictionPassingStringArrayTest() {
@@ -255,7 +255,7 @@ void ctkNetworkConnectorQtSoapTest::ctkNetworkConnectorQtSoapCommunictionPassing
     // compare results
     QtSoapType *soapTypeResult = m_NetWorkConnectorQtSoap->response();
     if(soapTypeResult)
-    qDebug("%s", soapTypeResult->toString().toLatin1().constData());
+    qDebug("%s", soapTypeResult->toString().toUtf8().constData());
 }
 
 void ctkNetworkConnectorQtSoapTest::ctkNetworkConnectorQtSoapCommunictionWithGSOAPServiceTest() {
@@ -288,7 +288,7 @@ void ctkNetworkConnectorQtSoapTest::ctkNetworkConnectorQtSoapCommunictionWithGSO
     // compare results
     QtSoapType *soapTypeResult = m_NetWorkConnectorQtSoap->response();
     if(soapTypeResult)
-    qDebug("%s", soapTypeResult->toString().toLatin1().constData());
+    qDebug("%s", soapTypeResult->toString().toUtf8().constData());
 }
 
 CTK_REGISTER_TEST(ctkNetworkConnectorQtSoapTest);

--- a/Plugins/org.commontk.eventbus/ctkEventBusManager.cpp
+++ b/Plugins/org.commontk.eventbus/ctkEventBusManager.cpp
@@ -214,7 +214,7 @@ void ctkEventBusManager::startListen() {
     if(connector) {
         connector->startListen();
     } else {
-        qWarning("%s", tr("Server can not start. Create it first, then call startListen again!!").toLatin1().data());
+        qWarning("%s", tr("Server can not start. Create it first, then call startListen again!!").toUtf8().data());
     }
 }
 

--- a/Plugins/org.commontk.eventbus/ctkEventDefinitions.h
+++ b/Plugins/org.commontk.eventbus/ctkEventDefinitions.h
@@ -42,7 +42,7 @@ class ctkBusEvent;
         ctkBusEvent *properties = new ctkBusEvent(topic, ctkEventBus::ctkEventTypeLocal, ctkEventBus::ctkSignatureTypeSignal, static_cast<QObject*>(sender), signature); \
         bool ok = ctkEventBus::ctkEventBusManager::instance()->addEventProperty(*properties);\
         if(!ok) {\
-            qWarning("%s", tr("Some problem occourred during the signal registration with ID '%1'.").arg(topic).toLatin1().data());\
+            qWarning("%s", tr("Some problem occourred during the signal registration with ID '%1'.").arg(topic).toUtf8().data());\
             if(properties) {delete properties; properties = NULL;} \
             }\
     }
@@ -52,7 +52,7 @@ class ctkBusEvent;
         ctkBusEvent *properties = new ctkBusEvent(topic, ctkEventBus::ctkEventTypeRemote, ctkEventBus::ctkSignatureTypeSignal, static_cast<QObject*>(sender), signature); \
         bool ok =  ctkEventBus::ctkEventBusManager::instance()->addEventProperty(*properties);\
         if(!ok) {\
-            qWarning("%s", tr("Some problem occourred during the signal registration with ID '%1'.").arg(topic).toLatin1().data());\
+            qWarning("%s", tr("Some problem occourred during the signal registration with ID '%1'.").arg(topic).toUtf8().data());\
             if(properties) {delete properties; properties = NULL;} \
         }\
     }
@@ -62,7 +62,7 @@ class ctkBusEvent;
         ctkBusEvent *properties = new ctkBusEvent(topic, ctkEventBus::ctkEventTypeLocal, ctkEventBus::ctkSignatureTypeCallback, static_cast<QObject*>(observer), signature); \
         bool ok =  ctkEventBus::ctkEventBusManager::instance()->addEventProperty(*properties);\
         if(!ok) {\
-            qWarning("%s", tr("Some problem occourred during the callback registration with ID '%1'.").arg(topic).toLatin1().data());\
+            qWarning("%s", tr("Some problem occourred during the callback registration with ID '%1'.").arg(topic).toUtf8().data());\
             if(properties) {delete properties; properties = NULL;} \
         }\
     }
@@ -72,7 +72,7 @@ class ctkBusEvent;
         ctkBusEvent *properties = new ctkBusEvent(topic, ctkEventBus::ctkEventTypeRemote, ctkEventBus::ctkSignatureTypeCallback, static_cast<QObject*>(sender), signature); \
         bool ok =  ctkEventBus::ctkEventBusManager::instance()->addEventProperty(*properties);\
         if(!ok) {\
-            qWarning("%s", tr("Some problem occourred during the callback registration with ID '%1'.").arg(topic).toLatin1().data());\
+            qWarning("%s", tr("Some problem occourred during the callback registration with ID '%1'.").arg(topic).toUtf8().data());\
             if(properties) {delete properties; properties = NULL;} \
         }\
     }

--- a/Plugins/org.commontk.eventbus/ctkEventDispatcher.cpp
+++ b/Plugins/org.commontk.eventbus/ctkEventDispatcher.cpp
@@ -303,9 +303,9 @@ bool ctkEventDispatcher::registerSignal(ctkBusEvent &props) {
         // Only one signal for a given id can be registered!!
         QObject *obj = props[OBJECT].value<QObject *>();
         if(obj != NULL) {
-            qWarning("%s", tr("Object %1 is trying to register a signal with Topic '%2' that has been already registered!!").arg(obj->metaObject()->className(), topic).toLatin1().data());
+            qWarning("%s", tr("Object %1 is trying to register a signal with Topic '%2' that has been already registered!!").arg(obj->metaObject()->className(), topic).toUtf8().data());
         } else {
-            qWarning("%s", tr("NULL is trying to register a signal with Topic '%2' that has been already registered!!").arg(topic).toLatin1().data());
+            qWarning("%s", tr("NULL is trying to register a signal with Topic '%2' that has been already registered!!").arg(topic).toUtf8().data());
         }
         return false;
     }

--- a/Plugins/org.commontk.eventbus/ctkEventDispatcherLocal.cpp
+++ b/Plugins/org.commontk.eventbus/ctkEventDispatcherLocal.cpp
@@ -92,7 +92,7 @@ void ctkEventDispatcherLocal::notifyEvent(ctkBusEvent &event_dictionary, ctkEven
                              argList->at(5), argList->at(6), argList->at(7), argList->at(8), argList->at(9));
                             break;
                         default:
-                            qWarning("%s", tr("Number of arguments not supported. Max 10 arguments").toLatin1().data());
+                            qWarning("%s", tr("Number of arguments not supported. Max 10 arguments").toUtf8().data());
                     } //switch
                  } else { //use return value
                     switch (argList->count()) {
@@ -144,7 +144,7 @@ void ctkEventDispatcherLocal::notifyEvent(ctkBusEvent &event_dictionary, ctkEven
                              argList->at(5), argList->at(6), argList->at(7), argList->at(8), argList->at(9));
                             break;
                         default:
-                            qWarning("%s", tr("Number of arguments not supported. Max 10 arguments").toLatin1().data());
+                            qWarning("%s", tr("Number of arguments not supported. Max 10 arguments").toUtf8().data());
                     } //switch
                  }
             } else {

--- a/Plugins/org.commontk.eventbus/ctkNetworkConnectorQXMLRPC.cpp
+++ b/Plugins/org.commontk.eventbus/ctkNetworkConnectorQXMLRPC.cpp
@@ -112,7 +112,7 @@ void ctkNetworkConnectorQXMLRPC::stopServer() {
 
 void ctkNetworkConnectorQXMLRPC::registerServerMethod(mafRegisterMethodsMap registerMethodsList) {
     if(m_Server->isListening()) {
-        qDebug("%s", tr("Server is already listening on port %1").arg(m_Server->property("port").toUInt()).toLatin1().data());
+        qDebug("%s", tr("Server is already listening on port %1").arg(m_Server->property("port").toUInt()).toUtf8().data());
         return;
     }
     // cycle over map:  method name and parameter list
@@ -163,7 +163,7 @@ void ctkNetworkConnectorQXMLRPC::send(const QString event_id, ctkEventArgumentsL
             typeArgument = argList->at(i).name();
             if(typeArgument != "QVariantList") {
                 qDebug() << typeArgument;
-                qWarning("%s", tr("Remote Dispatcher need to have arguments that are QVariantList").toLatin1().data());
+                qWarning("%s", tr("Remote Dispatcher need to have arguments that are QVariantList").toUtf8().data());
                 delete vl;
                 return;
             }
@@ -177,7 +177,7 @@ void ctkNetworkConnectorQXMLRPC::send(const QString event_id, ctkEventArgumentsL
             vl->push_back(var); //only the first parameter represent the whole list of arguments
         }
         if(size == 0) {
-            qWarning("%s", tr("Remote Dispatcher need to have at least one argument that is a QVariantList").toLatin1().data());
+            qWarning("%s", tr("Remote Dispatcher need to have at least one argument that is a QVariantList").toUtf8().data());
             return;
         }
     }
@@ -209,13 +209,13 @@ void ctkNetworkConnectorQXMLRPC::xmlrpcSend(const QString &methodName, QList<xml
 void ctkNetworkConnectorQXMLRPC::processReturnValue( int requestId, QVariant value ) {
     Q_UNUSED( requestId );
     Q_ASSERT( value.canConvert( QVariant::String ) );
-    qDebug("%s", value.toString().toLatin1().data());
+    qDebug("%s", value.toString().toUtf8().data());
     ctkEventBusManager::instance()->notifyEvent("ctk/local/eventBus/remoteCommunicationDone", ctkEventTypeLocal);
 }
 
 void ctkNetworkConnectorQXMLRPC::processFault( int requestId, int errorCode, QString errorString ) {
     // Log the error.
-    qDebug("%s", tr("Process Fault for requestID %1 with error %2 - %3").arg(QString::number(requestId), QString::number(errorCode), errorString).toLatin1().data());
+    qDebug("%s", tr("Process Fault for requestID %1 with error %2 - %3").arg(QString::number(requestId), QString::number(errorCode), errorString).toUtf8().data());
     ctkEventBusManager::instance()->notifyEvent("ctk/local/eventBus/remoteCommunicationFailed", ctkEventTypeLocal);
 }
 

--- a/Plugins/org.commontk.eventbus/ctkNetworkConnectorQtSoap.cpp
+++ b/Plugins/org.commontk.eventbus/ctkNetworkConnectorQtSoap.cpp
@@ -114,15 +114,15 @@ void ctkNetworkConnectorQtSoap::createClient(const QString hostName, const unsig
 
 void ctkNetworkConnectorQtSoap::createServer(const unsigned int port) {
     Q_UNUSED(port);
-    qDebug() << tr("QtSoap doesn't support server side implementation.").toLatin1();
+    qDebug() << tr("QtSoap doesn't support server side implementation.").toUtf8();
 }
 
 void ctkNetworkConnectorQtSoap::stopServer() {
-    qDebug() << tr("QtSoap doesn't support server side implementation.").toLatin1();
+    qDebug() << tr("QtSoap doesn't support server side implementation.").toUtf8();
 }
 
 void ctkNetworkConnectorQtSoap::startListen() {
-    qDebug() << tr("QtSoap doesn't support server side implementation.").toLatin1();
+    qDebug() << tr("QtSoap doesn't support server side implementation.").toUtf8();
 }
 
 QtSoapType *ctkNetworkConnectorQtSoap::marshall(const QString name, const QVariant &parameter) {
@@ -244,7 +244,7 @@ void ctkNetworkConnectorQtSoap::retrieveRemoteResponse()
     qDebug() << message.toXmlString();
     // Check if the response is a SOAP Fault message
     if (message.isFault()) {
-        qDebug("Error: %s", message.faultString().value().toString().toLatin1().constData());
+        qDebug("Error: %s", message.faultString().value().toString().toUtf8().constData());
         m_Response = NULL;
     }
     else {
@@ -258,13 +258,13 @@ void ctkNetworkConnectorQtSoap::retrieveRemoteResponse()
 void ctkNetworkConnectorQtSoap::processReturnValue( int requestId, QVariant value ) {
     Q_UNUSED( requestId );
     Q_ASSERT( value.canConvert( QVariant::String ) );
-    qDebug("%s", value.toString().toLatin1().data());
+    qDebug("%s", value.toString().toUtf8().data());
     ctkEventBusManager::instance()->notifyEvent("ctk/local/eventBus/remoteCommunicationDone", ctkEventTypeLocal);
 }
 
 void ctkNetworkConnectorQtSoap::processFault( int requestId, int errorCode, QString errorString ) {
     // Log the error.
-    qDebug("%s", tr("Process Fault for requestID %1 with error %2 - %3").arg(QString::number(requestId), QString::number(errorCode), errorString).toLatin1().data());
+    qDebug("%s", tr("Process Fault for requestID %1 with error %2 - %3").arg(QString::number(requestId), QString::number(errorCode), errorString).toUtf8().data());
     ctkEventBusManager::instance()->notifyEvent("ctk/local/eventBus/remoteCommunicationFailed", ctkEventTypeLocal);
 }
 

--- a/Plugins/org.commontk.metatype/Testing/Cpp/CMakeLists.txt
+++ b/Plugins/org.commontk.metatype/Testing/Cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ set(my_includes)
 ctkFunctionGetIncludeDirs(my_includes ${test_executable})
 include_directories(${my_includes})
 
-add_executable(${test_executable} ${SRCS} ${MY_MOC_CXX})
+ctk_add_executable_utf8(${test_executable} ${SRCS} ${MY_MOC_CXX})
 target_link_libraries(${test_executable}
   ${${test_executable}_DEPENDENCIES}
 )

--- a/Utilities/DGraph/CMakeLists.txt
+++ b/Utilities/DGraph/CMakeLists.txt
@@ -52,5 +52,3 @@ add_executable(${PROJECT_NAME}
   DGraph.cpp
   ${CTK_SOURCE_DIR}/Libs/Core/ctkDependencyGraph.h
   ${CTK_SOURCE_DIR}/Libs/Core/ctkDependencyGraph.cpp)
-
-


### PR DESCRIPTION
This pull request allows storing DICOM database in and importing DICOM files from folders that contains special characters in their names. Tested with CTK DICOM examples and in 3D Slicer.

In general, all std::string or char buffers in CTK are now expected to contain UTF-8 encoded string. This is what was the default on Mac OSX and Linux and it has been made available as an option on Windows as well. This is where VTK and ITK (and most other software libraries) are moving towards, too.

- use add_executable_utf8 instead of add_executable to make the application use UTF-8 code page on all platforms (already the default on Mac OSX and Linux, but this makes behavior on Windows the same, too)
- use toUtf8 instead of toLatin1 when converting from QString to std::string or char*, especially when converting file names, since now file IO functions expect filenames in UTF-8
- use qPrintable to convert QString to string to be printed on console (std::cout, std::cerr): this converts the string to the local encoding (which is often not be UTF-8 and maybe not Latin1)
- use qUtf8Printable with Qt logging macros (qDebug(), qWarning(), qCritical()) as per Qt documentation
- fixed ctkDICOMAppWidget (there were minor errors, such as signal mismatches)
- use UTF-8 encoding when passing strings to VTK (this is where VTK goes toward https://discourse.vtk.org/t/what-is-state-of-the-art-unicode-file-names-on-windows/1821)

DICOM field content encoding/decoding does not use UTF-8 everywhere (always Latin1 encoding is used when creating DICOM queries or when exporting DICOM items to file, while it could make sense to switch to UTF-8 when values cannot be encoded as Latin1; when exporting files, non-Latin1 characters are stripped for better compatibility with less-advanced file systems).