### PR TITLE
Error log widget improvements

### DIFF
--- a/Libs/Widgets/Resources/UI/ctkErrorLogWidget.ui
+++ b/Libs/Widgets/Resources/UI/ctkErrorLogWidget.ui
@@ -17,6 +17,16 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QPushButton" name="ConsoleModeButton">
+       <property name="text">
+        <string>Console mode</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="ShowAllEntryButton">
        <property name="text">
         <string>&amp;All</string>
@@ -95,7 +105,14 @@
     </widget>
    </item>
    <item>
-    <widget class="QTextBrowser" name="ErrorLogDescription"/>
+    <widget class="QTextBrowser" name="ErrorLogDescription">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/Libs/Widgets/ctkErrorLogModel.cpp
+++ b/Libs/Widgets/ctkErrorLogModel.cpp
@@ -19,6 +19,8 @@
 =========================================================================*/
 
 // Qt includes
+#include <QApplication>
+#include <QPalette>
 #include <QStandardItem>
 
 // CTK includes
@@ -100,8 +102,18 @@ void ctkErrorLogModel::addModelEntry(const QString& currentDateTime, const QStri
   // Description item
   QStandardItem * descriptionItem = new QStandardItem();
   QString descriptionText(text);
+  if (logLevel == "Error" || logLevel == "Critical")
+  {
+    QPalette palette = QApplication::palette();
+    descriptionItem->setForeground(palette.color(QPalette::BrightText));
+  }
+  else if (logLevel == "Warning")
+  {
+    descriptionItem->setForeground(QColor(255, 165, 0));
+  }
   descriptionItem->setData(descriptionText.left(160).append((descriptionText.size() > 160) ? "..." : ""), Qt::DisplayRole);
   descriptionItem->setData(descriptionText, ctkErrorLogModel::DescriptionTextRole);
+
   descriptionItem->setEditable(false);
   itemList << descriptionItem;
 

--- a/Libs/Widgets/ctkErrorLogWidget.cpp
+++ b/Libs/Widgets/ctkErrorLogWidget.cpp
@@ -316,10 +316,28 @@ void ctkErrorLogWidget::onSelectionChanged(const QItemSelection & selected,
 
   foreach(const QModelIndex& index, selectedRows)
     {
-    descriptions << index.data(ctkErrorLogModel::DescriptionTextRole).toString();
+    QString logLevelString = index.sibling(index.row(), 2).data().toString();
+    QString color;
+    if (logLevelString == "Error" || logLevelString == "Critical")
+    {
+      QPalette pal = this->palette();
+      color = pal.color(QPalette::BrightText).name();
+    }
+    else if (logLevelString == "Warning")
+    {
+      color = "orange";
+    }
+    QString descriptionString = index.data(ctkErrorLogModel::DescriptionTextRole).toString();
+    descriptionString = descriptionString.replace("&", "&amp;");
+    descriptionString = descriptionString.replace("<", "&lt;");
+    descriptionString = descriptionString.replace(">", "&gt;");
+    descriptionString = descriptionString.replace("\r", "<br />");
+    descriptionString = descriptionString.replace("\n", "<br />");
+    QString htmlString = "<span style=\"color:" + color + ";\">" + descriptionString + "</span>";
+    descriptions << htmlString;
     }
 
-  d->ErrorLogDescription->setText(descriptions.join("\n"));
+  d->ErrorLogDescription->setText(descriptions.join("<br />"));
 
   // fprintf(stdout, "onSelectionChanged: %d\n", start.msecsTo(QTime::currentTime()));
 }

--- a/Libs/Widgets/ctkErrorLogWidget.cpp
+++ b/Libs/Widgets/ctkErrorLogWidget.cpp
@@ -266,6 +266,90 @@ void ctkErrorLogWidget::setUnknownEntriesVisible(bool visibility)
       /* disableFilter= */ !visibility);
 }
 
