### PR TITLE
ENH: Improve usability of Directory Button by using native dialog

### DIFF
--- a/Libs/Widgets/ctkFileDialog.cpp
+++ b/Libs/Widgets/ctkFileDialog.cpp
@@ -67,17 +67,24 @@ void ctkFileDialogPrivate::init()
 {
   Q_Q(ctkFileDialog);
 
-  this->observeAcceptButton();
+  if (!(q->options() & QFileDialog::DontUseNativeDialog))
+  {
+    this->observeAcceptButton();
 
-  QObject::connect(this->listView()->selectionModel(),
+    QObject::connect(this->listView()->selectionModel(),
                    SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
                    q, SLOT(onSelectionChanged()));
+  }
 }
 
 //------------------------------------------------------------------------------
 QPushButton* ctkFileDialogPrivate::acceptButton()const
 {
   Q_Q(const ctkFileDialog);
+  if (!(q->options() & QFileDialog::DontUseNativeDialog))
+  {
+    return NULL;  // Native dialog does not supporting modifying or getting widget elements.
+  }
   QDialogButtonBox* buttonBox = q->findChild<QDialogButtonBox*>();
   Q_ASSERT(buttonBox);
   QDialogButtonBox::StandardButton button =
@@ -127,13 +134,6 @@ ctkFileDialog::ctkFileDialog(QWidget *parentWidget,
 {
   Q_D(ctkFileDialog);
 
-// The findChild<QDialogButtonBox*>() call fails on Mac/Qt5 because native
-// dialogs don't publish any internals. No problems on other OS.
-// Can be applied to Qt4 as well, if problems arise there.
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
-  this->setOptions(DontUseNativeDialog);
-#endif
-
   d->init();
 }
 
@@ -145,6 +145,10 @@ ctkFileDialog::~ctkFileDialog()
 //------------------------------------------------------------------------------
 void ctkFileDialog::setBottomWidget(QWidget* widget, const QString& label)
 {
+  if (!(this->options() & QFileDialog::DontUseNativeDialog))
+  {
+    return;  // Native dialog does not supporting modifying or getting widget elements.
+  }
   QGridLayout* gridLayout = qobject_cast<QGridLayout*>(this->layout());
   QWidget* oldBottomWidget = this->bottomWidget();
   // remove the old widget from the layout if any

--- a/Libs/Widgets/ctkFileDialog.cpp
+++ b/Libs/Widgets/ctkFileDialog.cpp
@@ -51,6 +51,7 @@ public:
   bool AcceptButtonEnable;
   bool AcceptButtonState;
   bool IgnoreEvent;
+  bool UsingNativeDialog;
 };
 
 //------------------------------------------------------------------------------
@@ -60,20 +61,21 @@ ctkFileDialogPrivate::ctkFileDialogPrivate(ctkFileDialog& object)
   this->IgnoreEvent = false;
   this->AcceptButtonEnable = true;
   this->AcceptButtonState = true;
+  this->UsingNativeDialog = true;
 }
 
 //------------------------------------------------------------------------------
 void ctkFileDialogPrivate::init()
 {
   Q_Q(ctkFileDialog);
-
-  if (!(q->options() & QFileDialog::DontUseNativeDialog))
+  this->UsingNativeDialog = !(q->options() & QFileDialog::DontUseNativeDialog);
+  if (!(this->UsingNativeDialog))
   {
     this->observeAcceptButton();
 
     QObject::connect(this->listView()->selectionModel(),
-                   SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
-                   q, SLOT(onSelectionChanged()));
+                    SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
+                    q, SLOT(onSelectionChanged()));
   }
 }
 
@@ -81,7 +83,7 @@ void ctkFileDialogPrivate::init()
 QPushButton* ctkFileDialogPrivate::acceptButton()const
 {
   Q_Q(const ctkFileDialog);
-  if (!(q->options() & QFileDialog::DontUseNativeDialog))
+  if (this->UsingNativeDialog)
   {
     return NULL;  // Native dialog does not supporting modifying or getting widget elements.
   }
@@ -145,7 +147,8 @@ ctkFileDialog::~ctkFileDialog()
 //------------------------------------------------------------------------------
 void ctkFileDialog::setBottomWidget(QWidget* widget, const QString& label)
 {
-  if (!(this->options() & QFileDialog::DontUseNativeDialog))
+  Q_D(ctkFileDialog);
+  if (d->UsingNativeDialog)
   {
     return;  // Native dialog does not supporting modifying or getting widget elements.
   }


### PR DESCRIPTION
This aims to improve directory selection by using the native dialog instead of Qt's own widget-based dialog design.

See 3D Slicer forum discussion of how users have been doing other methods to avoid using widgets that use Qt's widget-based dialog.
https://discourse.slicer.org/t/using-native-file-dialog-for-selecting-files-and-folders/17926

| Qt widget-based dialog | Native dialog (on Windows)|
|-------------------------|--------------------------------|
|![image](https://user-images.githubusercontent.com/15837524/120825251-3051dd80-c527-11eb-83a4-1a0c2c03971c.png)|![image](https://user-images.githubusercontent.com/15837524/120825677-9e96a000-c527-11eb-8200-2c2a4cecc8ae.png)|
