### PR TITLE
ENH: Remove warning message when nullptr is used as vtkObject pointer event data

### DIFF
--- a/Libs/Visualization/VTK/Core/ctkVTKConnection.cpp
+++ b/Libs/Visualization/VTK/Core/ctkVTKConnection.cpp
@@ -420,15 +420,6 @@ void ctkVTKConnectionPrivate::execute(vtkObject* vtk_obj, unsigned long vtk_even
         if (this->VTKEvent == vtk_event)
           {
           callDataAsVtkObject = reinterpret_cast<vtkObject*>( call_data );
-          if (!callDataAsVtkObject)
-            {
-            qCritical() << "The VTKEvent(" << this->VTKEvent<< ") triggered by vtkObject("
-              << this->VTKObject->GetClassName() << ") "
-              << "doesn't return data of type vtkObject." << endl
-              << "The slot (" << this->QtSlot <<  ") owned by "
-              << "QObject(" << this->QtObject->objectName() << ")"
-              << " may be incorrect.";
-            }
           emit q->emitExecute(vtk_obj, callDataAsVtkObject);
           }
         break;


### PR DESCRIPTION
ctkVTKConnection logged a warning message each time an event was received that vtkObject* as event data and the pointer was nullptr.

Always treating nullptr value as an error is too limiting, because it is often useful that an additional pointer can be supplied but not mandatory.

This change removes the warning message from ctkVTKConnection and makes it the event receiver's responsibility to log warning/error if in that particular case nullptr is not expected.
Since ctkVTKConnection just logged a warning message but already left nullptr values through, it is guaranteed that change does not alter any existing software behavior
(other than not displaying the warning).

This change is useful in Slicer because DisplayModified events typically contain the display node pointer as eventdata but if multiple DisplayModified events are lumped together
(due to batch update with Start/EndModify) then there is no display node that could be attached to the event.