### PR TITLE
BUG: Fix crash in popup widgets with Qt-5.15

### DIFF
--- a/Libs/Widgets/ctkBasePopupWidget.cpp
+++ b/Libs/Widgets/ctkBasePopupWidget.cpp
@@ -80,8 +80,8 @@ QGradient* duplicateGradient(const QGradient* gradient)
 ctkBasePopupWidgetPrivate::ctkBasePopupWidgetPrivate(ctkBasePopupWidget& object)
   :q_ptr(&object)
 {
-  this->Effect = ctkBasePopupWidget::ScrollEffect;
-  this->EffectDuration = 333; // in ms
+  this->Effect = ctkBasePopupWidget::FadeEffect;
+  this->EffectDuration = 30; // in ms
   this->EffectAlpha = 1.;
   this->AlphaAnimation = 0;
   this->ForcedTranslucent = false;


### PR DESCRIPTION
Popup widgets created with default settings (ScrollEffect) often cause crashes when used with Qt-5.15.0 on macOS.
https://github.com/Slicer/Slicer/issues/5092

Changed default animation effect to FadeEffect, which works robustly.

Also changed default effect duration to 30ms, as user complained that popup window display was too sluggish.

Since popup widgets are only used in 3D Slicer and application crash is a serious issue, I would merge this tonight before the nightly build cutoff time (10pm).