+// -------------------------------------------------------------------------
+void ctkErrorLogWidget::setConsoleModeButtonVisible(bool visibility)
+{
+  Q_D(ctkErrorLogWidget);
+  d->ConsoleModeButton->setVisible(visibility);
+}
+
+// -------------------------------------------------------------------------
+bool ctkErrorLogWidget::isConsoleModeButtonVisible()
+{
+  Q_D(ctkErrorLogWidget);
+  return d->ConsoleModeButton->isVisible();
+}
+
+// -------------------------------------------------------------------------
+void ctkErrorLogWidget::setAllEntryButtonVisible(bool visibility)
+{
+  Q_D(ctkErrorLogWidget);
+  d->ShowAllEntryButton->setVisible(visibility);
+}
+
+// -------------------------------------------------------------------------
+bool ctkErrorLogWidget::isAllEntryButtonVisible()
+{
+  Q_D(ctkErrorLogWidget);
+  return d->ShowAllEntryButton->isVisible();
+}
+
+// -------------------------------------------------------------------------
+void ctkErrorLogWidget::setErrorEntryButtonVisible(bool visibility)
+{
+  Q_D(ctkErrorLogWidget);
+  d->ShowErrorEntryButton->setVisible(visibility);
+}
+
+// -------------------------------------------------------------------------
+bool ctkErrorLogWidget::isErrorEntryButtonVisible()
+{
+  Q_D(ctkErrorLogWidget);
+  return d->ShowErrorEntryButton->isVisible();
+}
+
+// -------------------------------------------------------------------------
+void ctkErrorLogWidget::setWarningEntryButtonVisible(bool visibility)
+{
+  Q_D(ctkErrorLogWidget);
+  d->ShowWarningEntryButton->setVisible(visibility);
+}
+
+// -------------------------------------------------------------------------
+bool ctkErrorLogWidget::isWarningEntryButtonVisible()
+{
+  Q_D(ctkErrorLogWidget);
+  return d->ShowWarningEntryButton->isVisible();
+}
+
+// -------------------------------------------------------------------------
+void ctkErrorLogWidget::setInfoEntryButtonVisible(bool visibility)
+{
+  Q_D(ctkErrorLogWidget);
+  d->ShowInfoEntryButton->setVisible(visibility);
+}
+
+// -------------------------------------------------------------------------
+bool ctkErrorLogWidget::isInfoEntryButtonVisible()
+{
+  Q_D(ctkErrorLogWidget);
+  return d->ShowInfoEntryButton->isVisible();
+}
+
+// -------------------------------------------------------------------------
+void ctkErrorLogWidget::setClearButtonVisible(bool visibility)
+{
+  Q_D(ctkErrorLogWidget);
+  d->ClearButton->setVisible(visibility);
+}
+
+// -------------------------------------------------------------------------
+bool ctkErrorLogWidget::isClearButtonVisible()
+{
+  Q_D(ctkErrorLogWidget);
+  return d->ClearButton->isVisible();
+}
+
 // --------------------------------------------------------------------------
 void ctkErrorLogWidget::onRowsInserted(const QModelIndex &/*parent*/, int /*first*/, int /*last*/)
 {

--- a/Libs/Widgets/ctkErrorLogWidget.cpp
+++ b/Libs/Widgets/ctkErrorLogWidget.cpp
@@ -22,6 +22,7 @@
 #include <QDebug>
 #include <QAbstractItemModel>
 #include <QStandardItemModel>
+#include <QAbstractScrollArea>
 
 // CTK includes
 #include "ctkErrorLogWidget.h"
@@ -64,10 +65,14 @@ void ctkErrorLogWidgetPrivate::init()
   Q_Q(ctkErrorLogWidget);
 
   // this->ShowAllEntryButton->setIcon();
+  this->ConsoleModeButton->setIcon(q->style()->standardIcon(QStyle::SP_FileDialogDetailedView));
   this->ShowErrorEntryButton->setIcon(q->style()->standardIcon(QStyle::SP_MessageBoxCritical));
   this->ShowWarningEntryButton->setIcon(q->style()->standardIcon(QStyle::SP_MessageBoxWarning));
   this->ShowInfoEntryButton->setIcon(q->style()->standardIcon(QStyle::SP_MessageBoxInformation));
   this->ClearButton->setIcon(q->style()->standardIcon(QStyle::SP_DialogDiscardButton));
+
+  QObject::connect(this->ConsoleModeButton, SIGNAL(clicked(bool)),
+                   q, SLOT(setConsoleModeEnabled(bool)));
 
   QObject::connect(this->ShowAllEntryButton, SIGNAL(clicked()),
                    q, SLOT(setAllEntriesVisible()));
@@ -83,6 +88,10 @@ void ctkErrorLogWidgetPrivate::init()
 
   QObject::connect(this->ClearButton, SIGNAL(clicked()),
                    q, SLOT(removeEntries()));
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,2,0)
+  this->ErrorLogDescription->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
+#endif
 }
 
 // --------------------------------------------------------------------------
