### PR TITLE
BUG: don't try to update null database

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
@@ -377,7 +377,10 @@ void ctkDICOMQueryRetrieveWidget::retrieve()
     logger.info ( "Retrieve success" );
     }
 
-  retrieve->database()->updateDisplayedFields();
+  if (retrieve->database())
+    {
+    retrieve->database()->updateDisplayedFields();
+    }
 
   if(d->UseProgressDialog)
     {


### PR DESCRIPTION
Retrieve database is not created when there are no
studies selected leading to a crash.

Now there is no attempt to update a null database.

https://github.com/Slicer/Slicer/issues/5244