### PR TITLE
Adding support for VTK 9.0

### DIFF
--- a/Libs/Visualization/VTK/Core/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Core/CMakeLists.txt
@@ -15,7 +15,6 @@ else()
     list(APPEND _test_components
       TestingRendering
       CommonSystem
-      ImagingGeneral
       )
   endif()
 

--- a/Libs/Visualization/VTK/Widgets/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Widgets/CMakeLists.txt
@@ -10,6 +10,14 @@ else()
   # VTK >= 8.90 defines VTK_MAJOR_VERSION
   set(VTK_VERSION_MAJOR ${VTK_MAJOR_VERSION})
 
+  set(_test_components)
+  if(BUILD_TESTING)
+    list(APPEND _test_components
+      TestingRendering
+      ImagingGeneral
+      )
+  endif()
+
   find_package(VTK COMPONENTS
     ChartsCore
     CommonCore
@@ -20,6 +28,7 @@ else()
     FiltersModeling
     FiltersSources
     GUISupportQt
+    ImagingGeneral
     ImagingStatistics
     IOLegacy
     IOXML
@@ -32,8 +41,7 @@ else()
     RenderingOpenGL2
     ViewsCore
     ViewsInfovis
-  OPTIONAL_COMPONENTS
-    TestingRendering
+    ${_test_components}
   )
 endif()
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKAbstractViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKAbstractViewTest1.cpp
@@ -28,17 +28,9 @@
 #include "ctkVTKSliceView.h"
 #include "ctkVTKRenderView.h"
 #include "ctkCoreTestingMacros.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // VTK includes
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#else
-# include <QVTKWidget.h>
-#endif
 #include <vtkRenderWindow.h>
 #include <vtkCallbackCommand.h>
 