@@ -187,6 +196,22 @@ void ctkErrorLogWidget::setColumnHidden(int columnId, bool hidden) const
 }
 
 // --------------------------------------------------------------------------
+void ctkErrorLogWidget::setConsoleModeEnabled(bool enabled)
+{
+  Q_D(const ctkErrorLogWidget);
+  d->ErrorLogTableView->setHidden(enabled);
+  if (enabled)
+    {
+    d->ErrorLogTableView->selectAll();
+    }
+  else
+    {
+    d->ErrorLogTableView->clearSelection();
+    }
+
+}
+
+// --------------------------------------------------------------------------
 void ctkErrorLogWidget::setAllEntriesVisible(bool visibility)
 {
   this->setErrorEntriesVisible(visibility);
@@ -247,6 +272,10 @@ void ctkErrorLogWidget::onRowsInserted(const QModelIndex &/*parent*/, int /*firs
     {
     // For performance reason, resize first column only when first entry is added
     d->ErrorLogTableView->resizeColumnToContents(ctkErrorLogModel::TimeColumn);
+    }
+  if (d->ConsoleModeButton->isChecked())
+    {
+    d->ErrorLogTableView->selectAll();
     }
 }
 

--- a/Libs/Widgets/ctkErrorLogWidget.cpp
+++ b/Libs/Widgets/ctkErrorLogWidget.cpp
@@ -23,6 +23,7 @@
 #include <QAbstractItemModel>
 #include <QStandardItemModel>
 #include <QAbstractScrollArea>
+#include <QScrollBar>
 
 // CTK includes
 #include "ctkErrorLogWidget.h"
@@ -203,6 +204,7 @@ void ctkErrorLogWidget::setConsoleModeEnabled(bool enabled)
   if (enabled)
     {
     d->ErrorLogTableView->selectAll();
+    d->ErrorLogDescription->verticalScrollBar()->setValue(d->ErrorLogDescription->verticalScrollBar()->maximum());
     }
   else
     {
@@ -276,6 +278,7 @@ void ctkErrorLogWidget::onRowsInserted(const QModelIndex &/*parent*/, int /*firs
   if (d->ConsoleModeButton->isChecked())
     {
     d->ErrorLogTableView->selectAll();
+    d->ErrorLogDescription->verticalScrollBar()->setValue(d->ErrorLogDescription->verticalScrollBar()->maximum());
     }
 }
 

--- a/Libs/Widgets/ctkErrorLogWidget.cpp
+++ b/Libs/Widgets/ctkErrorLogWidget.cpp
@@ -93,6 +93,8 @@ void ctkErrorLogWidgetPrivate::init()
 #if QT_VERSION >= QT_VERSION_CHECK(5,2,0)
   this->ErrorLogDescription->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
 #endif
+
+  this->ShowAllEntryButton->setVisible(false);  // minimize the default width of the widget
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/Widgets/ctkErrorLogWidget.h
+++ b/Libs/Widgets/ctkErrorLogWidget.h
@@ -50,6 +50,8 @@ public:
   Q_INVOKABLE void setColumnHidden(int columnId, bool hidden) const;
 
 public Q_SLOTS:
+  void setConsoleModeEnabled(bool enabled);
+
   void setAllEntriesVisible(bool visibility = true);
 
   void setErrorEntriesVisible(bool visibility);
@@ -57,7 +59,7 @@ public Q_SLOTS:
   void setWarningEntriesVisible(bool visibility);
 
   void setInfoEntriesVisible(bool visibility);
-  
+
   void setUnknownEntriesVisible(bool visibility);
 
 protected Q_SLOTS:

--- a/Libs/Widgets/ctkErrorLogWidget.h
+++ b/Libs/Widgets/ctkErrorLogWidget.h
@@ -37,6 +37,12 @@ class QModelIndex;
 class CTK_WIDGETS_EXPORT ctkErrorLogWidget : public QWidget
 {
   Q_OBJECT
+  Q_PROPERTY(bool consoleModeButtonVisible READ isConsoleModeButtonVisible WRITE setConsoleModeButtonVisible)
+  Q_PROPERTY(bool allEntryButtonVisible READ isAllEntryButtonVisible WRITE setAllEntryButtonVisible)
+  Q_PROPERTY(bool errorEntryButtonVisible READ isErrorEntryButtonVisible WRITE setErrorEntryButtonVisible)
+  Q_PROPERTY(bool warningEntryButtonVisible READ isWarningEntryButtonVisible WRITE setWarningEntryButtonVisible)
+  Q_PROPERTY(bool infoEntryButtonVisible READ isInfoEntryButtonVisible WRITE setInfoEntryButtonVisible)
+  Q_PROPERTY(bool clearButtonVisible READ isClearButtonVisible WRITE setClearButtonVisible)
 public:
   typedef QWidget Superclass;
   explicit ctkErrorLogWidget(QWidget* parentWidget = 0);
@@ -61,6 +67,36 @@ public Q_SLOTS:
   void setInfoEntriesVisible(bool visibility);
 
   void setUnknownEntriesVisible(bool visibility);
+
+  ///
+  /// This property holds whether the Console Mode button is visible.
+  void setConsoleModeButtonVisible(bool enable);
+  bool isConsoleModeButtonVisible();
+
+  ///
+  /// This property holds whether the All entry button is visible.
+  void setAllEntryButtonVisible(bool enable);
+  bool isAllEntryButtonVisible();
+
+  ///
+  /// This property holds whether the Error entry button is visible.
+  void setErrorEntryButtonVisible(bool enable);
+  bool isErrorEntryButtonVisible();
+
+  ///
+  /// This property holds whether the Warning entry button is visible.
+  void setWarningEntryButtonVisible(bool enable);
+  bool isWarningEntryButtonVisible();
+
+  ///
+  /// This property holds whether the Info entry button is visible.
+  void setInfoEntryButtonVisible(bool enable);
+  bool isInfoEntryButtonVisible();
+
+  ///
+  /// This property holds whether the Clear button is visible.
+  void setClearButtonVisible(bool enable);
+  bool isClearButtonVisible();
 
 protected Q_SLOTS:
   void onRowsInserted(const QModelIndex &parent, int first, int last);


### PR DESCRIPTION
This adds improvements to the Error Log such as:
- a new "Hide Table" button which allows viewing the log not in table format, but just simple text format. This is supported by selecting all fields when hiding the table. When hiding the table you can still use the filter buttons to view all errors in the simple text format as well.
- supporting colored text in the description column and full description fields. Warning (orange), Error and Critical (red)

Note: Coloring is based on the log level, so if you see where a warning from "stream" is in red it is because it was logged as Critical which gets the red color.

## Current
|![image](https://user-images.githubusercontent.com/15837524/92335925-a34a2880-f069-11ea-9e0e-8d1e9ab17893.png)

## This PR
![image](https://user-images.githubusercontent.com/15837524/92407096-ac89d280-f107-11ea-8f8b-e4dff7ce281f.png)
![image](https://user-images.githubusercontent.com/15837524/92407113-ba3f5800-f107-11ea-9e73-df9ff7c4ac1b.png)
![image](https://user-images.githubusercontent.com/15837524/92407141-c6c3b080-f107-11ea-96e2-48abc6e7d675.png)
