### PR TITLE
ENH: Allow using custom DICOM schema and database update roles extern…

### DIFF
--- a/Libs/DICOM/Core/CMakeLists.txt
+++ b/Libs/DICOM/Core/CMakeLists.txt
@@ -12,6 +12,7 @@ set(KIT_SRCS
   ctkDICOMAbstractThumbnailGenerator.h
   ctkDICOMDatabase.cpp
   ctkDICOMDatabase.h
+  ctkDICOMDatabase_p.h
   ctkDICOMItem.h
   ctkDICOMDisplayedFieldGenerator.cpp
   ctkDICOMDisplayedFieldGenerator.h

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -80,6 +80,7 @@ ctkDICOMDatabasePrivate::ctkDICOMDatabasePrivate(ctkDICOMDatabase& o)
   , TagCacheVerified(false)
   , DisplayedFieldsTableAvailable(false)
   , UseShortStoragePath(true)
+  , SchemaVersion("0.6.3")
 {
   this->resetLastInsertedValues();
   this->DisplayedFieldGenerator = new ctkDICOMDisplayedFieldGenerator(q_ptr);
@@ -1684,10 +1685,10 @@ QString ctkDICOMDatabase::schemaVersionLoaded()
 }
 
 //------------------------------------------------------------------------------
-void ctkDICOMDatabase::setCustomSchemaVersion(QString customSchemaVersion)
+void ctkDICOMDatabase::setSchemaVersion(QString schemaVersion)
 {
   Q_D(ctkDICOMDatabase);
-  d->CustomSchemaVersion = customSchemaVersion;
+  d->SchemaVersion = schemaVersion;
 }
 
 //------------------------------------------------------------------------------
@@ -1699,19 +1700,8 @@ QString ctkDICOMDatabase::schemaVersion()
   // * make sure the 'Images' contains a 'Filename' column
   //   so that the ctkDICOMDatabasePrivate::filenames method
   //   still works.
-  //
-  // Return custom schema version if specified.
-  // Custom schema version is a way to use a custom schema without
-  // subclassing the DICOM database
   Q_D(ctkDICOMDatabase);
-  if (d->CustomSchemaVersion.isEmpty())
-  {
-    return QString("0.6.3");
-  }
-  else
-  {
-    return d->CustomSchemaVersion;
-  }
+  return d->SchemaVersion;
 };
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -33,6 +33,7 @@ class QDateTime;
 class ctkDICOMDatabasePrivate;
 class DcmDataset;
 class ctkDICOMAbstractThumbnailGenerator;
+class ctkDICOMDisplayedFieldGenerator;
 
 /// \ingroup DICOM_Core
 ///
@@ -155,6 +156,9 @@ public:
   /// in order to support schema updating
   Q_INVOKABLE QString schemaVersionLoaded();
 
+  /// Set custom schema version externally in case a non-standard schema is used
+  Q_INVOKABLE void setCustomSchemaVersion(QString customSchemaVersion);
+
   /// \brief database accessors
   Q_INVOKABLE QStringList patients();
   Q_INVOKABLE QStringList studiesForPatient(const QString patientUID);
@@ -271,6 +275,8 @@ public:
   /// Get if displayed fields are defined. It returns false for databases that were created with an old schema
   /// that did not contain ColumnDisplayProperties table.
   Q_INVOKABLE bool isDisplayedFieldsTableAvailable() const;
+  /// Get displayed field generator in order to be able to set new rules externally
+  ctkDICOMDisplayedFieldGenerator* displayedFieldGenerator() const;
 
   /// Reset cached item IDs to make sure previous
   /// inserts do not interfere with upcoming insert operations.

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -156,8 +156,8 @@ public:
   /// in order to support schema updating
   Q_INVOKABLE QString schemaVersionLoaded();
 
-  /// Set custom schema version externally in case a non-standard schema is used
-  Q_INVOKABLE void setCustomSchemaVersion(QString customSchemaVersion);
+  /// Set schema version externally in case a non-standard schema is used
+  Q_INVOKABLE void setSchemaVersion(QString schemaVersion);
 
   /// \brief database accessors
   Q_INVOKABLE QStringList patients();

