### PR TITLE
ENH: Make DICOM database relocatable

### DIFF
--- a/Libs/Core/ctkCorePythonQtDecorators.h
+++ b/Libs/Core/ctkCorePythonQtDecorators.h
@@ -26,6 +26,7 @@
 
 // CTK includes
 #include <ctkBooleanMapper.h>
+#include <ctkUtils.h>
 #include <ctkErrorLogContext.h>
 #include <ctkWorkflowStep.h>
 #include <ctkWorkflowTransitions.h>
@@ -235,9 +236,31 @@ public Q_SLOTS:
 };
 
 //-----------------------------------------------------------------------------
+class PythonQtWrapper_CTKCore : public QObject
+{
+  Q_OBJECT
+
+public Q_SLOTS:
+  QString static_ctkCoreUtils_absolutePathFromInternal(const QString& internalPath, const QString& basePath)
+    {
+    return ctk::absolutePathFromInternal(internalPath, basePath);
+    }
+
+  QString static_ctkCoreUtils_internalPathFromAbsolute(const QString& absolutePath, const QString& basePath)
+    {
+    return ctk::internalPathFromAbsolute(absolutePath, basePath);
+    }
+};
+
+//-----------------------------------------------------------------------------
 void initCTKCorePythonQtDecorators()
 {
   PythonQt::self()->addDecorators(new ctkCorePythonQtDecorators);
+
+  // PythonQt doesn't support wrapping a static function and adding it to the top-level
+  // ctk module. This exposes static functions from ctkCoreUtils as ctk.ctkCoreUtils.absolutePathFromInternal(), etc.
+  // Note that PythonQtWrapper_CTKCore installs itself as ctk.ctk but using that same module here would replace PythonQtWrapper_CTKCore.
+  PythonQt::self()->registerCPPClass("ctkCoreUtils", "", "CTKCore", PythonQtCreateObject<PythonQtWrapper_CTKCore>);
 }
 
 #endif

--- a/Libs/Core/ctkUtils.cpp
+++ b/Libs/Core/ctkUtils.cpp
@@ -413,3 +413,53 @@ qint64 ctk::msecsTo(const QDateTime& t1, const QDateTime& t2)
   return static_cast<qint64>(utcT1.daysTo(utcT2)) * static_cast<qint64>(1000*3600*24)
       + static_cast<qint64>(utcT1.time().msecsTo(utcT2.time()));
 }
+
+//------------------------------------------------------------------------------
+QString ctk::absolutePathFromInternal(const QString& internalPath, const QString& basePath)
+{
+  if (internalPath.isEmpty())
+  {
+    return internalPath;
+  }
+  if (QFileInfo(internalPath).isRelative())
+  {
+    QDir baseDirectory(basePath);
+    return QDir::cleanPath(baseDirectory.filePath(internalPath));
+  }
+  else
+  {
+    return internalPath;
+  }
+}
+
+//------------------------------------------------------------------------------
+QString ctk::internalPathFromAbsolute(const QString& absolutePath, const QString& basePath)
+{
+  if (absolutePath.isEmpty())
+  {
+    return absolutePath;
+  }
+  // Make it a relative path if it is within the base folder
+  if (QFileInfo(absolutePath).isRelative())
+  {
+    // already relative path, return it as is
+    return absolutePath;
+  }
+  QString baseFolderClean = QDir::cleanPath(QDir::fromNativeSeparators(basePath));
+  QString absolutePathClean = QDir::cleanPath(QDir::fromNativeSeparators(absolutePath));
+#ifdef Q_OS_WIN32
+  Qt::CaseSensitivity sensitivity = Qt::CaseInsensitive;
+#else
+  Qt::CaseSensitivity sensitivity = Qt::CaseSensitive;
+#endif
+  if (absolutePathClean.startsWith(baseFolderClean, sensitivity))
+  {
+    // file is in the base folder, make it a relative path
+    // (remove size+1 to remove the leading forward slash)
+    return absolutePathClean.remove(0, baseFolderClean.size() + 1);
+  }
+  else
+  {
+    return absolutePath;
+  }
+}

--- a/Libs/Core/ctkUtils.h
+++ b/Libs/Core/ctkUtils.h
@@ -168,6 +168,17 @@ QString CTK_CORE_EXPORT qtHandleToString(Qt::HANDLE handle);
 /// bumping the minimum required Qt version for CTK.
 qint64 CTK_CORE_EXPORT msecsTo(const QDateTime& t1, const QDateTime& t2);
 
+/// Get absolute path from an "internal" path. If internal path is already an absolute path
+/// then that is returned unchanged. If internal path is relative path then basePath is used
+/// as a basis (prepended to internalPath).
+QString CTK_CORE_EXPORT absolutePathFromInternal(const QString& internalPath, const QString& basePath);
+
+/// Get "internal" path from an absolute path. internalPath will be a relative path if
+/// absolutePath is within the basePath, otherwise interalPath will be the same as absolutePath.
+/// This is useful for paths/directories relative to a base folder, to make the data or application relocatable.
+/// Absolute path can be retrieved from an internal path using absolutePathFromInternal function.
+QString CTK_CORE_EXPORT internalPathFromAbsolute(const QString& absolutePath, const QString& basePath);
+
 }
 
 #endif

--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.h
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.h
@@ -61,6 +61,7 @@ class CTK_DICOM_WIDGETS_EXPORT ctkDICOMBrowser : public QWidget
   Q_ENUMS(ImportDirectoryMode)
   Q_PROPERTY(QString databaseDirectory READ databaseDirectory WRITE setDatabaseDirectory)
   Q_PROPERTY(QString databaseDirectorySettingsKey READ databaseDirectorySettingsKey WRITE setDatabaseDirectorySettingsKey)
+  Q_PROPERTY(QString databaseDirectoryBase READ databaseDirectoryBase WRITE setDatabaseDirectoryBase)
   Q_PROPERTY(int patientsAddedDuringImport READ patientsAddedDuringImport)
   Q_PROPERTY(int studiesAddedDuringImport READ studiesAddedDuringImport)
   Q_PROPERTY(int seriesAddedDuringImport READ seriesAddedDuringImport)
@@ -91,6 +92,15 @@ public:
   /// Calling this method sets DatabaseDirectory from current value stored in the settings
   /// (overwriting current value of DatabaseDirectory).
   void setDatabaseDirectorySettingsKey(const QString& settingsKey);
+
+  /// Get the directory that will be used as a basis if databaseDirectory is specified with a relative path.
+  /// @see setDatabaseDirectoryBase, setDatabaseDirectory
+  QString databaseDirectoryBase() const;
+
+  /// Set the directory that will be used as a basis if databaseDirectory is specified with a relative path.
+  /// If DatabaseDirectoryBase is empty (by default it is) then the current working directory is used as a basis.
+/// @see databaseDirectoryBase, setDatabaseDirectory
+  void setDatabaseDirectoryBase(const QString& base);
 
   /// See ctkDICOMDatabase for description - these accessors
   /// delegate to the corresponding routines of the internal


### PR DESCRIPTION
Previously full path was stored to DICOM files that were copied into the DICOM database. This made it impossible to move the database into any other location or store in on removable storage (such as a USB stick, which may be mapped with different path on different computers).

Now files that are copied (not linked) to the DICOM database are stored with path relative to the DICOM database folder (where the .sql files are located).

Also, DICOM database location can now be specified with relative path in application settings. This allows the database to be moved along with the application. For example, to implement a DICOM viewer that opens DICOM database in a folder relative to the application's location (e.g., use the application as a viewer on a DICOM CD).

FYI @cpinter @jcfr 