### PR TITLE
BUG: Fix DICOM table defined stylesheet messing up use with palette

### DIFF
--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMTableManager.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMTableManager.ui
@@ -142,11 +142,6 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="styleSheet">
-      <string notr="true">QSplitter::handle {background-color: rgb(200,200,200);}
-QSplitter::handle:horizontal {width: 2px;}
-QSplitter::handle:vertical {height: 2px;}</string>
-     </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -156,9 +151,9 @@ QSplitter::handle:vertical {height: 2px;}</string>
      <property name="childrenCollapsible">
       <bool>false</bool>
      </property>
-     <widget class="ctkDICOMTableView" name="patientsTable" native="true"/>
-     <widget class="ctkDICOMTableView" name="studiesTable" native="true"/>
-     <widget class="ctkDICOMTableView" name="seriesTable" native="true"/>
+     <widget class="ctkDICOMTableView" name="patientsTable"/>
+     <widget class="ctkDICOMTableView" name="studiesTable"/>
+     <widget class="ctkDICOMTableView" name="seriesTable"/>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
When switching style using palettes as part of some work in 3D Slicer to implement Light and Dark modes this defined stylesheet in the ctkDICOMTableManager was messing things up by not changing when the style in 3D Slicer was dynamically changed after startup. It was flip-flopping and using the previous palette color instead of the currently specified one.  Removing this stylesheet solves this issue.

Note to see these exact results in Slicer, one must use the latest of https://github.com/Slicer/Slicer/pull/4993.

| On startup | After changing style (the issue) | After changing style with this PR |
|-------------|------------------------------------|---------------|
|![image](https://user-images.githubusercontent.com/15837524/88465271-a6a99c00-ce8f-11ea-889c-b1bbeda6a0a9.png)|![image](https://user-images.githubusercontent.com/15837524/88465279-b0cb9a80-ce8f-11ea-99cd-24b395637ee9.png)|![image](https://user-images.githubusercontent.com/15837524/88465334-318a9680-ce90-11ea-945a-e7c2d3efc51b.png)|

cc: @lassoan 
