### PR TITLE
BUG: Revert invalid workaround for slice viewer issue with VTK9

### DIFF
--- a/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
+++ b/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
@@ -131,13 +131,7 @@ void RenderWindowItem::SetupImageMapperActor(double colorWindow, double colorLev
   // .. and its corresponding 2D actor
   this->ImageActor = vtkSmartPointer<vtkActor2D>::New();
   this->ImageActor->SetMapper(this->ImageMapper);
-#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
-  // Waiting issue Slicer/Slicer#5220 is resolved, accept that other actors like corner
-  // annotations and crosshairs are occluded and ensure image data is displayed.
-  // See https://github.com/Slicer/Slicer/issues/5220
-#else
   this->ImageActor->GetProperty()->SetDisplayLocationToBackground();
-#endif
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
This reverts commit 2f164d767f8d944d2565f9a08ace91f779e6f142.

See https://github.com/Slicer/Slicer/pull/5272#issuecomment-717663125