### PR TITLE
Update ctkUtils adding qListToQSet and qSetToQList 

### DIFF
--- a/Libs/Core/Testing/Cpp/ctkUtilsTest.cpp
+++ b/Libs/Core/Testing/Cpp/ctkUtilsTest.cpp
@@ -44,6 +44,9 @@ private slots:
 
   void testQStringListToQSet();
   void testQStringListToQSet_data();
+
+  void testQSetToQStringList();
+  void testQSetToQStringList_data();
 };
 
 // ----------------------------------------------------------------------------
@@ -270,6 +273,29 @@ void ctkUtilsTester::testQStringListToQSet_data()
   QTest::newRow("0")
       << (QStringList() << "foo" << "bar" << "foo")
       << (QSet<QString>() << "foo" << "bar");
+}
+
+// ----------------------------------------------------------------------------
+void ctkUtilsTester::testQSetToQStringList()
+{
+  QFETCH(QSet<QString>, input);
+  QFETCH(QStringList, output);
+
+  QStringList current = ctk::qSetToQStringList(input);
+  current.sort();
+
+  QCOMPARE(current, output);
+}
+
+// ----------------------------------------------------------------------------
+void ctkUtilsTester::testQSetToQStringList_data()
+{
+  QTest::addColumn< QSet<QString> >("input");
+  QTest::addColumn< QStringList >("output");
+
+  QTest::newRow("0")
+      << (QSet<QString>() << "foo" << "bar")
+      << (QStringList() << "bar" << "foo");
 }
 
 // ----------------------------------------------------------------------------

--- a/Libs/Core/Testing/Cpp/ctkUtilsTest.cpp
+++ b/Libs/Core/Testing/Cpp/ctkUtilsTest.cpp
@@ -41,6 +41,9 @@ private slots:
 
   void testSignificantDecimals();
   void testSignificantDecimals_data();
+
+  void testQStringListToQSet();
+  void testQStringListToQSet_data();
 };
 
 // ----------------------------------------------------------------------------
@@ -250,7 +253,31 @@ void ctkUtilsTester::testSignificantDecimals_data()
 }
 
 // ----------------------------------------------------------------------------
+void ctkUtilsTester::testQStringListToQSet()
+{
+  QFETCH(QStringList, input);
+  QFETCH(QSet<QString>, output);
+
+  QCOMPARE(ctk::qStringListToQSet(input), output);
+}
+
+// ----------------------------------------------------------------------------
+void ctkUtilsTester::testQStringListToQSet_data()
+{
+  QTest::addColumn<QStringList>("input");
+  QTest::addColumn< QSet<QString> >("output");
+
+  QTest::newRow("0")
+      << (QStringList() << "foo" << "bar" << "foo")
+      << (QSet<QString>() << "foo" << "bar");
+}
+
+// ----------------------------------------------------------------------------
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+Q_DECLARE_METATYPE (QSet<QString>)
+#endif
+
+// ----------------------------------------------------------------------------
 CTK_TEST_MAIN(ctkUtilsTest)
 #include "moc_ctkUtilsTest.cpp"
-
 

--- a/Libs/Core/ctkUtils.cpp
+++ b/Libs/Core/ctkUtils.cpp
@@ -79,6 +79,16 @@ void ctk::stlVectorToQList(const std::vector<std::string>& vector,
   std::transform(vector.begin(),vector.end(),std::back_inserter(list),&QString::fromStdString);
 }
 
+//------------------------------------------------------------------------------
+QSet<QString> ctk::qStringListToQSet(const QStringList& list)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  return QSet<QString>(list.begin(), list.end());
+#else
+  return list.toSet();
+#endif
+}
+
 //-----------------------------------------------------------------------------
 const char *ctkNameFilterRegExp =
   "^(.*)\\(([a-zA-Z0-9_.*? +;#\\-\\[\\]@\\{\\}/!<>\\$%&=^~:\\|]*)\\)$";

--- a/Libs/Core/ctkUtils.cpp
+++ b/Libs/Core/ctkUtils.cpp
@@ -89,6 +89,16 @@ QSet<QString> ctk::qStringListToQSet(const QStringList& list)
 #endif
 }
 
