### PR TITLE
ENH: Allow saving relative paths to settings

### DIFF
--- a/Libs/Core/CMakeLists.txt
+++ b/Libs/Core/CMakeLists.txt
@@ -37,6 +37,8 @@ set(KIT_SRCS
   ctkCallback.h
   ctkCommandLineParser.cpp
   ctkCommandLineParser.h
+  ctkCoreSettings.cpp
+  ctkCoreSettings.h
   ctkCoreTestingUtilities.cpp
   ctkCoreTestingUtilities.tpp
   ctkCoreTestingUtilities.h
@@ -100,6 +102,7 @@ set(KIT_MOC_SRCS
   ctkBooleanMapper.h
   ctkCallback.h
   ctkCommandLineParser.h
+  ctkCoreSettings.h
   ctkErrorLogAbstractMessageHandler.h
   ctkErrorLogAbstractModel.h
   ctkErrorLogFDMessageHandler_p.h

--- a/Libs/Core/Testing/Cpp/CMakeLists.txt
+++ b/Libs/Core/Testing/Cpp/CMakeLists.txt
@@ -26,6 +26,7 @@ set(KITTests_SRCS
   ctkBooleanMapperTest.cpp
   ctkCallbackTest1.cpp
   ctkCommandLineParserTest1.cpp
+  ctkCoreSettingsTest.cpp
   ctkCoreTestingMacrosTest.cpp
   ctkCoreTestingUtilitiesTest.cpp
   ctkExceptionTest.cpp
@@ -96,6 +97,7 @@ set(Tests_Helpers_MOC_SRCS
 
 set(Tests_Helpers_MOC_CPPS
   ctkBooleanMapperTest.cpp
+  ctkCoreSettingsTest.cpp
   ctkFileLoggerTest.cpp
   ctkLinearValueProxyTest.cpp
   ctkUtilsTest.cpp
@@ -151,6 +153,7 @@ endif()
 SIMPLE_TEST( ctkBooleanMapperTest )
 SIMPLE_TEST( ctkCallbackTest1 )
 SIMPLE_TEST( ctkCommandLineParserTest1 )
+SIMPLE_TEST( ctkCoreSettingsTest )
 SIMPLE_TEST( ctkCoreTestingMacrosTest )
 SIMPLE_TEST( ctkCoreTestingUtilitiesTest )
 SIMPLE_TEST( ctkDependencyGraphTest1 )

--- a/Libs/Core/Testing/Cpp/ctkCoreSettingsTest.cpp
+++ b/Libs/Core/Testing/Cpp/ctkCoreSettingsTest.cpp
@@ -1,0 +1,155 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+// CTK includes
+#include "ctkCoreSettings.h"
+#include "ctkTest.h"
+
+// STD includes
+#include <iostream>
+#include <limits>
+
+// Qt includes
+#include <QApplication>
+
+// ----------------------------------------------------------------------------
+class ctkCoreSettingsTester: public QObject
+{
+  Q_OBJECT
+private slots:
+  void initTestCase();
+
+  void testSinglePath();
+  void testSinglePath_data();
+
+  void testMultiplePaths();
+  void testMultiplePaths_data();
+};
+
+// ----------------------------------------------------------------------------
+void ctkCoreSettingsTester::initTestCase()
+{
+}
+
+// ----------------------------------------------------------------------------
+void ctkCoreSettingsTester::testSinglePath()
+{
+  QFETCH(QString, homeDir);
+  QFETCH(QString, inputPath);
+  QFETCH(QString, expectedStoredValue);
+
+  ctkCoreSettings settings;
+  settings.setApplicationHomeDirectory(homeDir);
+  QString key("someKey");
+  settings.setPathValue(key, inputPath);
+
+  QCOMPARE(settings.value(key).toString(), expectedStoredValue);
+  QCOMPARE(settings.pathValue(key).toString().toLower(), QDir::cleanPath(inputPath).toLower());
+}
+
+// ----------------------------------------------------------------------------
+void ctkCoreSettingsTester::testSinglePath_data()
+{
+  QTest::addColumn<QString>("homeDir");
+  QTest::addColumn<QString>("inputPath");
+  QTest::addColumn<QString>("expectedStoredValue");
+
+  QTest::newRow("windows-style relative 1") << "c:/windows/path"
+    << "c:/windows/path/internal/dir" << "<APPLICATION_HOME_DIR>/internal/dir";
+  QTest::newRow("windows-style relative 2") << "c:\\windows\\path"
+    << "c:/windows/path/internal/subdir/file.txt" << "<APPLICATION_HOME_DIR>/internal/subdir/file.txt";
+  QTest::newRow("windows-style relative 3") << "c:/windows/path/"
+    << "C:/windows/path/internal/dir" << "<APPLICATION_HOME_DIR>/internal/dir";
+  QTest::newRow("windows-style relative 4") << "c:/windows/path/"
+    << "c:/windows/path/internal/subdir/file.txt" << "<APPLICATION_HOME_DIR>/internal/subdir/file.txt";
+  QTest::newRow("windows-style absolute 1") << "c:/windows/path"
+    << "d:/windows/path/internal/dir" << "d:/windows/path/internal/dir";
+  QTest::newRow("windows-style absolute 2") << "c:/windows/path"
+    << "c:/windows/external/subdir/file.txt" << "c:/windows/external/subdir/file.txt";
+
+  QTest::newRow("linux-style relative 1") << "/linux/path"
+    << "/linux/path/internal/dir" << "<APPLICATION_HOME_DIR>/internal/dir";
+  QTest::newRow("linux-style relative 2") << "/linux/path/"
+    << "/linux/path/internal/dir" << "<APPLICATION_HOME_DIR>/internal/dir";
+  QTest::newRow("linux-style relative 3") << "/linux/path/"
+    << "/linux/path/internal/subdir/file.txt" << "<APPLICATION_HOME_DIR>/internal/subdir/file.txt";
+  QTest::newRow("linux-style absolute 1") << "/linux/path"
+    <<  "/xunil/path/internal/dir" << "/xunil/path/internal/dir";
+  QTest::newRow("linux-style absolute 2") << "/linux/path"
+    << "/linux/external/subdir/file.txt" << "/linux/external/subdir/file.txt";
+}
+
+// ----------------------------------------------------------------------------
+void ctkCoreSettingsTester::testMultiplePaths()
+{
+  QFETCH(QString, homeDir);
+  QFETCH(QStringList, inputPaths);
+  QFETCH(QStringList, expectedStoredValues);
+
+  ctkCoreSettings settings;
+  settings.setApplicationHomeDirectory(homeDir);
+  QString key("someKey");
+  settings.setPathValue(key, inputPaths);
+
+  QCOMPARE(settings.value(key).toStringList(), expectedStoredValues);
+
+  QStringList retrievedPaths = settings.pathValue(key).toStringList();
+  QCOMPARE(inputPaths.size(), retrievedPaths.size());
+  for (int index=0; index < inputPaths.size(); index++)
+    {
+    QCOMPARE(retrievedPaths[index].toLower(), QDir::cleanPath(inputPaths[index]).toLower());
+    }
+}
+
+// ----------------------------------------------------------------------------
+void ctkCoreSettingsTester::testMultiplePaths_data()
+{
+  QTest::addColumn<QString>("homeDir");
+  QTest::addColumn<QStringList>("inputPaths");
+  QTest::addColumn<QStringList>("expectedStoredValues");
+
+  QTest::newRow("relative paths multiple items") << "c:/windows/path"
+    << (QStringList() << "c:/windows/path/internal/dir" << "c:/windows/path/internal/subdir/file.txt")
+    << (QStringList() << "<APPLICATION_HOME_DIR>/internal/dir" << "<APPLICATION_HOME_DIR>/internal/subdir/file.txt");
+
+  QTest::newRow("relative paths single item") << "c:/windows/path"
+    << (QStringList() << "C:/windows/path/internal/dir")
+    << (QStringList() << "<APPLICATION_HOME_DIR>/internal/dir");
+
+  QTest::newRow("absolute paths") << "c:/windows/path"
+    << (QStringList() << "d:/windows/path/internal/dir" << "c:/windows/external/subdir/file.txt")
+    << (QStringList() << "d:/windows/path/internal/dir" << "c:/windows/external/subdir/file.txt");
+}
+
+// ----------------------------------------------------------------------------
+int ctkCoreSettingsTest(int argc, char* argv[])
+{
+  QApplication app(argc, argv);
+  app.setOrganizationName("CommonToolkit");
+  app.setOrganizationDomain("commontk.org");
+  app.setApplicationName("CTK");
+  QSettings::setDefaultFormat(QSettings::IniFormat);
+
+  QTEST_DISABLE_KEYPAD_NAVIGATION
+  ctkCoreSettingsTester tc;
+  return QTest::qExec(&tc, argc, argv);
+}
+
+#include "moc_ctkCoreSettingsTest.cpp"

--- a/Libs/Core/ctkCoreSettings.cpp
+++ b/Libs/Core/ctkCoreSettings.cpp
@@ -1,0 +1,233 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+#include "ctkCoreSettings.h"
+
+// CTK includes
+#include <ctkPimpl.h>
+
+// Qt includes
+#include <QDebug>
+#include <QDir>
+#include <QFileInfo>
+#include <QVariant>
+
+
+//-----------------------------------------------------------------------------
+class ctkCoreSettingsPrivate
+{
+  Q_DECLARE_PUBLIC(ctkCoreSettings);
+protected:
+  ctkCoreSettings* const q_ptr;
+public:
+  ctkCoreSettingsPrivate(ctkCoreSettings& object);
+  virtual ~ctkCoreSettingsPrivate();
+
+  QString ApplicationHomeDirectory;
+  QString ApplicationHomePlaceholder;
+};
+
+//-----------------------------------------------------------------------------
+ctkCoreSettingsPrivate::ctkCoreSettingsPrivate(ctkCoreSettings& object)
+  : q_ptr(&object)
+{
+  this->ApplicationHomePlaceholder = "<APPLICATION_HOME_DIR>";
+}
+
+// --------------------------------------------------------------------------
+ctkCoreSettingsPrivate::~ctkCoreSettingsPrivate()
+{
+}
+
+// --------------------------------------------------------------------------
+CTK_GET_CPP(ctkCoreSettings, QString, applicationHomeDirectory, ApplicationHomeDirectory);
+CTK_SET_CPP(ctkCoreSettings, const QString&, setApplicationHomeDirectory, ApplicationHomeDirectory);
+CTK_GET_CPP(ctkCoreSettings, QString, applicationHomePlaceholder, ApplicationHomePlaceholder);
+CTK_SET_CPP(ctkCoreSettings, const QString&, setApplicationHomePlaceholder, ApplicationHomePlaceholder);
+
+//-----------------------------------------------------------------------------
+ctkCoreSettings::ctkCoreSettings(const QString& organization,
+                         const QString& application,
+                         QObject* parentObject)
+  : QSettings(organization, application, parentObject)
+  , d_ptr(new ctkCoreSettingsPrivate(*this))
+{
+}
+
+//-----------------------------------------------------------------------------
+ctkCoreSettings::~ctkCoreSettings()
+{
+}
+
+//-----------------------------------------------------------------------------
+ctkCoreSettings::ctkCoreSettings(QSettings::Scope scope,
+                         const QString& organization,
+                         const QString& application,
+                         QObject* parentObject)
+  : QSettings(scope, organization,application, parentObject)
+  , d_ptr(new ctkCoreSettingsPrivate(*this))
+{
+}
+
+//-----------------------------------------------------------------------------
+ctkCoreSettings::ctkCoreSettings(QSettings::Format format,
+                         QSettings::Scope scope,
+                         const QString& organization,
+                         const QString& application,
+                         QObject* parentObject)
+  : QSettings(format, scope, organization, application, parentObject)
+  , d_ptr(new ctkCoreSettingsPrivate(*this))
+{
+}
+
+//-----------------------------------------------------------------------------
+ctkCoreSettings::ctkCoreSettings(const QString& fileName, QSettings::Format format, QObject* parentObject)
+  : QSettings(fileName, format, parentObject)
+  , d_ptr(new ctkCoreSettingsPrivate(*this))
+{
+}
+
+//-----------------------------------------------------------------------------
+ctkCoreSettings::ctkCoreSettings(QObject* parentObject)
+  : QSettings(parentObject)
+  , d_ptr(new ctkCoreSettingsPrivate(*this))
+{
+}
+
+//-----------------------------------------------------------------------------
+void ctkCoreSettings::setPathValue(const QString& key, const QVariant& value)
+{
+  if (!value.isValid() || value.isNull())
+    {
+    this->setValue(key, value);
+    }
+  else if (QString(value.typeName()).compare("QStringList") == 0)
+    {
+    // string list
+    QStringList relativePaths = this->toApplicationHomeRelativePaths(value.toStringList());
+    this->setValue(key, relativePaths);
+    }
+  else if (value.canConvert<QString>())
+    {
+    // single string
+    QString relativePath = this->toApplicationHomeRelativePath(value.toString());
+    this->setValue(key, relativePath);
+    }
+  else
+    {
+    qWarning() << Q_FUNC_INFO << ": cannot interpret value type " << value.typeName() << " as path";
+    this->setValue(key, value);
+    }
+}
+
+//-----------------------------------------------------------------------------
+QVariant ctkCoreSettings::pathValue(const QString& key, const QVariant& defaultValue/*=QVariant()*/) const
+{
+  Q_D(const ctkCoreSettings);
+  QVariant value = this->value(key, defaultValue);
+  if (!value.isValid() || value.isNull())
+    {
+    return value;
+    }
+  else if (QString(value.typeName()).compare("QStringList") == 0)
+    {
+    // string list
+    QStringList relativePaths = this->toApplicationHomeAbsolutePaths(value.toStringList());
+    return relativePaths;
+    }
+  else if (value.canConvert<QString>())
+    {
+    // single string
+    QString relativePath = this->toApplicationHomeAbsolutePath(value.toString());
+    return relativePath;
+    }
+  else
+    {
+    qWarning() << Q_FUNC_INFO << ": cannot interpret value type " << value.typeName() << " as path";
+    return value;
+    }
+}
+
+//-----------------------------------------------------------------------------
+QString ctkCoreSettings::toApplicationHomeAbsolutePath(const QString& path) const
+{
+  Q_D(const ctkCoreSettings);
+  if (path.isEmpty() || d->ApplicationHomeDirectory.isEmpty())
+    {
+    return path;
+    }
+  QString absolutePath = path;
+  absolutePath.replace(d->ApplicationHomePlaceholder, QDir::cleanPath(d->ApplicationHomeDirectory));
+  return absolutePath;
+}
+
+//-----------------------------------------------------------------------------
+QString ctkCoreSettings::toApplicationHomeRelativePath(const QString& path) const
+{
+  Q_D(const ctkCoreSettings);
+  if (path.isEmpty() || d->ApplicationHomeDirectory.isEmpty())
+    {
+    return path;
+    }
+  if (path.contains(d->ApplicationHomePlaceholder))
+    {
+    // already relative path
+    return path;
+    }
+  // Check if path is within ApplicationHomeDirectory
+  // startsWith(const QString &s, Qt::CaseSensitivity cs = Qt::CaseSensitive) const
+  QString cleanHomeDir = QDir::cleanPath(d->ApplicationHomeDirectory);
+  QString cleanPath = QDir::cleanPath(path);
+  // There is no way to know if a file system is case sensitive or insensitive
+  // (and the path may not even exist), so we choose case insensitive comparison to
+  // make child folder detection more robust.
+  if (!cleanPath.startsWith(cleanHomeDir, Qt::CaseInsensitive))
+    {
+    return path;
+    }  
+  // relative path
+  QString relativePath = QDir(cleanHomeDir).relativeFilePath(cleanPath);
+  return QDir(d->ApplicationHomePlaceholder).filePath(relativePath);
+}
+
+//-----------------------------------------------------------------------------
+QStringList ctkCoreSettings::toApplicationHomeAbsolutePaths(const QStringList& paths) const
+{
+  Q_D(const ctkCoreSettings);
+  QStringList absolutePaths;
+  foreach(QString path, paths)
+    {
+    absolutePaths << this->toApplicationHomeAbsolutePath(path);
+    }
+  return absolutePaths;
+}
+
+
+//-----------------------------------------------------------------------------
+QStringList ctkCoreSettings::toApplicationHomeRelativePaths(const QStringList& paths) const
+{
+  Q_D(const ctkCoreSettings);
+  QStringList relativePaths;
+  foreach(QString path, paths)
+    {
+    relativePaths << this->toApplicationHomeRelativePath(path);
+    }
+  return relativePaths;
+}

--- a/Libs/Core/ctkCoreSettings.h
+++ b/Libs/Core/ctkCoreSettings.h
@@ -1,0 +1,117 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+/// \file ctkCoreSettings.h
+///
+
+#ifndef __ctkCoreSettings_h
+#define __ctkCoreSettings_h
+
+// Qt includes
+#include <QSettings>
+#include <QString>
+#include <QStringList>
+
+// CTK includes
+#include "ctkCoreExport.h"
+
+class QDialog;
+class QMainWindow;
+class ctkCoreSettingsPrivate;
+
+/// \ingroup Widgets
+/// ctkCoreSettings is a QSettings that store absolute paths as relative paths
+/// to allow the application to be relocatable.
+class CTK_CORE_EXPORT ctkCoreSettings : public QSettings
+{
+  Q_OBJECT
+
+  /// If applicationHomeDirectory is not empty then paths within this directory will be written out
+  /// relative to this directory (by replacing absolute path of applicationHomeDirectory by
+  /// applicationHomePlaceholder special string). This allows the application to read/write absolute paths
+  /// to the settings, yet make all the files within applicationHomeDirectory relocatable.
+  ///
+  /// Example: If applicationHomeDirectory is set to /some/path/to/myapp 
+  /// and applicationHomePlaceholder is left at the default <APPLICATION_HOME_DIR> value then
+  /// then /some/path/to/myapp/data will be stored in settings as <APPLICATION_HOME_DIR>/data.
+  /// If the application is moved over to /someotherplace/path/to/myapp
+  /// then <APPLICATION_HOME_DIR>/data path stored in settings remains valid.
+
+  /// Subfolders within this directory will be stored as relative folders.
+  /// Empty by default, which means no substitution is performed.
+  Q_PROPERTY(QString applicationHomeDirectory READ applicationHomeDirectory WRITE setApplicationHomeDirectory)
+
+  /// applicationHomeDirectory absolute path is replaced by this string in settings file.
+  Q_PROPERTY(QString applicationHomePlaceholder READ applicationHomePlaceholder WRITE setApplicationHomePlaceholder)
+
+public:
+  /// \see QSettings::QSettings(const QString& ,const QString& , QObject* )
+  ctkCoreSettings(
+    const QString& organization,
+    const QString& application,
+    QObject* parent = 0);
+  /// \see QSettings::QSettings(QSettings::Scope ,const QString& ,const QString& , QObject* )
+  ctkCoreSettings(
+    QSettings::Scope scope,
+    const QString& organization,
+    const QString& application = QString(),
+    QObject* parent = 0);
+  /// \see QSettings::QSettings(QSettings::Format ,QSettings::Scope ,const QString& ,const QString& , QObject* )
+  ctkCoreSettings(
+    QSettings::Format format,
+    QSettings::Scope scope,
+    const QString& organization,
+    const QString& application = QString(),
+    QObject* parent = 0);
+  /// \see QSettings::QSettings(const QString& , QSettings::Format , QObject* )
+  ctkCoreSettings(const QString& fileName, QSettings::Format format, QObject* parent = 0);
+  /// \see QSettings::QSettings(QObject*)
+  ctkCoreSettings(QObject* parent = 0);
+  virtual ~ctkCoreSettings();
+
+  QString applicationHomeDirectory() const;
+  QString applicationHomePlaceholder() const;
+
+  /// Save paths(s) stored in QString or QStringList. If path is within applicationHomeDirectory then it will be written
+  /// as relative path to the settings file.
+  Q_INVOKABLE void setPathValue(const QString& key, const QVariant& value);
+
+  /// Get path(s) QString or QStringList value as path. Paths relative to applicationHomeDirectory are
+  /// converted to absolute path.
+  Q_INVOKABLE QVariant pathValue(const QString& key, const QVariant& defaultValue = QVariant()) const;
+
+  Q_INVOKABLE QString toApplicationHomeAbsolutePath(const QString& path) const;
+  Q_INVOKABLE QString toApplicationHomeRelativePath(const QString& path) const;
+  Q_INVOKABLE QStringList toApplicationHomeAbsolutePaths(const QStringList& paths) const;
+  Q_INVOKABLE QStringList toApplicationHomeRelativePaths(const QStringList& paths) const;
+
+public Q_SLOTS:
+  void setApplicationHomeDirectory(const QString& dir);
+  void setApplicationHomePlaceholder(const QString& dir);
+
+protected:
+  QScopedPointer<ctkCoreSettingsPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(ctkCoreSettings);
+  Q_DISABLE_COPY(ctkCoreSettings);
+};
+
+#endif

--- a/Libs/Widgets/ctkSettings.cpp
+++ b/Libs/Widgets/ctkSettings.cpp
@@ -59,7 +59,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ctkSettings::ctkSettings(const QString& organization,
                          const QString& application,
                          QObject* parentObject)
-  : QSettings(organization, application, parentObject)
+  : ctkCoreSettings(organization, application, parentObject)
 {
 }
 
@@ -68,7 +68,7 @@ ctkSettings::ctkSettings(QSettings::Scope scope,
                          const QString& organization,
                          const QString& application,
                          QObject* parentObject)
-  : QSettings(scope, organization,application, parentObject)
+  : ctkCoreSettings(scope, organization,application, parentObject)
 {
 }
 
@@ -78,19 +78,19 @@ ctkSettings::ctkSettings(QSettings::Format format,
                          const QString& organization,
                          const QString& application,
                          QObject* parentObject)
-  : QSettings(format, scope, organization, application, parentObject)
+  : ctkCoreSettings(format, scope, organization, application, parentObject)
 {
 }
 
 //-----------------------------------------------------------------------------
 ctkSettings::ctkSettings(const QString& fileName, QSettings::Format format, QObject* parentObject)
-  : QSettings(fileName, format, parentObject)
+  : ctkCoreSettings(fileName, format, parentObject)
 {
 }
 
 //-----------------------------------------------------------------------------
 ctkSettings::ctkSettings(QObject* parentObject)
-  : QSettings(parentObject)
+  : ctkCoreSettings(parentObject)
 {
 }
 

--- a/Libs/Widgets/ctkSettings.h
+++ b/Libs/Widgets/ctkSettings.h
@@ -56,11 +56,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __ctkSettings_h
 #define __ctkSettings_h
 
-// Qt includes
-#include <QSettings>
-
 // CTK includes
 #include "ctkWidgetsExport.h"
+#include "ctkCoreSettings.h"
 
 class QDialog;
 class QMainWindow;
@@ -68,7 +66,7 @@ class QMainWindow;
 /// \ingroup Widgets
 /// ctkSettings is a QSettings that additionally can save and restore the 
 /// state (position/size) of QMainWindow and QDialogs.
-class CTK_WIDGETS_EXPORT ctkSettings : public QSettings
+class CTK_WIDGETS_EXPORT ctkSettings : public ctkCoreSettings
 {
   Q_OBJECT
 


### PR DESCRIPTION
ctkCoreSettings allows storing paths relative to an "application home" folder. This makes it easy to create fully portable applications (that do not have absolute paths in application settings).

It will be used with this development in 3D Slicer: https://github.com/Slicer/Slicer/pull/5029