--- a/Libs/DICOM/Core/ctkDICOMDatabase_p.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase_p.h
@@ -181,7 +181,7 @@ public:
   bool insertSeries( const ctkDICOMItem& dataset, QString studyInstanceUID);
 
   /// Facilitate using custom schema with the database without subclassing
-  QString CustomSchemaVersion;
+  QString SchemaVersion;
 };
 
 #endif

--- a/Libs/DICOM/Core/ctkDICOMDatabase_p.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase_p.h
@@ -1,0 +1,187 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+#ifndef __ctkDICOMDatabase_p_h
+#define __ctkDICOMDatabase_p_h
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the CTK API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+// ctkDICOM includes
+#include "ctkDICOMDatabase.h"
+#include "ctkDICOMDisplayedFieldGenerator.h"
+
+class CTK_DICOM_CORE_EXPORT ctkDICOMDatabasePrivate
+{
+  Q_DECLARE_PUBLIC(ctkDICOMDatabase);
+protected:
+  ctkDICOMDatabase* const q_ptr;
+
+public:
+  ctkDICOMDatabasePrivate(ctkDICOMDatabase&);
+  ~ctkDICOMDatabasePrivate();
+  void init(QString databaseFile);
+  void registerCompressionLibraries();
+  bool executeScript(const QString script);
+
+  /// Run a query and prints debug output of status
+  bool loggedExec(QSqlQuery& query);
+  bool loggedExec(QSqlQuery& query, const QString& queryString);
+  bool loggedExecBatch(QSqlQuery& query);
+  bool LoggedExecVerbose;
+
+  bool removeImage(const QString& sopInstanceUID);
+
+  /// Store copy of the dataset in database folder.
+  /// If the original file is available then that will be inserted. If not then a file is created from the dataset object.
+  bool storeDatasetFile(const ctkDICOMItem& dataset, const QString& originalFilePath,
+    const QString& studyInstanceUID, const QString& seriesInstanceUID, const QString& sopInstanceUID, QString& storedFilePath);
+
+  /// Helper function that generates folders for storing an instance in the database.
+  /// Folders are based on UIDs, but may be shortened.
+  QString internalStoragePath(const QString& studyInstanceUID,
+    const QString& seriesInstanceUID, const QString& sopInstanceUID);
+
+  /// Returns false in case of an error
+  bool indexingStatusForFile(const QString& filePath, const QString& sopInstanceUID, bool& datasetInDatabase, bool& datasetUpToDate, QString& databaseFilename);
+
+  /// Retrieve thumbnail from file and store in database folder.
+  bool storeThumbnailFile(const QString& originalFilePath,
+    const QString& studyInstanceUID, const QString& seriesInstanceUID, const QString& sopInstanceUID);
+
+  /// Get basic UIDs for a data set, return true if the data set has all the required tags
+  bool uidsForDataSet(const ctkDICOMItem& dataset, QString& patientsName, QString& patientID, QString& studyInstanceUID, QString& seriesInstanceUID);
+  bool uidsForDataSet(QString& patientsName, QString& patientID, QString& studyInstanceUID);
+
+  /// Dataset must be set always
+  /// \param filePath It has to be set if this is an import of an actual file
+  void insert ( const ctkDICOMItem& dataset, const QString& filePath, bool storeFile = true, bool generateThumbnail = true);
+
+  /// Copy the complete list of files to an extra table
+  QStringList allFilesInDatabase();
+
+  /// Update database tables from the displayed fields determined by the plugin roles
+  /// \return Success flag
+  bool applyDisplayedFieldsChanges( QMap<QString, QMap<QString, QString> > &displayedFieldsMapSeries,
+                                    QMap<QString, QMap<QString, QString> > &displayedFieldsMapStudy,
+                                    QMap<QString, QMap<QString, QString> > &displayedFieldsMapPatient );
+
+  /// Find patient by composite patient ID and return its index and insert it in the given fields map
+  /// \param displayedFieldsMapPatient Map of patient field maps (name, value pairs) to which the found patient
+  ///   is inserted on success. Also contains the generated patient index
+  /// \return The composite patient ID if successfully found, empty string otherwise
+  QString getDisplayPatientFieldsKey(const QString& patientID, const QString& patientsName, const QString& patientsBirthDate,
+    QMap<QString, QMap<QString, QString> >& displayedFieldsMapPatient);
+
+  /// Find study by instance UID and insert it in the given fields map
+  /// \param displayedFieldsMapStudy Map of study field maps (name, value pairs) to which the found study has been inserted on success
+  /// \return The study instance UID if successfully found, empty string otherwise
+  QString getDisplayStudyFieldsKey(QString studyInstanceUID, QMap<QString, QMap<QString, QString> > &displayedFieldsMapStudy);
+
+  /// Find series by instance UID and insert it in the given fields map
+  /// \param displayedFieldsMapSeries Map of series field maps (name, value pairs) to which the found series has been inserted on success
+  /// \return The series instance UID if successfully found, empty string otherwise
+  QString getDisplaySeriesFieldsKey(QString seriesInstanceUID, QMap<QString, QMap<QString, QString> > &displayedFieldsMapSeries);
+
+  /// Get all Filename values from table
+  QStringList filenames(QString table);
+
+  QVector<QMap<QString /*DisplayField*/, QString /*Value*/> > displayedFieldsVectorPatient; // The index in the vector is the internal patient UID
+  /// Calculate count (number of objects in interest) for each series in the displayed fields container
+  /// \param displayedFieldsMapSeries (SeriesInstanceUID -> (DisplayField -> Value) )
+  void setCountToSeriesDisplayedFields(QMap<QString, QMap<QString, QString> > &displayedFieldsMapSeries);
+  /// Calculate number of series for each study in the displayed fields container
+  /// \param displayedFieldsMapStudy (StudyInstanceUID -> (DisplayField -> Value) )
+  void setNumberOfSeriesToStudyDisplayedFields(QMap<QString, QMap<QString, QString> > &displayedFieldsMapStudy);
+  /// Calculate number of studies for each patient in the displayed fields container
+  /// \param displayedFieldsVectorPatient (Internal_ID -> (DisplayField -> Value) )
+  void setNumberOfStudiesToPatientDisplayedFields(QMap<QString, QMap<QString, QString> >& displayedFieldsMapPatient);
+  /// Determine last study date for each patient in the displayed fields container
+  /// \param displayedFieldsVectorPatient (Internal_ID -> (DisplayField -> Value) )
+  void setLastStudyDateToPatientDisplayedFields(QMap<QString, QMap<QString, QString> >& displayedFieldsMapPatient);
+
+  int rowCount(const QString& tableName);
+
+  /// Convert an internal path (absolute or relative to database folder) to an absolute path.
+  QString absolutePathFromInternal(const QString& filename);
+  /// Convert an absolute path to an internal path (absolute if outside database folder, relative if inside database folder).
+  QString internalPathFromAbsolute(const QString& filename);
+
+  /// Name of the database file (i.e. for SQLITE the sqlite file)
+  QString DatabaseFileName;
+  QString LastError;
+  QSqlDatabase Database;
+  QMap<QString, QString> LoadedHeader;
+  bool DisplayedFieldsTableAvailable;
+
+  bool UseShortStoragePath;
+
+  ctkDICOMAbstractThumbnailGenerator* ThumbnailGenerator;
+
+  ctkDICOMDisplayedFieldGenerator* DisplayedFieldGenerator;
+
+  /// These are for optimizing the import of image sequences
+  /// since most information are identical for all slices.
+  /// It would be very expensive to check in the database
+  /// presence of all these records on each slice insertion,
+  /// therefore we cache recently added entries in memory.
+  QMap<QString, int> InsertedPatientsCompositeIDCache; // map from composite patient ID to database ID
+  QSet<QString> InsertedStudyUIDsCache;
+  QSet<QString> InsertedSeriesUIDsCache;
+
+  /// There is no unique patient ID. We use this composite ID in InsertedPatientsCompositeIDCache.
+  /// It is not a problem that is somewhat more strict than the criteria that is used to decide if a study should be insert
+  /// under the same patient.
+  QString compositePatientID(const QString& patientID, const QString& patientsName, const QString& patientsBirthDate);
+
+  /// resets the variables to new inserts won't be fooled by leftover values
+  void resetLastInsertedValues();
+
+  /// tagCache table has been checked to exist
+  bool TagCacheVerified;
+  /// tag cache has independent database to avoid locking issue
+  /// with other access to the database which need to be
+  /// reading while the tag cache is writing
+  QSqlDatabase TagCacheDatabase;
+  QString TagCacheDatabaseFilename;
+  QStringList TagsToPrecache;
+  QStringList TagsToExcludeFromStorage;
+  bool openTagCacheDatabase();
+  void precacheTags(const ctkDICOMItem& dataset, const QString sopInstanceUID);
+
+  // Return true if a new item is inserted
+  bool insertPatientStudySeries(const ctkDICOMItem& dataset, const QString& patientID, const QString& patientsName);
+  bool insertPatient(const ctkDICOMItem& dataset, int& databasePatientID);
+  bool insertStudy(const ctkDICOMItem& dataset, int dbPatientID);
+  bool insertSeries( const ctkDICOMItem& dataset, QString studyInstanceUID);
+
+  /// Facilitate using custom schema with the database without subclassing
+  QString CustomSchemaVersion;
+};
+
+#endif

