### PR TITLE
COMP: Fix build of ctkVTKWidgetsUtilsTestImageConversion using Qt 5.10

### DIFF
--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKWidgetsUtilsTestImageConversion.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKWidgetsUtilsTestImageConversion.cpp
@@ -25,7 +25,7 @@
 #include <QIcon>
 #include <QImage>
 #include <QLabel>
-#include <QPixmap.h>
+#include <QPixmap>
 #include <QStyle>
 #include <QTimer>
 #include <QVBoxLayout>


### PR DESCRIPTION
This commit fixes the following error:

  /path/to/CTK/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKWidgetsUtilsTestImageConversion.cpp:28:21: fatal error: QPixmap.h: No such file or directory