### PR TITLE
ENH: Change DICOM displayed field update in indexing to use custom rules

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMIndexer.cpp
+++ b/Libs/DICOM/Core/ctkDICOMIndexer.cpp
@@ -124,7 +124,6 @@ void ctkDICOMIndexerPrivateWorker::start()
     emit progressStep("Updating database displayed fields");
     emit progress(this->TimePercentageIndexing);
 
-    database.updateDisplayedFields();
     patientsCountAfter = database.patientsCount();
     studiesCountAfter = database.studiesCount();
     seriesCountAfter = database.seriesCount();
@@ -283,6 +282,9 @@ ctkDICOMIndexerPrivate::ctkDICOMIndexerPrivate(ctkDICOMIndexer& o)
   connect(worker, &ctkDICOMIndexerPrivateWorker::updatingDatabase, q_ptr, &ctkDICOMIndexer::updatingDatabase);
   connect(worker, &ctkDICOMIndexerPrivateWorker::indexingComplete, q_ptr, &ctkDICOMIndexer::indexingComplete);
 
+  // Update displayed fields after each indexing run
+  connect(q_ptr, SIGNAL(indexingComplete(int,int,int,int)), this, SLOT(onIndexingComplete(int,int,int,int)));
+
   this->WorkerThread.start();
 }
 
@@ -309,6 +311,20 @@ void ctkDICOMIndexerPrivate::pushIndexingRequest(const DICOMIndexingQueue::Index
     this->Database->allFilesModifiedTimes(modifiedTimeForFilepath);
     this->RequestQueue.setModifiedTimeForFilepath(modifiedTimeForFilepath);
     emit startWorker();
+  }
+}
+
+//------------------------------------------------------------------------------
+void ctkDICOMIndexerPrivate::onIndexingComplete(int patientsAdded, int studiesAdded, int seriesAdded, int imagesAdded)
+{
+  Q_UNUSED(patientsAdded);
+  Q_UNUSED(studiesAdded);
+  Q_UNUSED(seriesAdded);
+  Q_UNUSED(imagesAdded);
+
+  if (this->Database)
+  {
+    this->Database->updateDisplayedFields();
   }
 }
 

--- a/Libs/DICOM/Core/ctkDICOMIndexer_p.h
+++ b/Libs/DICOM/Core/ctkDICOMIndexer_p.h
@@ -257,7 +257,8 @@ public:
 Q_SIGNALS:
   void startWorker();
 
-//public Q_SLOTS:
+public Q_SLOTS:
+  void onIndexingComplete(int patientsAdded, int studiesAdded, int seriesAdded, int imagesAdded);
 
 public:
   DICOMIndexingQueue RequestQueue;


### PR DESCRIPTION
The function that updates displayed fields after DICOM indexing uses an internal instance of the database, which does not contain the displayed field generator rules that may be registered externally. The update displayed fields step has been moved to the main thread using the database set to the indexer, so that it has access to the custom rules.