### PR TITLE
ENH: Make gradient opacity transfer function shift independently from opacity and color transfer functions

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKVolumePropertyWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKVolumePropertyWidget.h
@@ -59,21 +59,40 @@ public:
   bool isThresholdToggleVisible()const;
   void setThresholdToggleVisible(bool showToggle);
 
+  /// Get intensity bounds of the chart.
   void chartsBounds(double bounds[4])const;
+  /// Get intensity bounds of the chart.
   Q_INVOKABLE QList<double> chartsBounds()const;
+  /// Get intensity extents of the chart.
   void chartsExtent(double extent[4])const;
+  /// Get intensity extents of the chart.
   Q_INVOKABLE QList<double> chartsExtent()const;
+
+  /// Get gradient bounds of the chart.
+  void chartsGradientBounds(double bounds[4])const;
+  /// Get gradient bounds of the chart.
+  Q_INVOKABLE QList<double> chartsGradientBounds()const;
+  /// Get gradient  extents of the chart.
+  void chartsGradientExtent(double extent[4])const;
+  /// Get gradient extents of the chart.
+  Q_INVOKABLE QList<double> chartsGradientExtent()const;
 
 public Q_SLOTS:
   void setVolumeProperty(vtkVolumeProperty* volumeProperty);
 
-  /// Move all the control points of the opacity, colors and gradient
-  /// of a give offset.
+  /// Move all the control points of the opacity and colors
+  /// by a given offset.
   /// \sa vtkControlPoints::movePoints()
   void moveAllPoints(double xOffset, double yOffset = 0.,
                      bool dontSpreadFirstAndLast = false);
 
-  /// Spread all the control points of the opacity, colors and gradient
+  /// Move all the control points of the gradient opacity transfer function
+  /// by a given offset.
+  /// \sa vtkControlPoints::movePoints()
+  void moveAllGradientPoints(double xOffset, double yOffset = 0.,
+    bool dontSpreadFirstAndLast = false);
+
+  /// Spread all the control points of the opacity and colors
   /// by a given offset.
   /// A value >0 will space the control points, a value <0. will contract
   /// them.
@@ -81,11 +100,23 @@ public Q_SLOTS:
   void spreadAllPoints(double factor = 1.,
                        bool dontSpreadFirstAndLast = false);
 
+  /// Spread all the control points of the gradient opacity transfer function
+  /// by a given offset.
+  /// A value >0 will space the control points, a value <0. will contract
+  /// them.
+  /// \sa vtkControlPoints::spreadPoints()
+  void spreadAllGradientPoints(double factor = 1.,
+                       bool dontSpreadFirstAndLast = false);
+
   void setThresholdEnabled(bool enable);
 
-  /// Set chart extent
+  /// Set charts intensity extent
   void setChartsExtent(double extent[2]);
   void setChartsExtent(double min, double max);
+
+  /// Set charts gradient extent
+  void setChartsGradientExtent(double extent[2]);
+  void setChartsGradientExtent(double min, double max);
 
 Q_SIGNALS:
   void thresholdEnabledChanged(bool enable);


### PR DESCRIPTION
X axis of scalar opacity and color transfer functions is image intensity, so it makes sense to shift them together along the x axis.

However, x axis of gradient opacity transfer function is the image intensity gradient, therefore it should not be changed when the image is offset along x axis.
