### PR TITLE
BUG: Fix crash instantiating ctkDICOMBrowser

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
@@ -327,7 +327,7 @@ void ctkDICOMBrowserPrivate::init()
   this->QueryRetrieveWidget = new ctkDICOMQueryRetrieveWidget();
   this->QueryRetrieveWidget->setWindowModality ( Qt::ApplicationModal );
   this->QueryRetrieveWidget->useProgressDialog(true);
-  
+
   this->dicomTableManager->setDICOMDatabase(this->DICOMDatabase.data());
 
   // TableView signals
@@ -529,7 +529,7 @@ void ctkDICOMBrowser::createNewDatabaseDirectory()
         if (defaultSubfolderName.isEmpty())
         {
           defaultSubfolderName = defaultFolderInfo.dir().dirName();
-        }          
+        }
         baseFolder += "/" + defaultSubfolderName;
       }
     }
@@ -918,6 +918,10 @@ void ctkDICOMBrowser::onImportDirectoryComboBoxCurrentIndexChanged(int index)
 {
   Q_D(ctkDICOMBrowser);
   Q_UNUSED(index);
+  if (!(d->ImportDialog->options() & QFileDialog::DontUseNativeDialog))
+  {
+    return;  // Native dialog does not support modifying or getting widget elements.
+  }
   QComboBox* comboBox = d->ImportDialog->bottomWidget()->findChild<QComboBox*>();
   ctkDICOMBrowser::ImportDirectoryMode mode =
       static_cast<ctkDICOMBrowser::ImportDirectoryMode>(comboBox->itemData(index).toInt());
@@ -1030,6 +1034,10 @@ void ctkDICOMBrowser::setImportDirectoryMode(ctkDICOMBrowser::ImportDirectoryMod
   if (!d->ImportDialog)
   {
     return;
+  }
+  if (!(d->ImportDialog->options() & QFileDialog::DontUseNativeDialog))
+  {
+    return;  // Native dialog does not support modifying or getting widget elements.
   }
   QComboBox* comboBox = d->ImportDialog->bottomWidget()->findChild<QComboBox*>();
   comboBox->setCurrentIndex(comboBox->findData(mode));
@@ -1565,7 +1573,6 @@ void ctkDICOMBrowser::exportSelectedItems(ctkDICOMModel::IndexType level)
 {
   Q_D(const ctkDICOMBrowser);
   ctkFileDialog* directoryDialog = new ctkFileDialog();
-  directoryDialog->setOption(QFileDialog::DontUseNativeDialog);
   directoryDialog->setOption(QFileDialog::ShowDirsOnly);
   directoryDialog->setFileMode(QFileDialog::DirectoryOnly);
   bool res = directoryDialog->exec();

--- a/Libs/Widgets/ctkFileDialog.cpp
+++ b/Libs/Widgets/ctkFileDialog.cpp
@@ -85,7 +85,7 @@ QPushButton* ctkFileDialogPrivate::acceptButton()const
   Q_Q(const ctkFileDialog);
   if (this->UsingNativeDialog)
   {
-    return NULL;  // Native dialog does not supporting modifying or getting widget elements.
+    return NULL;  // Native dialog does not support modifying or getting widget elements.
   }
   QDialogButtonBox* buttonBox = q->findChild<QDialogButtonBox*>();
   Q_ASSERT(buttonBox);
@@ -150,7 +150,7 @@ void ctkFileDialog::setBottomWidget(QWidget* widget, const QString& label)
   Q_D(ctkFileDialog);
   if (d->UsingNativeDialog)
   {
-    return;  // Native dialog does not supporting modifying or getting widget elements.
+    return;  // Native dialog does not support modifying or getting widget elements.
   }
   QGridLayout* gridLayout = qobject_cast<QGridLayout*>(this->layout());
   QWidget* oldBottomWidget = this->bottomWidget();

--- a/Libs/Widgets/ctkFileDialog.cpp
+++ b/Libs/Widgets/ctkFileDialog.cpp
@@ -69,7 +69,7 @@ void ctkFileDialogPrivate::init()
 {
   Q_Q(ctkFileDialog);
   this->UsingNativeDialog = !(q->options() & QFileDialog::DontUseNativeDialog);
-  if (!(this->UsingNativeDialog))
+  if (!this->UsingNativeDialog)
   {
     this->observeAcceptButton();
 

--- a/Libs/Widgets/ctkFileDialog.cpp
+++ b/Libs/Widgets/ctkFileDialog.cpp
@@ -197,6 +197,10 @@ QWidget* ctkFileDialog::bottomWidget()const
 void ctkFileDialog::setSelectionMode(QAbstractItemView::SelectionMode mode)
 {
   Q_D(ctkFileDialog);
+  if (d->UsingNativeDialog)
+  {
+    return;  // Native dialog does not support modifying or getting widget elements.
+  }
   foreach(QAbstractItemView* view, QList<QAbstractItemView*>()
           << d->listView()
           << d->treeView()


### PR DESCRIPTION
Following up to https://github.com/commontk/CTK/pull/973, this makes changes for ctkDICOMBrowser to not crash on initialization. @lassoan Would you like to make the additional DICOM related changes here now that the "Copy" import mode wouldn't be used? I'm a user that does not do any DICOM work so I do not know what would be appropriate behavior.