--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGenerator.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGenerator.cpp
@@ -41,7 +41,7 @@ static ctkLogger logger("org.commontk.dicom.DICOMDisplayedFieldGenerator" );
 //------------------------------------------------------------------------------
 ctkDICOMDisplayedFieldGeneratorPrivate::ctkDICOMDisplayedFieldGeneratorPrivate(ctkDICOMDisplayedFieldGenerator& o)
   : q_ptr(&o)
-  , Database(NULL)
+  , Database(nullptr)
 {
   // register commonly used rules
   this->AllRules.append(new ctkDICOMDisplayedFieldGeneratorDefaultRule);
@@ -127,10 +127,43 @@ void ctkDICOMDisplayedFieldGenerator::updateDisplayedFieldsForInstance(
 }
 
 //------------------------------------------------------------------------------
+void ctkDICOMDisplayedFieldGenerator::startUpdate()
+{
+  Q_D(ctkDICOMDisplayedFieldGenerator);
+  foreach(ctkDICOMDisplayedFieldGeneratorAbstractRule* rule, d->AllRules)
+  {
+    rule->startUpdate();
+  }
+}
+
+//------------------------------------------------------------------------------
+void ctkDICOMDisplayedFieldGenerator::endUpdate(QMap<QString, QMap<QString, QString> > &displayedFieldsMapSeries,
+                                                QMap<QString, QMap<QString, QString> > &displayedFieldsMapStudy,
+                                                QMap<QString, QMap<QString, QString> > &displayedFieldsMapPatient)
+{
+  Q_D(ctkDICOMDisplayedFieldGenerator);
+  foreach(ctkDICOMDisplayedFieldGeneratorAbstractRule* rule, d->AllRules)
+  {
+    rule->endUpdate(displayedFieldsMapSeries, displayedFieldsMapStudy, displayedFieldsMapPatient);
+  }
+}
+
+//------------------------------------------------------------------------------
 void ctkDICOMDisplayedFieldGenerator::setDatabase(ctkDICOMDatabase* database)
 {
   Q_D(ctkDICOMDisplayedFieldGenerator);
-  d->Database=database;
+
+  if (d->Database == database)
+  {
+    return;
+  }
+
+  d->Database = database;
+
+  foreach(ctkDICOMDisplayedFieldGeneratorAbstractRule* rule, d->AllRules)
+  {
+    rule->setDatabase(database);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGenerator.h
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGenerator.h
@@ -67,6 +67,18 @@ public:
                                                     QMap<QString, QString> &displayedFieldsForCurrentStudy,
                                                     QMap<QString, QString> &displayedFieldsForCurrentPatient);
 
+  /// Start updating displayed fields (reset counters, etc.).
+  /// Calls function with same name of all registered rules.
+  Q_INVOKABLE void startUpdate();
+
+  /// End updating displayed fields (accumulate stored variables, compute final result, etc.).
+  /// Has a chance to update any field in the series, study, or patient field maps, based on
+  /// the maps themselves or the database.
+  /// Calls function with same name of all registered rules.
+  Q_INVOKABLE void endUpdate(QMap<QString, QMap<QString, QString> > &displayedFieldsMapSeries,
+                             QMap<QString, QMap<QString, QString> > &displayedFieldsMapStudy,
+                             QMap<QString, QMap<QString, QString> > &displayedFieldsMapPatient);
+
   /// Register new displayed field generator rule
   void registerDisplayedFieldGeneratorRule(ctkDICOMDisplayedFieldGeneratorAbstractRule* rule);
 

--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorAbstractRule.h
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorAbstractRule.h
@@ -64,6 +64,16 @@ public:
   /// Specify list of DICOM tags required by the rule. These tags will be included in the tag cache
   virtual QStringList getRequiredDICOMTags()=0;
 
+  /// Start updating displayed fields (reset counters, etc.). No-op by default.
+  virtual void startUpdate() { };
+
+  /// End updating displayed fields (accumulate stored variables, compute final result, etc.). No-op by default.
+  /// Has a chance to update any field in the series, study, or patient field maps, based on
+  /// the maps themselves or the database.
+  virtual void endUpdate(QMap<QString, QMap<QString, QString> > &displayedFieldsMapSeries,
+                         QMap<QString, QMap<QString, QString> > &displayedFieldsMapStudy,
+                         QMap<QString, QMap<QString, QString> > &displayedFieldsMapPatient) { };
+
   /// Utility function to convert a DICOM tag enum to string
   static QString dicomTagToString(const DcmTagKey& tag)
   {    
@@ -76,6 +86,11 @@ public:
   virtual void registerEmptyFieldNames(
     QMap<QString, QString> emptyFieldsSeries, QMap<QString, QString> emptyFieldsStudies, QMap<QString, QString> emptyFieldsPatients)=0;
 
+  /// Set DICOM database to the rule in case it needs to use it e.g. in \sa end().
+  void setDatabase(ctkDICOMDatabase* database) { this->DICOMDatabase = database; }
+
+// Static utility functions
+public:
   /// Utility function determining whether a given field is considered empty
   static bool isFieldEmpty(const QString &fieldName, const QMap<QString, QString> &fields, const QMap<QString, QString> &emptyValuesForEachField)
   {
@@ -160,6 +175,8 @@ public:
     mergedFields[fieldName]=initialFields[fieldName]+", "+newFields[fieldName];
   }
 
+protected:
+  ctkDICOMDatabase* DICOMDatabase;
 };
 
 #endif

--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRadiotherapySeriesDescriptionRule.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRadiotherapySeriesDescriptionRule.cpp
@@ -60,6 +60,9 @@ void ctkDICOMDisplayedFieldGeneratorRadiotherapySeriesDescriptionRule::registerE
   QMap<QString, QString> emptyFieldsDisplayStudies,
   QMap<QString, QString> emptyFieldsDisplayPatients )
 {
+  Q_UNUSED(emptyFieldsDisplayStudies);
+  Q_UNUSED(emptyFieldsDisplayPatients);
+
   emptyFieldsDisplaySeries.insertMulti("SeriesDescription", this->EmptySeriesDescriptionRtPlan);
   emptyFieldsDisplaySeries.insertMulti("SeriesDescription", this->EmptySeriesDescriptionRtStruct);
   emptyFieldsDisplaySeries.insertMulti("SeriesDescription", this->EmptySeriesDescriptionRtImage);

--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRadiotherapySeriesDescriptionRule.h
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRadiotherapySeriesDescriptionRule.h
@@ -28,7 +28,7 @@
 
 /// \ingroup DICOM_Core
 ///
-/// Default rule for generating displayed fields from DICOM fields
+/// Special rule for generating series description displayed fields for different RT modalities
 class CTK_DICOM_CORE_EXPORT ctkDICOMDisplayedFieldGeneratorRadiotherapySeriesDescriptionRule : public ctkDICOMDisplayedFieldGeneratorAbstractRule
 {
 public:


### PR DESCRIPTION
…ally

- Add setCustomSchemaVersion to be able to use custom schema version
- Expose displayed field generator in new function displayedFieldGenerator to be able to register roles defined externally
- Add startUpdate and endUpdate functions to displayed field generator. startUpdate can initialize the field update process and endUpdate can make final calculations. The endUpdate function receives the complete patient/study/series displayed field maps (as opposed to only the currently updated one in updateDisplayedFieldsForInstance)
- Allow the displayed field generator rules to access the DICOM database (it was already set to the generator class but was not used so far)
- Split ctkDICOMDatabase private implementation header into separate file to make the source code more manageable (as well as enabling subclassing the private class if needed)
- Minor fixes throughout the related code