### PR TITLE
BUG: Fix ctkMessageBox don't show again feature in Qt-5.12

### DIFF
--- a/Libs/Widgets/ctkMessageBox.h
+++ b/Libs/Widgets/ctkMessageBox.h
@@ -95,6 +95,8 @@ public Q_SLOTS:
   /// Change the checkbox and the settings if any
   void setDontShowAgain(bool dontShow);
 
+  void onFinished(int resultCode);
+
 protected:
   QScopedPointer<ctkMessageBoxPrivate> d_ptr;
 


### PR DESCRIPTION
QMessageBox::done(int) is not called after Qt-5.12 (see https://bugreports.qt.io/browse/QTBUG-74699), so use onFinished(int) signal instead.

This new mechanism would probably work with earlier Qt versions, too, but we keep using the old way for earlier Qt versions to avoid any potential regressions.