### PR TITLE
ENH: add command and history properties to ctkConsole

### DIFF
--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -1253,6 +1253,36 @@ void ctkConsole::setRunFileOptions(const RunFileOptions& newOptions)
 }
 
 //-----------------------------------------------------------------------------
+const QString& ctkConsole::commandBuffer()
+{
+  Q_D(ctkConsole);
+  return d->commandBuffer();
+}
+
+//-----------------------------------------------------------------------------
+void ctkConsole::setCommandBuffer(const QString& command)
+{
+  Q_D(ctkConsole);
+  d->replaceCommandBuffer(command);
+}
+
+//-----------------------------------------------------------------------------
+const QStringList& ctkConsole::commandHistory()
+{
+  Q_D(ctkConsole);
+  return d->CommandHistory;
+}
+
+//-----------------------------------------------------------------------------
+void ctkConsole::setCommandHistory(const QStringList& commandHistory)
+{
+  Q_D(ctkConsole);
+  d->CommandHistory = commandHistory;
+  d->CommandHistory.append("");
+  d->CommandPosition = d->CommandHistory.size()-1;
+}
+
+//-----------------------------------------------------------------------------
 void ctkConsole::exec(const QString& command)
 {
   Q_D(ctkConsole);

--- a/Libs/Widgets/ctkConsole.h
+++ b/Libs/Widgets/ctkConsole.h
@@ -87,6 +87,8 @@ class CTK_WIDGETS_EXPORT ctkConsole : public QWidget
   Q_FLAGS(RunFileOption RunFileOptions)
   Q_PROPERTY(RunFileOptions runFileOptions READ runFileOptions WRITE setRunFileOptions)
   Q_PROPERTY(int maxVisibleCompleterItems READ maxVisibleCompleterItems WRITE setMaxVisibleCompleterItems)
+  Q_PROPERTY(QString commandBuffer READ commandBuffer WRITE setCommandBuffer)
+  Q_PROPERTY(QStringList commandHistory READ commandHistory WRITE setCommandHistory)
 
 public:
 
@@ -226,6 +228,15 @@ public:
   /// \sa runFileOptions()
   void setRunFileOptions(const RunFileOptions& newOptions);
 
+  /// Get the current command buffer (text on current input line, not yet executed)
+  /// \sa setCommandBuffer()
+  virtual const QString& commandBuffer();
+
+  /// Get the command history list (previously executed commands)
+  /// \sa commandBuffer()
+  /// \sa setCommandBuffer()
+  virtual const QStringList& commandHistory();
+
 Q_SIGNALS:
 
   /// This signal emitted before and after a command is executed
@@ -243,6 +254,14 @@ public Q_SLOTS:
 
   /// Clears the contents of the console and display welcome message
   virtual void reset();
+
+  /// Set the the command buffer (pending command for user)
+  /// \sa commandBuffer()
+  virtual void setCommandBuffer(const QString&);
+
+  /// Set the command history (e.g. if restored from file)
+  /// \sa commandHistory()
+  virtual void setCommandHistory(const QStringList&);
 
   /// Exec the contents of the last console line
   /// \sa openFile(), runFile(QString)


### PR DESCRIPTION
Previously, the API allowed execution of commands but not
setting the state of the command buffer to be executed when the
user hit enter.

Also the command history always started empty.

This change adds read/write properties to fix this.

Now the command buffer can be set, e.g. by a hot key or other
custom code and it will be editable and the user can add more text,
user the completer, etc.

Also the command history can be controlled by the appication so
that it can save and restore previous sessions as a convenience
to the user.