### PR TITLE
COMP: FindDCMTK: fix wrong DCMTK_DIR in CTK-build/CTKConfig.cmake

### DIFF
--- a/Utilities/CMake/FindDCMTK.cmake
+++ b/Utilities/CMake/FindDCMTK.cmake
@@ -117,6 +117,11 @@
 
 set(_dcmtk_dir_description "The directory of DCMTK build or install tree.")
 
+if (DCMTK_FOUND AND NOT (DCMTK_DIR STREQUAL "/usr/include/dcmtk"))
+  message(STATUS "DCMTK already found: DCMTK_DIR=${DCMTK_DIR}")
+  return()
+endif()
+
 # Ensure that DCMTK_DIR is set to a reasonable default value
 # so that DCMTK libraries can be found on a standard Unix distribution.
 # It also overwrite the value of DCMTK_DIR after this one has been


### PR DESCRIPTION
This commit fixes an issue discovered when launching cpack on 3d slicer 4.11.20210226

find_package(DCMTK QUIET NO_MODULE) can overwrite DCMTK_DIR which was found previously without the NO_MODULE option.

This wrong DCMTK_DIR in CTK-build/CTKConfig.cmake breaks 3d slicer cpack which cannot find the dcmtk executables like storescu.