### PR TITLE
Added python bindings for `ctkCheckableHeaderView`

### DIFF
--- a/Libs/Widgets/ctkCheckableHeaderView.h
+++ b/Libs/Widgets/ctkCheckableHeaderView.h
@@ -103,15 +103,15 @@ public:
   /// Utility function that returns the checkState of the section. 
   /// One can access the same value through the model:
   /// model->headerData(orientation, section, Qt::CheckStateRole)
-  Qt::CheckState checkState(int section)const;
+  Q_INVOKABLE Qt::CheckState checkState(int section)const;
 
   ///
   /// Utility function that returns the checkState of the section. 
   /// One can access the same value through the model:
   /// model->headerData(orientation, section, Qt::CheckStateRole)
-  bool checkState(int section,Qt::CheckState& checkState )const;
+  Q_INVOKABLE bool checkState(int section,Qt::CheckState& checkState )const;
   
-  ctkCheckableModelHelper* checkableModelHelper()const;
+  Q_INVOKABLE ctkCheckableModelHelper* checkableModelHelper()const;
 
 public Q_SLOTS:
   ///

--- a/Libs/Widgets/ctkWidgetsPythonQtDecorators.h
+++ b/Libs/Widgets/ctkWidgetsPythonQtDecorators.h
@@ -31,6 +31,7 @@
 #include <ctkTransferFunctionGradientItem.h>
 #include <ctkWidgetsUtils.h>
 #include <ctkWorkflowWidgetStep.h>
+#include <ctkCheckableHeaderView.h>
 
 // NOTE:
 //
@@ -143,6 +144,13 @@ public Q_SLOTS:
     delete obj;
     }
 
+  // ctkCheckableHeaderView
+
+  ctkCheckableHeaderView *new_ctkCheckableHeaderView(Qt::Orientation orient, QWidget *parent = 0) 
+    {
+    return new ctkCheckableHeaderView(orient, parent);
+    }
+
 };
 
 //-----------------------------------------------------------------------------
@@ -169,6 +177,7 @@ void initCTKWidgetsPythonQtDecorators()
   PythonQt::self()->registerClass(&ctkTransferFunctionBarsItem::staticMetaObject, "CTKWidgets");
   PythonQt::self()->registerClass(&ctkTransferFunctionControlPointsItem::staticMetaObject, "CTKWidgets");
   PythonQt::self()->registerClass(&ctkTransferFunctionGradientItem::staticMetaObject, "CTKWidgets");
+  PythonQt::self()->registerClass(&ctkCheckableHeaderView::staticMetaObject, "CTKWidgets");
 
   PythonQt::self()->addDecorators(new ctkWidgetsPythonQtDecorators);
 


### PR DESCRIPTION
`ctkCheckableHeaderView` used to be missing in python #793. 
I modified CTK such that class constructor: `ctkCheckableHeaderView(Qt::Orientation, QWidget *parent)` is now accessible from python. 
Also I moved two overloaded methods `ctkCheckableHeaderView::checkState(...)` to `public Q_SLOTS` so they are now also accessible from python.