### PR TITLE
BUG: Fix font style in DICOM browser

### DIFF
--- a/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.ui
+++ b/Applications/ctkXnatTreeBrowser/ctkXnatTreeBrowserMainWindow.ui
@@ -90,10 +90,6 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <widget class="QLabel" name="downloadLabel">
-        <property name="styleSheet">
-         <string notr="true">color: rgb(64, 64, 64);
-font: 75 10pt &quot;Lucida Grande&quot;;</string>
-        </property>
         <property name="text">
          <string>Select a xnat file, resource, scan, or scan folder to download...</string>
         </property>

--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMTableView.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMTableView.ui
@@ -88,9 +88,6 @@
    </item>
    <item>
     <widget class="QTableView" name="tblDicomDatabaseView">
-     <property name="styleSheet">
-      <string notr="true">font: 75 10pt &quot;Lucida Grande&quot;;</string>
-     </property>
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
With recent Qt versions, such as Qt-5.15, the special font set in the DICOM browser (in ctkDICOMTableView) does not get rendered correctly on Windows.
It is safer to remove this special font setting in CTK. It can be overridden set by the application anyway.

The only other place where font style was set in CTK was in ctkXnatTreeBrowserMainWindow. For consistency, the font setting has been removed from there, too.

Fixes https://github.com/Slicer/Slicer/issues/4951