### PR TITLE
BUG: avoid app freeze on mac

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
@@ -763,8 +763,9 @@ void ctkDICOMBrowser::openImportDialog()
 {
   Q_D(ctkDICOMBrowser);
 
-  d->ImportDialog->show();
-  d->ImportDialog->raise();
+  //d->ImportDialog->show();
+  //d->ImportDialog->raise();
+  d->ImportDialog->exec();
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
@@ -763,8 +763,6 @@ void ctkDICOMBrowser::openImportDialog()
 {
   Q_D(ctkDICOMBrowser);
 
-  //d->ImportDialog->show();
-  //d->ImportDialog->raise();
   d->ImportDialog->exec();
 }
 

--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
@@ -785,6 +785,7 @@ void ctkDICOMBrowser::openQueryDialog()
 {
   Q_D(ctkDICOMBrowser);
 
+  // QueryRetrieveWidget is a QWidget not a QDialog, so use this instead of exec
   d->QueryRetrieveWidget->show();
   d->QueryRetrieveWidget->raise();
 }


### PR DESCRIPTION
After recent changes to allow native file browsers,
clicking the button would apparently create a dialog
on mac but it was not visible.  Because it was modal
the app would be alive but unresponive.

This change replaces show() and raise() which work
for QDialog with exec() which is apparently needed
for the native dialog to work properly.

https://discourse.slicer.org/t/slicer-is-freezing-on-macos-when-clicking-on-import-dicom-files/18624

Co-authored-by: Andras Lasso <lasso@queensu.ca>