### PR TITLE
ENH: Allow ctkMessageBox to store any don't-show-again button roles in settings

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkMessageBoxDontShowAgainTest.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkMessageBoxDontShowAgainTest.cpp
@@ -475,7 +475,10 @@ void ctkMessageBoxDontShowAgainTester::testDontShowAgainSettingsKeySetDontShowAg
 void ctkMessageBoxDontShowAgainTester::testDontShowAgainSettingsKeyClickDontShowAgain()
 {
   ctkMessageBox messageBox;
-  messageBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+  messageBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+
+  messageBox.addDontShowAgainButtonRole(QMessageBox::YesRole);
+  messageBox.addDontShowAgainButtonRole(QMessageBox::NoRole);
 
   QFETCH(QString, key);
   messageBox.setDontShowAgainSettingsKey(key);
@@ -507,6 +510,10 @@ void ctkMessageBoxDontShowAgainTester::testDontShowAgainSettingsKeyClickDontShow
     << "NonExistingKey" << true << int(QMessageBox::Ok)
     << int(QMessageBox::Ok) << QMessageBox::AcceptRole
     << int(QMessageBox::Ok);
+  QTest::newRow("NonExistingKey dont show again no")
+    << "NonExistingKey" << true << int(QMessageBox::No)
+    << int(QMessageBox::No) << QMessageBox::NoRole
+    << int(QMessageBox::No);
   QTest::newRow("NonExistingKey dont show again cancel")
     << "NonExistingKey" << true << int(QMessageBox::Cancel)
     << int(QMessageBox::Cancel) << QMessageBox::RejectRole
@@ -516,6 +523,10 @@ void ctkMessageBoxDontShowAgainTester::testDontShowAgainSettingsKeyClickDontShow
     << "Show" << true << int(QMessageBox::Ok)
     << int(QMessageBox::Ok) << QMessageBox::AcceptRole
     << int(QMessageBox::Ok);
+  QTest::newRow("Show dont show again no")
+    << "Show" << true << int(QMessageBox::No)
+    << int(QMessageBox::No) << QMessageBox::NoRole
+    << int(QMessageBox::No);
   QTest::newRow("Show dont show again cancel")
     << "Show" << true << int(QMessageBox::Cancel)
     << int(QMessageBox::Cancel) << QMessageBox::RejectRole
@@ -525,6 +536,10 @@ void ctkMessageBoxDontShowAgainTester::testDontShowAgainSettingsKeyClickDontShow
     << "NonExistingKey" << false << int(QMessageBox::Ok)
     << int(QMessageBox::Ok) << QMessageBox::AcceptRole
     << int(QMessageBox::InvalidRole);
+  QTest::newRow("NonExistingKey show again no")
+    << "NonExistingKey" << false << int(QMessageBox::No)
+    << int(QMessageBox::No) << QMessageBox::NoRole
+    << int(QMessageBox::InvalidRole);
   QTest::newRow("NonExistingKey show again reject")
     << "NonExistingKey" << false << int(QMessageBox::Cancel)
     << int(QMessageBox::Cancel) << QMessageBox::RejectRole
@@ -533,6 +548,10 @@ void ctkMessageBoxDontShowAgainTester::testDontShowAgainSettingsKeyClickDontShow
   QTest::newRow("Show show again accept")
     << "Show" << false << int(QMessageBox::Ok)
     << int(QMessageBox::Ok) << QMessageBox::AcceptRole
+    << int(QMessageBox::InvalidRole);
+  QTest::newRow("Show show again no")
+    << "Show" << false << int(QMessageBox::No)
+    << int(QMessageBox::No) << QMessageBox::NoRole
     << int(QMessageBox::InvalidRole);
   QTest::newRow("Show dont show reject")
     << "Show" << false << int(QMessageBox::Cancel)

--- a/Libs/Widgets/ctkMessageBox.cpp
+++ b/Libs/Widgets/ctkMessageBox.cpp
@@ -28,6 +28,7 @@
 
 // CTK includes
 #include "ctkMessageBox.h"
+#include "ctkPimpl.h"
 
 //-----------------------------------------------------------------------------
 // ctkMessageBoxPrivate methods
@@ -51,7 +52,7 @@ public:
 public:
   QString        DontShowAgainSettingsKey;
   QCheckBox*     DontShowAgainCheckBox;
-  bool           SaveDontShowAgainSettingsOnAcceptOnly;
+  QList<QMessageBox::ButtonRole> DontShowAgainButtonRoles;
 };
 
 //-----------------------------------------------------------------------------
@@ -60,7 +61,7 @@ ctkMessageBoxPrivate::ctkMessageBoxPrivate(ctkMessageBox& object)
 {
   this->DontShowAgainSettingsKey = QString();
   this->DontShowAgainCheckBox = 0;
-  this->SaveDontShowAgainSettingsOnAcceptOnly = true;
+  this->DontShowAgainButtonRoles.append(QMessageBox::AcceptRole);
 }
 
 //-----------------------------------------------------------------------------
