### PR TITLE
BUG: Fix ctkVTKThresholdWidget 'pow' was not declared

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKThresholdWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKThresholdWidget.cpp
@@ -30,6 +30,9 @@
 // VTK includes
 #include <vtkPiecewiseFunction.h>
 
+// STD includes
+#include <cmath> // for pow
+
 //----------------------------------------------------------------------------
 static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkVTKThresholdWidget");
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Adding `<cmath>` header