### PR TITLE
BUG: Fix crash when man instances of ctkPathLineEdit is instantiated

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkPathLineEditTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkPathLineEditTest1.cpp
@@ -25,6 +25,12 @@
 #include <QTimer>
 #include <QVBoxLayout>
 
+#if (QT_VERSION < QT_VERSION_CHECK(5,0,0))
+#include <QDesktopServices>
+#else
+#include <QStandardPaths>
+#endif 
+
 // CTK includes
 #include "ctkPathLineEdit.h"
 
@@ -38,11 +44,22 @@ int ctkPathLineEditTest1(int argc, char * argv [] )
   QApplication app(argc, argv);
 
   QWidget topLevel;
+
   ctkPathLineEdit button;
+
   ctkPathLineEdit button2("Files",
                           QStringList() << "Images (*.png *.jpg)" << "Text (*.txt)",
                           ctkPathLineEdit::Files);
-  ctkPathLineEdit button3("Dirs", QStringList("CTK*"));
+
+  ctkPathLineEdit button3("Dirs", QStringList(), ctkPathLineEdit::Dirs);
+  button3.setShowHistoryButton(false);
+
+#if (QT_VERSION < QT_VERSION_CHECK(5,0,0))
+  QString documentsFolder = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
+#else
+  QString documentsFolder = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+#endif 
+  button3.setCurrentPath(documentsFolder);
 
   QVBoxLayout* layout = new QVBoxLayout;
   layout->addWidget(&button);


### PR DESCRIPTION
Each ctkPathLineEdit widget created a QFileSystemModel for auto-complete, which overloaded Linux and Mac systems.
Instead, now we use a shared QFileSystemModel for all instances (similar to how it is done in ParaView) and a custom QFileSystemModel is only created if it strictly necessary (when name filter is set).