@@ -170,6 +171,9 @@ void ctkMessageBoxPrivate::writeSettings(int button)
 
 //-----------------------------------------------------------------------------
 // ctkMessageBox methods
+
+CTK_GET_CPP(ctkMessageBox, QList<QMessageBox::ButtonRole>, dontShowAgainButtonRoles, DontShowAgainButtonRoles;);
+CTK_SET_CPP(ctkMessageBox, const QList<QMessageBox::ButtonRole>&, setDontShowAgainButtonRoles, DontShowAgainButtonRoles);
 
 //-----------------------------------------------------------------------------
 ctkMessageBox::ctkMessageBox(QWidget* newParent)
@@ -292,8 +296,7 @@ void ctkMessageBox::onFinished(int resultCode)
 {
   Q_D(ctkMessageBox);
   // Don't save if the button is not an accepting button
-  if (!d->SaveDontShowAgainSettingsOnAcceptOnly ||
-      this->buttonRole( this->clickedButton() ) == QMessageBox::AcceptRole )
+  if (d->DontShowAgainButtonRoles.contains(this->buttonRole( this->clickedButton())))
     {
     d->writeSettings(resultCode);
     }
@@ -334,4 +337,16 @@ bool ctkMessageBox
   dialog->setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
   dialog->setDontShowAgainSettingsKey(dontShowAgainKey);
   return dialog->exec() == QMessageBox::Ok;
+}
+
+//-----------------------------------------------------------------------------
+void ctkMessageBox::addDontShowAgainButtonRole(QMessageBox::ButtonRole role)
+{
+  Q_D(ctkMessageBox);
+  if (d->DontShowAgainButtonRoles.contains(role))
+  {
+    // already added
+    return;
+  }
+  d->DontShowAgainButtonRoles.append(role);
 }

--- a/Libs/Widgets/ctkMessageBox.h
+++ b/Libs/Widgets/ctkMessageBox.h
@@ -23,6 +23,7 @@
 
 // Qt includes
 #include <QMessageBox>
+#include <QList>
 
 // CTK includes
 #include "ctkWidgetsExport.h"
@@ -46,6 +47,13 @@ class CTK_WIDGETS_EXPORT ctkMessageBox : public QMessageBox
   /// the value of the key.
   /// By default, dontShowAgain is false.
   Q_PROPERTY(bool dontShowAgain READ dontShowAgain WRITE setDontShowAgain)
+  /// This list contains button roles that are saved in dontShowAgain settings
+  /// if dontShowAgain flag is set. By default the choice is only saved if the
+  /// role of the pushed button is QMessageBox::AcceptRole.
+  /// For example, if a message box has Yes, No, and Cancel buttons then it
+  /// QMessageBox::YesRole and QMessageBox::YesRole roles have to be added to the list
+  /// to allow saving yes/no selection in settings.
+  Q_PROPERTY(QList<QMessageBox::ButtonRole> dontShowAgainButtonRoles READ dontShowAgainButtonRoles WRITE setDontShowAgainButtonRoles)
 
   /// This property holds the settings key that is used to synchronize the state
   /// of the checkbox "Don't show this message again"
@@ -78,6 +86,21 @@ public:
 
   void setDontShowAgainVisible(bool visible);
   bool isDontShowAgainVisible()const;
+
+  /// Get the list of button roles that can be saved in settings when
+  /// "Don't show again" checkbox is checked.
+  /// \sa setDontShowAgainButtonRoles(), addDontShowAgainButtonRole()
+  QList<QMessageBox::ButtonRole> dontShowAgainButtonRoles()const;
+
+  /// Set the list of button roles that can be saved in settings when
+  /// "Don't show again" checkbox is checked.
+  /// \sa dontShowAgainButtonRoles(), addDontShowAgainButtonRole()
+  void setDontShowAgainButtonRoles(const QList<QMessageBox::ButtonRole>& roles);
+
+  /// Add one role to the list of button roles that can be saved in settings when
+  /// "Don't show again" checkbox is checked.
+  /// \sa dontShowAgainButtonRoles(), setDontShowAgainButtonRoles()
+  Q_INVOKABLE void addDontShowAgainButtonRole(QMessageBox::ButtonRole role);
 
   /// Utility function that opens a dialog to confirm exit.
   /// If \a dontShowAgainKey is empty, the dontShowAgain checkbox is hidden


### PR DESCRIPTION
Previously, when dontShowAgain flag was enabled, only buttons with AcceptRole could be saved in settings.
Now the user can customize the list of button roles.

For example Yes and No button choice can be saved, while still not saving anything if user clicks Cancel.