### PR TITLE
COMP: Update ctkMacroGenerateMocs to fix warnings using qt5_generate_moc

### DIFF
--- a/CMake/ctkMacroGenerateMocs.cmake
+++ b/CMake/ctkMacroGenerateMocs.cmake
@@ -3,9 +3,14 @@
 
 include(MacroAddFileDependencies)
 
-function(QT4_GENERATE_MOCS)
+function(_ctk_generate_mocs)
   if(CTK_QT_VERSION VERSION_GREATER "4")
-    QT5_GET_MOC_FLAGS(_moc_flags)
+    if(Qt5_VERSION VERSION_LESS "5.15.0")
+      QT5_GET_MOC_FLAGS(_moc_flags)
+    else()
+       # _moc_flags is not needed because it is internally handled
+       # by qt5_generate_moc called below.
+    endif()
   else()
     QT4_GET_MOC_FLAGS(_moc_flags)
   endif()
@@ -28,8 +33,12 @@ function(QT4_GENERATE_MOCS)
     if(CTK_QT_VERSION VERSION_GREATER "4")
       if(Qt5_VERSION VERSION_LESS "5.6")
         QT5_CREATE_MOC_COMMAND(${abs_file} ${moc_file} "${_moc_flags}" "" "")
-      else()
+      elseif(Qt5_VERSION VERSION_LESS "5.15.0")
         QT5_CREATE_MOC_COMMAND(${abs_file} ${moc_file} "${_moc_flags}" "" "" "")
+      else()
+        # qt5_generate_moc internally calls qt5_get_moc_flags and ensure
+        # no warnings are reported.
+        qt5_generate_moc(${abs_file} ${moc_file})
       endif()
     else()
       QT4_CREATE_MOC_COMMAND(${abs_file} ${moc_file} "${_moc_flags}" "" "")
@@ -38,7 +47,12 @@ function(QT4_GENERATE_MOCS)
   endforeach()
 endfunction()
 
+# create a Qt4 alias
+macro(QT4_GENERATE_MOCS)
+  _ctk_generate_mocs(${ARGN})
+endmacro()
+
 # create a Qt5 alias
 macro(QT5_GENERATE_MOCS)
-  QT4_GENERATE_MOCS(${ARGN})
+  _ctk_generate_mocs(${ARGN})
 endmacro()


### PR DESCRIPTION
This commit prepare the transition to Qt6 by fixing warnings like the following:

```
  CMake Warning (dev) at /path/to/Support/Qt/5.15.2/clang_64/lib/cmake/Qt5Core/Qt5CoreMacros.cmake:44 (message):
    qt5_get_moc_flags is not part of the official API, and might be removed in
    Qt 6.
  Call Stack (most recent call first):
    /path/to/Support/Qt/5.15.2/clang_64/lib/cmake/Qt5Core/Qt5CoreMacros.cmake:86 (_qt5_warn_deprecated)
    /path/to/Projects/S-r-v8/CTK/CMake/ctkMacroGenerateMocs.cmake:8 (QT5_GET_MOC_FLAGS)
    /path/to/Projects/S-r-v8/CTK/CMake/ctkMacroGenerateMocs.cmake:43 (QT4_GENERATE_MOCS)
    Modules/Loadable/VolumeRendering/Testing/Cxx/CMakeLists.txt:41 (QT5_GENERATE_MOCS)
```

```
  CMake Warning (dev) at /path/to/Support/Qt/5.15.2/clang_64/lib/cmake/Qt5Core/Qt5CoreMacros.cmake:44 (message):
    qt5_create_moc_command is not part of the official API, and might be
    removed in Qt 6.
  Call Stack (most recent call first):
    /path/to/Support/Qt/5.15.2/clang_64/lib/cmake/Qt5Core/Qt5CoreMacros.cmake:120 (_qt5_warn_deprecated)
    /path/to/Projects/S-r-v8/CTK/CMake/ctkMacroGenerateMocs.cmake:32 (QT5_CREATE_MOC_COMMAND)
    /path/to/Projects/S-r-v8/CTK/CMake/ctkMacroGenerateMocs.cmake:43 (QT4_GENERATE_MOCS)
    Modules/Loadable/VolumeRendering/Testing/Cxx/CMakeLists.txt:41 (QT5_GENERATE_MOCS)
  This warning is for project developers.  Use -Wno-dev to suppress it.
```