### PR TITLE
ENH: Add API to select items in the DICOM browser

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.h
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.h
@@ -241,6 +241,11 @@ public Q_SLOTS:
 
   void removeSelectedItems(ctkDICOMModel::IndexType level);
 
+  /// Select items in a browser table.
+  /// Selection is also updated at levels higher than the specified level
+  /// (otherwise items would not be available at the current level).
+  void setSelectedItems(ctkDICOMModel::IndexType level, QStringList uids);
+
 Q_SIGNALS:
   /// Emitted when directory is changed
   void databaseDirectoryChanged(const QString&);

--- a/Libs/DICOM/Widgets/ctkDICOMTableManager.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMTableManager.cpp
@@ -252,6 +252,27 @@ QStringList ctkDICOMTableManager::currentSeriesSelection()
 }
 
 //------------------------------------------------------------------------------
+void ctkDICOMTableManager::setCurrentPatientsSelection(const QStringList& uids)
+{
+  Q_D(ctkDICOMTableManager);
+  d->patientsTable->setCurrentSelection(uids);
+}
+
+//------------------------------------------------------------------------------
+void ctkDICOMTableManager::setCurrentStudiesSelection(const QStringList& uids)
+{
+  Q_D(ctkDICOMTableManager);
+  d->studiesTable->setCurrentSelection(uids);
+}
+
+//------------------------------------------------------------------------------
+void ctkDICOMTableManager::setCurrentSeriesSelection(const QStringList& uids)
+{
+  Q_D(ctkDICOMTableManager);
+  d->seriesTable->setCurrentSelection(uids);
+}
+
+//------------------------------------------------------------------------------
 void ctkDICOMTableManager::onPatientsQueryChanged(const QStringList &uids)
 {
   Q_D(ctkDICOMTableManager);

--- a/Libs/DICOM/Widgets/ctkDICOMTableManager.h
+++ b/Libs/DICOM/Widgets/ctkDICOMTableManager.h
@@ -85,6 +85,13 @@ public:
   Q_INVOKABLE QStringList currentStudiesSelection();
   Q_INVOKABLE QStringList currentSeriesSelection();
 
+  /**
+   * @brief Set the current selection of the dicomTableViews
+   */
+  Q_INVOKABLE void setCurrentPatientsSelection(const QStringList& uids);
+  Q_INVOKABLE void setCurrentStudiesSelection(const QStringList& uids);
+  Q_INVOKABLE void setCurrentSeriesSelection(const QStringList& uids);
+
   void setDynamicTableLayout(bool);
   bool dynamicTableLayout() const;
 

--- a/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
@@ -292,7 +292,7 @@ void ctkDICOMTableViewPrivate::applyColumnProperties()
     int columnIndicesCount = columnIndicesByVisualIndex.size();
     for (int i=0; i<columnIndicesCount-1; ++i)
     {
-      // Last i elements are already in place    
+      // Last i elements are already in place
       for (int j=0; j<columnIndicesCount -i-1; ++j)
       {
         if (columnIndicesByVisualIndex[j] > columnIndicesByVisualIndex[j+1])
@@ -306,7 +306,7 @@ void ctkDICOMTableViewPrivate::applyColumnProperties()
   // Change column order according to weights (use bubble sort)
   for (int i=0; i<columnCount-1; ++i)
   {
-    // Last i elements are already in place    
+    // Last i elements are already in place
     for (int j=0; j<columnCount-i-1; ++j)
     {
       if (columnWeights[j] > columnWeights[j+1])
@@ -800,6 +800,30 @@ QStringList ctkDICOMTableView::currentSelection() const
 }
 
 //------------------------------------------------------------------------------
+void ctkDICOMTableView::setCurrentSelection(const QStringList& uids)
+{
+  Q_D(const ctkDICOMTableView);
+
+  QAbstractItemModel* tableModel = d->tblDicomDatabaseView->model();
+  int numberOfRows = tableModel->rowCount();
+  for (int row = 0; row < numberOfRows; ++row)
+  {
+    QModelIndex index = tableModel->index(row, 0);
+    QString uid = index.data().toString();
+    bool needToSelect = uids.contains(uid);
+    if (d->tblDicomDatabaseView->selectionModel()->isSelected(index) == needToSelect)
+    {
+      // selection state is already correct
+      continue;
+    }
+    QItemSelectionModel::QItemSelectionModel::SelectionFlags flags = QFlags<QItemSelectionModel::SelectionFlag>();
+    flags.setFlag(needToSelect ? QItemSelectionModel::Select : QItemSelectionModel::Deselect);
+    flags.setFlag(QItemSelectionModel::Rows);
+    d->tblDicomDatabaseView->selectionModel()->select(index, flags);
+  }
+}
+
+//------------------------------------------------------------------------------
 bool ctkDICOMTableView::filterActive()
 {
   Q_D(ctkDICOMTableView);
@@ -851,7 +875,7 @@ bool ctkDICOMTableView::setBatchUpdate(bool enable)
     {
       this->onInstanceAdded();
     }
-  }  
+  }
   d->batchUpdateModificationPending = false;
   d->batchUpdateInstanceAddedPending = false;
   return !d->batchUpdate;

--- a/Libs/DICOM/Widgets/ctkDICOMTableView.h
+++ b/Libs/DICOM/Widgets/ctkDICOMTableView.h
@@ -220,6 +220,11 @@ public:
   Q_INVOKABLE QStringList currentSelection() const;
 
   /**
+   * @brief Select rows corresponding to the provided uids.
+   */
+  Q_INVOKABLE void setCurrentSelection(const QStringList& uids);
+
+  /**
    * @brief Getting the UIDs for all rows
    * @return a QStringList with the uids for all rows
    */


### PR DESCRIPTION
Allow selecting patient/study/series in the DICOM browser GUI.

This is can be used for example for highlighting new items after DICOM import.
