### PR TITLE
ENH: Add checkBoxControlsButtonToggleState property to ctkCheckablePushButton

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkCheckablePushButtonTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCheckablePushButtonTest1.cpp
@@ -127,7 +127,7 @@ int ctkCheckablePushButtonTest1(int argc, char * argv [] )
   button13.setCheckBoxUserCheckable(true);
   button13.setCheckable(true);
 
-  // Checkbox controlls button toggle state
+  // Checkbox control button toggle state
   button16.setCheckable(true);
   button16.setCheckBoxUserCheckable(true);
   button16.setCheckBoxControlsButton(true);

--- a/Libs/Widgets/Testing/Cpp/ctkCheckablePushButtonTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCheckablePushButtonTest1.cpp
@@ -54,6 +54,7 @@ int ctkCheckablePushButtonTest1(int argc, char * argv [] )
   ctkCheckablePushButton button13(QObject::tr("Checkbox and Button User Checkable"));
   ctkCheckablePushButton button14(QObject::tr("Checkable PushButton with menu"));
   ctkCheckablePushButton button15(QObject::tr("Checkable PushButton with icon"));
+  ctkCheckablePushButton button16(QObject::tr("Check box controls button toggle state"));
 
   QVBoxLayout *layout= new QVBoxLayout;
   layout->addWidget(&button1);
@@ -71,6 +72,7 @@ int ctkCheckablePushButtonTest1(int argc, char * argv [] )
   layout->addWidget(&button13);
   layout->addWidget(&button14);
   layout->addWidget(&button15);
+  layout->addWidget(&button16);
   topLevel.setLayout(layout);
 
   topLevel.show();
@@ -95,17 +97,17 @@ int ctkCheckablePushButtonTest1(int argc, char * argv [] )
   button3.setButtonTextAlignment(Qt::AlignCenter);
   button3.setIndicatorAlignment(Qt::AlignCenter);
   button3.setCheckable(true);
-  
+
   button4.setCheckable(true);
   button4.toggle();
-  
+
   button5.setButtonTextAlignment(Qt::AlignCenter);
   button5.setIndicatorAlignment(Qt::AlignRight);
-  
+
   button6.setIndicatorAlignment(Qt::AlignTop);
   button7.setButtonTextAlignment(Qt::AlignCenter);
   button7.setIndicatorAlignment(Qt::AlignLeft);
-  
+
   // Connected to button, not user checkable:
   button8.setCheckBoxUserCheckable(false);
   button8.setCheckState(Qt::Checked);
@@ -124,6 +126,12 @@ int ctkCheckablePushButtonTest1(int argc, char * argv [] )
   button13.setCheckBoxControlsButton(false);
   button13.setCheckBoxUserCheckable(true);
   button13.setCheckable(true);
+
+  // Checkbox controlls button toggle state
+  button16.setCheckable(true);
+  button16.setCheckBoxUserCheckable(true);
+  button16.setCheckBoxControlsButton(true);
+  button16.setCheckBoxControlsButtonToggleState(true);
 
   QMenu menu(&button14);
   menu.addAction("menu action");

--- a/Libs/Widgets/ctkCheckablePushButton.h
+++ b/Libs/Widgets/ctkCheckablePushButton.h
@@ -30,19 +30,8 @@ class ctkCheckablePushButtonPrivate;
 
 /// \ingroup Widgets
 /// Description
-/// ctkCheckablePushButton is a QPushButton with a checkbox. By default
-/// the checkbox is connected to the checkable property of the push button.
-/// You can change this behaviour by clearing the "checkBoxControlsButton"
-/// property.
-/// The checkBoxUserCheckable property determines if the state of the
-/// checkbox can be changed interactively by the user by clicking on the
-/// checkbox.
-/// \note In checkBoxControlsButton mode, calling setCheckable instead of
-/// setCheckState may not refresh the button automatically. Use setCheckState
-/// instead.
-/// \note You can automatically check the button when the user checks the
-/// checkbox by connecting the checkBoxToggled(bool) signal with the
-/// setChecked(bool) slot.
+/// ctkCheckablePushButton is a QPushButton with a checkbox.
+///
 /// \warning The checkbox is drawn in place of the pushbuton icon, any icon
 /// will then be ignored.
 class CTK_WIDGETS_EXPORT ctkCheckablePushButton : public ctkPushButton