@@ -103,15 +95,7 @@ bool function1(ctkVTKAbstractView* view)
 //-----------------------------------------------------------------------------
 int ctkVTKAbstractViewTest1(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKAbstractViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKAbstractViewTest1.cpp
@@ -31,7 +31,13 @@
 
 // VTK includes
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
+#else
+# include <QVTKWidget.h>
 #endif
 #include <vtkRenderWindow.h>
 #include <vtkCallbackCommand.h>
@@ -98,7 +104,11 @@ bool function1(ctkVTKAbstractView* view)
 int ctkVTKAbstractViewTest1(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKChartViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKChartViewTest1.cpp
@@ -33,7 +33,11 @@
 #include <vtkTable.h>
 #include <vtkVersion.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 // STD includes
@@ -49,7 +53,11 @@ static int data_2010[] = {9058, 10941, 9979, 10270, 8900, 11228, 14688, 12231, 1
 int ctkVTKChartViewTest1(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKChartViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKChartViewTest1.cpp
@@ -25,6 +25,7 @@
 
 // CTK includes
 #include "ctkVTKChartView.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // VTK includes
 #include <vtkIntArray.h>
@@ -32,13 +33,6 @@
 #include <vtkPlotBar.h>
 #include <vtkTable.h>
 #include <vtkVersion.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
 
 // STD includes
 #include <iostream>
@@ -52,15 +46,7 @@ static int data_2010[] = {9058, 10941, 9979, 10270, 8900, 11228, 14688, 12231, 1
 //-----------------------------------------------------------------------------
 int ctkVTKChartViewTest1(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMagnifyViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMagnifyViewTest1.cpp
@@ -29,10 +29,15 @@
 
 // VTK includes
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#include <vtkGenericOpenGLRenderWindow.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
+# include <QSurfaceFormat>
+# include <vtkGenericOpenGLRenderWindow.h>
 #endif
+
 #include <vtkNew.h>
 #include <vtkRenderer.h>
 #include <vtkRendererCollection.h>
@@ -46,7 +51,11 @@
 int ctkVTKMagnifyViewTest1(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMagnifyViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMagnifyViewTest1.cpp
@@ -26,18 +26,12 @@
 // CTK includes
 #include "ctkVTKMagnifyView.h"
 #include "ctkVTKOpenGLNativeWidget.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // VTK includes
 #if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-# include <QSurfaceFormat>
 # include <vtkGenericOpenGLRenderWindow.h>
 #endif
-
 #include <vtkNew.h>
 #include <vtkRenderer.h>
 #include <vtkRendererCollection.h>
@@ -50,15 +44,7 @@
 //-----------------------------------------------------------------------------
 int ctkVTKMagnifyViewTest1(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewEventTranslatorPlayerTest1.cpp
@@ -34,14 +34,6 @@
 #include <vtkRenderer.h>
 #include <vtkSmartPointer.h>
 #include <vtkSphereSource.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
-
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkSplineWidget2.h>
@@ -53,6 +45,7 @@
 #include "ctkVTKRenderView.h"
 #include "ctkVTKRenderViewEventPlayer.h"
 #include "ctkVTKRenderViewEventTranslator.h"
+#include "ctkVTKWidgetsUtils.h"
 #include "ctkEventTranslatorPlayerWidget.h"
 #include "ctkWidgetsUtils.h"
 
@@ -105,15 +98,7 @@ void screenshotAvailable(void* data)
 //-----------------------------------------------------------------------------
 int ctkVTKRenderViewEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewEventTranslatorPlayerTest1.cpp
@@ -35,7 +35,11 @@
 #include <vtkSmartPointer.h>
 #include <vtkSphereSource.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 #include <vtkRenderWindow.h>
@@ -102,7 +106,11 @@ void screenshotAvailable(void* data)
 int ctkVTKRenderViewEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest1.cpp
@@ -30,7 +30,11 @@
 #include <vtkRenderer.h>
 #include <vtkSphereSource.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 // CTK includes
@@ -44,7 +48,11 @@
 int ctkVTKRenderViewTest1(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest1.cpp
@@ -29,17 +29,11 @@
 #include <vtkPolyDataMapper.h>
 #include <vtkRenderer.h>
 #include <vtkSphereSource.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
 
 // CTK includes
 #include "ctkVTKRenderView.h"
 #include "ctkCommandLineParser.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // STD includes
 #include <iostream>
@@ -47,15 +41,7 @@
 //-----------------------------------------------------------------------------
 int ctkVTKRenderViewTest1(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest2.cpp
@@ -29,17 +29,11 @@
 #include <vtkPolyDataMapper.h>
 #include <vtkRenderer.h>
 #include <vtkSphereSource.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
 
 // CTK includes
 #include "ctkVTKRenderView.h"
 #include "ctkCommandLineParser.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // STD includes
 #include <iostream>
@@ -47,15 +41,7 @@
 //-----------------------------------------------------------------------------
 int ctkVTKRenderViewTest2(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest2.cpp
@@ -30,7 +30,11 @@
 #include <vtkRenderer.h>
 #include <vtkSphereSource.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 // CTK includes
@@ -44,7 +48,11 @@
 int ctkVTKRenderViewTest2(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest1.cpp
@@ -30,7 +30,11 @@
 #include <vtkColorTransferFunction.h>
 #include <vtkSmartPointer.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 // STD includes
@@ -40,7 +44,11 @@
 int ctkVTKScalarsToColorsViewTest1(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest1.cpp
@@ -25,17 +25,11 @@
 
 // CTK includes
 #include "ctkVTKScalarsToColorsView.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // VTK includes
 #include <vtkColorTransferFunction.h>
 #include <vtkSmartPointer.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
 
 // STD includes
 #include <iostream>
@@ -43,15 +37,7 @@
 //-----------------------------------------------------------------------------
 int ctkVTKScalarsToColorsViewTest1(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest2.cpp
@@ -25,6 +25,7 @@
 
 // CTK includes
 #include "ctkVTKScalarsToColorsView.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // VTK includes
 #include <vtkChartXY.h>
@@ -38,13 +39,6 @@
 #include <vtkSmartPointer.h>
 #include <vtkTable.h>
 #include <vtkVersion.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
 
 // STD includes
 #include <iostream>
@@ -52,15 +46,7 @@
 //-----------------------------------------------------------------------------
 int ctkVTKScalarsToColorsViewTest2(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest2.cpp
@@ -39,7 +39,11 @@
 #include <vtkTable.h>
 #include <vtkVersion.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 // STD includes
@@ -49,7 +53,11 @@
 int ctkVTKScalarsToColorsViewTest2(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest3.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest3.cpp
@@ -25,18 +25,12 @@
 
 // CTK includes
 #include "ctkVTKScalarsToColorsView.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // VTK includes
 #include <vtkColorTransferFunction.h>
 #include <vtkPiecewiseFunction.h>
 #include <vtkSmartPointer.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
 
 // STD includes
 #include <iostream>
@@ -44,15 +38,7 @@
 //-----------------------------------------------------------------------------
 int ctkVTKScalarsToColorsViewTest3(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest3.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewTest3.cpp
@@ -31,7 +31,11 @@
 #include <vtkPiecewiseFunction.h>
 #include <vtkSmartPointer.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 // STD includes
@@ -41,7 +45,11 @@
 int ctkVTKScalarsToColorsViewTest3(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest1.cpp
@@ -27,19 +27,13 @@
 #include "ctkCoreTestingMacros.h"
 #include "ctkVTKScalarsToColorsView.h"
 #include "ctkVTKScalarsToColorsWidget.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // VTK includes
 #include <vtkChartXY.h>
 #include <vtkPiecewiseFunction.h>
 #include <vtkPlot.h>
 #include <vtkSmartPointer.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
 
 // STD includes
 #include <iostream>
@@ -47,15 +41,7 @@
 //-----------------------------------------------------------------------------
 int ctkVTKScalarsToColorsWidgetTest1(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest1.cpp
@@ -34,7 +34,11 @@
 #include <vtkPlot.h>
 #include <vtkSmartPointer.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 // STD includes
@@ -44,7 +48,11 @@
 int ctkVTKScalarsToColorsWidgetTest1(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest2.cpp
@@ -27,6 +27,7 @@
 #include "ctkCoreTestingMacros.h"
 #include "ctkVTKScalarsToColorsView.h"
 #include "ctkVTKScalarsToColorsWidget.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // VTK includes
 #include <vtkChartXY.h>
@@ -34,13 +35,6 @@
 #include <vtkPiecewiseFunction.h>
 #include <vtkPlot.h>
 #include <vtkSmartPointer.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
 
 // STD includes
 #include <iostream>
@@ -48,15 +42,7 @@
 //-----------------------------------------------------------------------------
 int ctkVTKScalarsToColorsWidgetTest2(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest2.cpp
@@ -35,7 +35,11 @@
 #include <vtkPlot.h>
 #include <vtkSmartPointer.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 // STD includes
@@ -45,7 +49,11 @@
 int ctkVTKScalarsToColorsWidgetTest2(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest3.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest3.cpp
@@ -27,6 +27,7 @@
 #include "ctkCoreTestingMacros.h"
 #include "ctkVTKScalarsToColorsView.h"
 #include "ctkVTKScalarsToColorsWidget.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // VTK includes
 #include <vtkChartXY.h>
@@ -34,13 +35,6 @@
 #include <vtkPiecewiseFunction.h>
 #include <vtkPlot.h>
 #include <vtkSmartPointer.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
 
 // STD includes
 #include <iostream>
@@ -48,15 +42,7 @@
 //-----------------------------------------------------------------------------
 int ctkVTKScalarsToColorsWidgetTest3(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest3.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetTest3.cpp
@@ -35,7 +35,11 @@
 #include <vtkPlot.h>
 #include <vtkSmartPointer.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 // STD includes
@@ -45,7 +49,11 @@
 int ctkVTKScalarsToColorsWidgetTest3(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest1.cpp
@@ -29,7 +29,11 @@
 
 // VKT includes
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 // STD includes
@@ -39,7 +43,11 @@
 int ctkVTKSliceViewTest1(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest1.cpp
@@ -26,15 +26,7 @@
 #include "ctkCommandLineParser.h"
 #include "ctkVTKObjectEventsObserver.h"
 #include "ctkVTKSliceView.h"
-
-// VKT includes
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
+#include "ctkVTKWidgetsUtils.h"
 
 // STD includes
 #include <iostream>
@@ -42,15 +34,7 @@
 //-----------------------------------------------------------------------------
 int ctkVTKSliceViewTest1(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest2.cpp
@@ -30,6 +30,7 @@
 #include "ctkCommandLineParser.h"
 #include "ctkVTKObjectEventsObserver.h"
 #include "ctkVTKSliceView.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // VTK includes
 #include <vtkImageReader2Factory.h>
@@ -39,13 +40,6 @@
 #include <vtkInteractorStyleImage.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkLightBoxRendererManager.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
 
 // STD includes
 #include <iostream>
@@ -53,15 +47,7 @@
 //-----------------------------------------------------------------------------
 int ctkVTKSliceViewTest2(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
 

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewTest2.cpp
@@ -40,7 +40,11 @@
 #include <vtkRenderWindowInteractor.h>
 #include <vtkLightBoxRendererManager.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 // STD includes
@@ -50,7 +54,11 @@
 int ctkVTKSliceViewTest2(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKThumbnailViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKThumbnailViewTest1.cpp
@@ -28,7 +28,11 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #if CTK_USE_QVTKOPENGLWIDGET
-#include <QVTKOpenGLWidget.h>
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+#  include <QVTKOpenGLNativeWidget.h>
+# else
+#  include <QVTKOpenGLWidget.h>
+# endif
 #endif
 
 #include <vtkActor.h>
@@ -46,7 +50,11 @@
 int ctkVTKThumbnailViewTest1(int argc, char * argv [] )
 {
 #if CTK_USE_QVTKOPENGLWIDGET
+# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
+    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
+# else
     QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
+# endif
     format.setSamples(0);
     QSurfaceFormat::setDefaultFormat(format);
 #endif

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKThumbnailViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKThumbnailViewTest1.cpp
@@ -22,25 +22,18 @@
 #include <QApplication>
 #include <QTimer>
 
-// qMRML includes
+// CTK includes
 #include "ctkVTKThumbnailView.h"
+#include "ctkVTKWidgetsUtils.h"
 
 // VTK includes
-#include <vtkSmartPointer.h>
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-#  include <QVTKOpenGLNativeWidget.h>
-# else
-#  include <QVTKOpenGLWidget.h>
-# endif
-#endif
-
 #include <vtkActor.h>
 #include <vtkCubeSource.h>
 #include <vtkPolyDataMapper.h>
 #include <vtkRenderer.h>
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
+#include <vtkSmartPointer.h>
 #include <vtkVersion.h>
 
 // STD includes
@@ -49,15 +42,7 @@
 
 int ctkVTKThumbnailViewTest1(int argc, char * argv [] )
 {
-#if CTK_USE_QVTKOPENGLWIDGET
-# if CTK_HAS_QVTKOPENGLNATIVEWIDGET_H
-    QSurfaceFormat format = QVTKOpenGLNativeWidget::defaultFormat();
-# else
-    QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-# endif
-    format.setSamples(0);
-    QSurfaceFormat::setDefaultFormat(format);
-#endif
+  ctk::vtkSetSurfaceDefaultFormat();
 
   QApplication app(argc, argv);
   

--- a/Libs/Visualization/VTK/Widgets/ctkVTKWidgetsUtils.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKWidgetsUtils.cpp
@@ -215,3 +215,13 @@ QImage ctk::scalarsToColorsImage(vtkScalarsToColors* scalarsToColors,
 
   return transferFunctionImage;
 }
+
+//----------------------------------------------------------------------------
+void ctk::vtkSetSurfaceDefaultFormat(void)
+{
+#if CTK_USE_QVTKOPENGLWIDGET
+  QSurfaceFormat format = ctkVTKOpenGLNativeWidget::defaultFormat();
+  format.setSamples(0);
+  QSurfaceFormat::setDefaultFormat(format);
+#endif
+}

--- a/Libs/Visualization/VTK/Widgets/ctkVTKWidgetsUtils.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKWidgetsUtils.h
@@ -63,6 +63,11 @@ bool CTK_VISUALIZATION_VTK_WIDGETS_EXPORT qImageToVTKImageData(const QImage& ima
 QImage CTK_VISUALIZATION_VTK_WIDGETS_EXPORT scalarsToColorsImage(
   vtkScalarsToColors* scalarsToColors, const QSize& size = QSize());
 
+///
+/// \ingroup Visualization_VTK_Widgets
+/// Sets the default format for QSurfaceFormat depending on the VTK OpenGL widget implementation.
+void CTK_VISUALIZATION_VTK_WIDGETS_EXPORT vtkSetSurfaceDefaultFormat(void);
+
 }
 
 #endif


### PR DESCRIPTION
Changes to support build with VTK 9.0

In VTK 9.0 QVTKOpenGLWidget is deprecated and should be replaced by QVTKOpenGLNativeWidget. Additional library references are required in VTK/Core and VTK/Widget.

Changes tested under Win10 with external build VTK 9.0.1.