### PR TITLE
COMP: Fix -Wunused-parameter in ctkVTKRenderView::lookFromAxis()

### DIFF
--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest1.cpp
@@ -73,12 +73,12 @@ int ctkVTKRenderViewTest1(int argc, char * argv [] )
   renderView.renderer()->AddActor(sphereActor.GetPointer());
 
   renderView.lookFromAxis(ctkAxesWidget::Right);
-  renderView.lookFromAxis(ctkAxesWidget::Left, 10);
-  renderView.lookFromAxis(ctkAxesWidget::Anterior, 1.);
-  renderView.lookFromAxis(ctkAxesWidget::Posterior, 1.);
-  renderView.lookFromAxis(ctkAxesWidget::Superior, 0.333333);
-  renderView.lookFromAxis(ctkAxesWidget::Inferior, 0.333333);
-  renderView.lookFromAxis(ctkAxesWidget::None, 100.);
+  renderView.lookFromAxis(ctkAxesWidget::Left);
+  renderView.lookFromAxis(ctkAxesWidget::Anterior);
+  renderView.lookFromAxis(ctkAxesWidget::Posterior);
+  renderView.lookFromAxis(ctkAxesWidget::Superior);
+  renderView.lookFromAxis(ctkAxesWidget::Inferior);
+  renderView.lookFromAxis(ctkAxesWidget::None);
 
   if (!interactive)
     {

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest2.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewTest2.cpp
@@ -82,12 +82,12 @@ int ctkVTKRenderViewTest2(int argc, char * argv [] )
   renderView.renderer()->AddActor(sphereActor.GetPointer());
 
   renderView.lookFromAxis(ctkAxesWidget::Right);
-  renderView.lookFromAxis(ctkAxesWidget::Left, 10);
-  renderView.lookFromAxis(ctkAxesWidget::Anterior, 1.);
-  renderView.lookFromAxis(ctkAxesWidget::Posterior, 1.);
-  renderView.lookFromAxis(ctkAxesWidget::Superior, 0.333333);
-  renderView.lookFromAxis(ctkAxesWidget::Inferior, 0.333333);
-  renderView.lookFromAxis(ctkAxesWidget::None, 100.);
+  renderView.lookFromAxis(ctkAxesWidget::Left);
+  renderView.lookFromAxis(ctkAxesWidget::Anterior);
+  renderView.lookFromAxis(ctkAxesWidget::Posterior);
+  renderView.lookFromAxis(ctkAxesWidget::Superior);
+  renderView.lookFromAxis(ctkAxesWidget::Inferior);
+  renderView.lookFromAxis(ctkAxesWidget::None);
 
   if (!interactive)
     {

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp
@@ -492,6 +492,16 @@ void ctkVTKRenderView::resetFocalPoint()
 void ctkVTKRenderView::lookFromAxis(const ctkAxesWidget::Axis& axis, double fov)
 {
   Q_UNUSED(fov);
+  // The FOV parameter is not used anymore. It was not a good idea to force changing
+  // the camera distance from the focal point when the user only requested a view direction
+  // change.
+  qWarning() << "This function is deprecated. Use lookFromAxis(const ctkAxesWidget::Axis& axis) instead";
+  this->lookFromAxis(axis);
+}
+
+//----------------------------------------------------------------------------
+void ctkVTKRenderView::lookFromAxis(const ctkAxesWidget::Axis& axis)
+{
   Q_D(ctkVTKRenderView);
   Q_ASSERT(d->Renderer);
   if (!d->Renderer->IsActiveCameraCreated())

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp
@@ -491,6 +491,7 @@ void ctkVTKRenderView::resetFocalPoint()
 //----------------------------------------------------------------------------
 void ctkVTKRenderView::lookFromAxis(const ctkAxesWidget::Axis& axis, double fov)
 {
+  Q_UNUSED(fov);
   Q_D(ctkVTKRenderView);
   Q_ASSERT(d->Renderer);
   if (!d->Renderer->IsActiveCameraCreated())

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
@@ -120,8 +120,12 @@ public Q_SLOTS:
 
   /// \brief Change camera to look from a given axis to the focal point
   /// Translate/Rotate the camera to look from a given axis
-  /// The Field of View (fov) controls how far from the focal point the
-  /// camera must be (final_pos = focal_point + 3*fov).
+  void lookFromAxis(const ctkAxesWidget::Axis& axis);
+
+  /// \deprecated
+  /// \brief Change camera to look from a given axis to the focal point
+  /// Translate/Rotate the camera to look from a given axis
+  /// \sa lookFromAxis(const ctkAxesWidget::Axis&)
   void lookFromAxis(const ctkAxesWidget::Axis& axis, double fov = 10.);
 
 public:


### PR DESCRIPTION
The fov parameter became obsolete following d620ad9 (BUG: Fix
unexpected camera position change in ctkVTKRenderView::lookFromAxis)