### PR TITLE
ENH: Make console message printing methods available in Python

### DIFF
--- a/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
+++ b/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
@@ -578,9 +578,9 @@ void ctkPythonConsole::initialize(ctkAbstractPythonManager* newPythonManager)
   d->initializeInteractiveConsole();
 
   this->connect(PythonQt::self(), SIGNAL(pythonStdOut(QString)),
-                d, SLOT(printOutputMessage(QString)));
+                this, SLOT(printOutputMessage(QString)));
   this->connect(PythonQt::self(), SIGNAL(pythonStdErr(QString)),
-                d, SLOT(printErrorMessage(QString)));
+                this, SLOT(printErrorMessage(QString)));
 
   PythonQt::self()->setRedirectStdInCallback(
         ctkConsole::stdInRedirectCallBack, reinterpret_cast<void*>(this));

--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -846,32 +846,6 @@ void ctkConsolePrivate::printString(const QString& text)
   this->textCursor().insertText(text);
 }
 
-//----------------------------------------------------------------------------
-void ctkConsolePrivate::printOutputMessage(const QString& text)
-{
-  Q_Q(ctkConsole);
-  QString textToPrint = text;
-  if (this->MessageOutputSize == 0)
-    {
-    textToPrint.prepend("\n");
-    }
-  this->MessageOutputSize += textToPrint.size();
-  q->printMessage(textToPrint, q->outputTextColor());
-}
-
-//----------------------------------------------------------------------------
-void ctkConsolePrivate::printErrorMessage(const QString& text)
-{
-  Q_Q(ctkConsole);
-  QString textToPrint = text;
-  if (this->MessageOutputSize == 0)
-    {
-    textToPrint.prepend("\n");
-    }
-  this->MessageOutputSize += textToPrint.size();
-  q->printMessage(textToPrint, q->errorTextColor());
-}
-
 //-----------------------------------------------------------------------------
 void ctkConsolePrivate::printCommand(const QString& cmd)
 {
@@ -1337,6 +1311,32 @@ void ctkConsole::printMessage(const QString& message, const QColor& color)
   format.setForeground(color);
   this->setFormat(format);
   d->printString(message);
+}
+
+//----------------------------------------------------------------------------
+void ctkConsole::printOutputMessage(const QString& text)
+{
+  Q_D(ctkConsole);
+  QString textToPrint = text;
+  if (d->MessageOutputSize == 0)
+    {
+    textToPrint.prepend("\n");
+    }
+  d->MessageOutputSize += textToPrint.size();
+  this->printMessage(textToPrint, this->outputTextColor());
+}
+
+//----------------------------------------------------------------------------
+void ctkConsole::printErrorMessage(const QString& text)
+{
+  Q_D(ctkConsole);
+  QString textToPrint = text;
+  if (d->MessageOutputSize == 0)
+    {
+    textToPrint.prepend("\n");
+    }
+  d->MessageOutputSize += textToPrint.size();
+  this->printMessage(textToPrint, this->errorTextColor());
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Widgets/ctkConsole.h
+++ b/Libs/Widgets/ctkConsole.h
@@ -172,9 +172,6 @@ public:
   /// \sa scrollBarPolicy()
   void setScrollBarPolicy(const Qt::ScrollBarPolicy& newScrollBarPolicy);
 
-  /// Prints text on the console
-  void printMessage(const QString& message, const QColor& color);
-
   /// Returns the string used as primary prompt
   virtual QString ps1() const;
 
@@ -255,6 +252,17 @@ public Q_SLOTS:
 
   /// Print the console help with shortcuts.
   virtual void printHelp();
+
+  /// Prints text on the console
+  void printMessage(const QString& message, const QColor& color);
+
+  /// Print a message
+  /// \sa ctkConsole::outputTextColor
+  void printOutputMessage(const QString& text);
+
+  /// Print a message
+  /// \sa ctkConsole::errorTextColor
+  void printErrorMessage(const QString& text);
 
 protected:
 

--- a/Libs/Widgets/ctkConsole_p.h
+++ b/Libs/Widgets/ctkConsole_p.h
@@ -123,14 +123,6 @@ public Q_SLOTS:
   ///  FALSE - Just insert the word replacing only the text from the current position until StartOfWord
   void insertCompletion(const QString& text);
 
-  /// Print a message
-  /// \sa ctkConsole::outputTextColor
-  void printOutputMessage(const QString& text);
-
-  /// Print a message
-  /// \sa ctkConsole::errorTextColor
-  void printErrorMessage(const QString& text);
-
   /// Update the value of ScrollbarAtBottom given the current position of the scollbar
   void onScrollBarValueChanged(int value);
 


### PR DESCRIPTION
Make console message printing methods (printMessage, printOutputMessage, printErrorMessage) available in Python.
This is useful for example when custom display hook is used in Python and output is not redirected to stderr/stdout.

See https://github.com/Slicer/SlicerJupyter/pull/38 for information about how it is used.