@@ -53,6 +42,7 @@ class CTK_WIDGETS_EXPORT ctkCheckablePushButton : public ctkPushButton
   Q_PROPERTY(Qt::Alignment indicatorAlignment READ indicatorAlignment WRITE setIndicatorAlignment)
   Q_PROPERTY(Qt::CheckState checkState READ checkState WRITE setCheckState NOTIFY checkStateChanged)
   Q_PROPERTY(bool checkBoxControlsButton READ checkBoxControlsButton WRITE setCheckBoxControlsButton)
+  Q_PROPERTY(bool checkBoxControlsButtonToggleState READ checkBoxControlsButtonToggleState WRITE setCheckBoxControlsButtonToggleState)
   Q_PROPERTY(bool checkBoxUserCheckable READ isCheckBoxUserCheckable WRITE setCheckBoxUserCheckable)
 
 public:
@@ -65,12 +55,33 @@ public:
   void setIndicatorAlignment(Qt::Alignment indicatorAlignment);
   Qt::Alignment indicatorAlignment()const;
 
+  /// Get checked state of the checkbox on the button.
   virtual Qt::CheckState checkState()const;
+  /// Set checked state of the checkbox on the button.
   virtual void setCheckState(Qt::CheckState checkState);
 
+  /// By default the checkbox is connected to the checkable property of the push button.
+  /// You can change this behaviour by clearing the "checkBoxControlsButton"
+  /// property.
+  /// \note In checkBoxControlsButton mode, calling setCheckable() instead of
+  /// setCheckState() may not refresh the button automatically. Use setCheckState()
+  /// instead.
+  /// \note You can automatically check the button when the user checks the
+  /// checkbox by connecting the checkBoxToggled(bool) signal with the
+  /// setChecked(bool) slot or by enabling "checkBoxControlsButtonToggleState" property.
   virtual bool checkBoxControlsButton()const;
   virtual void setCheckBoxControlsButton(bool b);
 
+  /// If both checkBoxControlsButton and checkBoxControlsButtonToggleState
+  /// are enabled then check state is synchronized with pushed state of the button
+  /// (checking the checkbox also pushes down the button and releasing the button
+  /// unchecks the checkbox).
+  virtual bool checkBoxControlsButtonToggleState()const;
+  virtual void setCheckBoxControlsButtonToggleState(bool b);
+
+  /// The checkBoxUserCheckable property determines if the state of the
+  /// checkbox can be changed interactively by the user by clicking on the
+  /// checkbox.
   virtual bool isCheckBoxUserCheckable()const;
   virtual void setCheckBoxUserCheckable(bool b);
 
@@ -85,7 +96,10 @@ protected:
   virtual void mousePressEvent(QMouseEvent* event);
   /// Reimplemented for internal reasons
   virtual bool hitButton(const QPoint & pos) const;
-
+  /// Reimplemented for internal reasons
+  void checkStateSet() override;
+  /// Reimplemented for internal reasons
+  void nextCheckState() override;
 private:
   Q_DECLARE_PRIVATE(ctkCheckablePushButton);
   Q_DISABLE_COPY(ctkCheckablePushButton);


### PR DESCRIPTION
If checkBoxControlsButtonToggleState is enabled then clicking the checkbox also makes the button pushed (for user's convenience) and unpushing the button makes it unchecked, too (to avoid the ambiguous state when the button's checkbox is checked but the button is not pressed down).

The property is disabled for now to preserve the current behavior (for backward compatibility).

Co-authored-by: Kyle Sunderland <sunderlandkyl@gmail.com>

Replaces https://github.com/commontk/CTK/pull/899