### PR TITLE
COMP: Support ITK with RTK Cuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,9 @@
 cmake_minimum_required(VERSION 3.0)
 
 foreach(p
-  CMP0054 # CMake 3.1
   CMP0020 # CMake 2.8.11
+  CMP0054 # CMake 3.1
+  CMP0057 # CMake 3.3
   )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)


### PR DESCRIPTION
ITK when built with RTK and CUDA, calls ` FindCUDA_wrap.cmake`  in `find_package(ITK)`.
` FindCUDA_wrap.cmake` uses `if(... IN_LIST...)`