+//------------------------------------------------------------------------------
+QStringList ctk::qSetToQStringList(const QSet<QString>& set)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  return QList<QString>(set.begin(), set.end());
+#else
+  return QStringList::fromSet(set);
+#endif
+}
+
 //-----------------------------------------------------------------------------
 const char *ctkNameFilterRegExp =
   "^(.*)\\(([a-zA-Z0-9_.*? +;#\\-\\[\\]@\\{\\}/!<>\\$%&=^~:\\|]*)\\)$";

--- a/Libs/Core/ctkUtils.h
+++ b/Libs/Core/ctkUtils.h
@@ -72,6 +72,15 @@ QSet<QString> CTK_CORE_EXPORT qStringListToQSet(const QStringList& list);
 
 ///
 /// \ingroup Core
+/// \brief Convert a set of strings to a QStringList
+///
+/// This method was added so that the same code compiles without deprecation warnings
+/// pre and post Qt 5.14.
+QStringList CTK_CORE_EXPORT qSetToQStringList(const QSet<QString>& set);
+
+
+///
+/// \ingroup Core
 /// Convert a nameFilter to a list of file extensions:
 /// "Images (*.png *.jpg *.tiff)" -> "*.png", "*.jpg", "*.tiff"
 /// Note: the nameFilter can be a simple wildcard "*.jpg" in that case, it

--- a/Libs/Core/ctkUtils.h
+++ b/Libs/Core/ctkUtils.h
@@ -64,6 +64,14 @@ void CTK_CORE_EXPORT stlVectorToQList(const std::vector<std::string>& vector, QS
 
 ///
 /// \ingroup Core
+/// \brief Convert a QStringList to a set.
+///
+/// This method was added so that the same code compiles without deprecation warnings
+/// pre and post Qt 5.14.
+QSet<QString> CTK_CORE_EXPORT qStringListToQSet(const QStringList& list);
+
+///
+/// \ingroup Core
 /// Convert a nameFilter to a list of file extensions:
 /// "Images (*.png *.jpg *.tiff)" -> "*.png", "*.jpg", "*.tiff"
 /// Note: the nameFilter can be a simple wildcard "*.jpg" in that case, it


### PR DESCRIPTION
These functions are useful to support building against `Qt>=5.14` and avoid
warnings like the following:

```
  /path/to/S/Base/QTApp/qSlicerApplicationHelper.txx:170:55: warning: 'toSet' is deprecated: Use QSet<T>(list.begin(), list.end()) instead. [-Wdeprecated-declarations]
          moduleFactoryManager->registeredModuleNames().toSet() - moduleFactoryManager->instantiatedModuleNames().toSet());
                                                        ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qlist.h:412:5: note: 'toSet' has been explicitly marked deprecated here
      QT_DEPRECATED_VERSION_X_5_14("Use QSet<T>(list.begin(), list.end()) instead.")
      ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qglobal.h:366:45: note: expanded from macro 'QT_DEPRECATED_VERSION_X_5_14'
  # define QT_DEPRECATED_VERSION_X_5_14(text) QT_DEPRECATED_X(text)
                                              ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
  #  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                  ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
  #    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
                                                        ^  
```

```

  /path/to/S/Base/QTApp/qSlicerApplicationHelper.txx:169:64: warning: 'fromSet' is deprecated: Use QList<T>(set.begin(), set.end()) instead. [-Wdeprecated-declarations]
    QStringList failedToBeInstantiatedModuleNames = QStringList::fromSet(
                                                                 ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qlist.h:410:5: note: 'fromSet' has been explicitly marked deprecated here
      QT_DEPRECATED_VERSION_X_5_14("Use QList<T>(set.begin(), set.end()) instead.")
      ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qglobal.h:366:45: note: expanded from macro 'QT_DEPRECATED_VERSION_X_5_14'
  # define QT_DEPRECATED_VERSION_X_5_14(text) QT_DEPRECATED_X(text)
                                              ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
  #  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                  ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
  #    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
                                                        ^
```