### PR TITLE
COMP: Fix QModelIndex::child() deprecation warnings

### DIFF
--- a/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerTreeWidget.cpp
+++ b/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerTreeWidget.cpp
@@ -22,6 +22,7 @@
 #include "ctkCmdLineModuleExplorerTreeWidget.h"
 #include "ctkCmdLineModuleExplorerShowXmlAction.h"
 
+#include <ctkUtils.h>
 #include <ctkCmdLineModuleFrontend.h>
 #include <ctkCmdLineModuleBackend.h>
 #include <ctkCmdLineModuleFrontendFactory.h>
@@ -277,8 +278,7 @@ ctkCmdLineModuleFrontend* ctkCmdLineModuleExplorerTreeWidget::createFrontend(con
 bool ModuleSortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
 {
   QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-
-  QModelIndex childIndex = index.child(0, 0);
+  QModelIndex childIndex = ctk::modelChildIndex(sourceModel(), index, 0, 0);
   if (childIndex.isValid())
   {
     int i = 0;
@@ -288,7 +288,7 @@ bool ModuleSortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelInd
       accept = this->filterAcceptsRow(childIndex.row(), index);
       if (accept) return true;
 
-      childIndex = index.child(++i, 0);
+      childIndex = ctk::modelChildIndex(sourceModel(), index, ++i, 0);
     }
     return false;
   }

--- a/Libs/Core/ctkModelTester.cpp
+++ b/Libs/Core/ctkModelTester.cpp
@@ -24,6 +24,7 @@
 
 // CTK includes
 #include "ctkModelTester.h"
+#include "ctkUtils.h"
 
 //-----------------------------------------------------------------------------
 class ctkModelTesterPrivate
@@ -292,7 +293,7 @@ void ctkModelTester::testParent(const QModelIndex& vparent)const
     for (int j = 0; j < d->Model->columnCount(vparent); ++j)
       {
       this->test(d->Model->hasIndex(i, j, vparent), "hasIndex should return true for int range {0->rowCount(), 0->columnCount()}");
-      QModelIndex child = vparent.child(i, j);
+      QModelIndex child = ctk::modelChildIndex(d->Model, vparent, i, j);
       this->test(child.row() == i, "A child's row must be the same as given");
       this->test(child.column() == j, "A child's column must be the same as given");
       QModelIndex childParent = child.parent();

--- a/Libs/Core/ctkUtils.cpp
+++ b/Libs/Core/ctkUtils.cpp
@@ -504,3 +504,18 @@ QTextStream& ctk::endl(QTextStream &stream)
   return stream << QLatin1Char('\n') << ctk::flush;
 #endif
 }
+
+//------------------------------------------------------------------------------
+QModelIndex ctk::modelChildIndex(QAbstractItemModel* item, const QModelIndex &parent, int row, int colum)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 8, 0))
+  if (!item)
+    {
+    return QModelIndex();
+    }
+  return item->index(row, colum, parent);
+#else
+  Q_UNUSED(item);
+  return parent.child(row, colum);
+#endif
+}

--- a/Libs/Core/ctkUtils.h
+++ b/Libs/Core/ctkUtils.h
@@ -22,9 +22,11 @@
 #define __ctkUtils_h
 
 // Qt includes
-#include <QStringList>
+#include <QAbstractItemModel>
 #include <QDateTime>
 #include <QDebug>
+#include <QModelIndex>
+#include <QStringList>
 
 // STD includes
 #include <vector>
@@ -214,6 +216,14 @@ CTK_CORE_EXPORT QTextStream &flush(QTextStream &stream);
 ///
 /// For Qt >= 5.14, it is equivalent to \a Qt::endl;
 CTK_CORE_EXPORT QTextStream & endl(QTextStream &stream);
+
+
+/// \ingroup Core
+/// \brief Returns the child of the model index that is stored in the given row and column.
+///
+/// This method was added so that the same code compiles without deprecation warnings
+/// pre and post Qt 5.8.
+CTK_CORE_EXPORT QModelIndex modelChildIndex(QAbstractItemModel* item, const QModelIndex &parent, int row, int colum);
 }
 
 #endif

--- a/Libs/DICOM/Core/ctkDICOMModel.cpp
+++ b/Libs/DICOM/Core/ctkDICOMModel.cpp
@@ -32,6 +32,9 @@
 // dcmtk includes
 #include "dcmtk/dcmdata/dcvrpn.h"
 
+// ctkCore includes
+#include "ctkUtils.h"
+
 // ctkDICOMCore includes
 #include "ctkDICOMModel.h"
 #include "ctkLogger.h"
@@ -742,7 +745,7 @@ bool ctkDICOMModel::setData(const QModelIndex &index, const QVariant &value, int
 
   for(int i=0; i<node->Children.count(); i++)
     {
-      this->setChildData(index.child(i,0), value, role);
+    this->setChildData(ctk::modelChildIndex(this, index, i, 0), value, role);
     }
 
   if(index.parent().isValid())
@@ -771,7 +774,7 @@ bool ctkDICOMModel::setChildData(const QModelIndex &index, const QVariant &value
 
   for(int i=0; i<node->Children.count(); i++)
     {
-      this->setData(index.child(i,0), value, role);
+    this->setData(ctk::modelChildIndex(this, index, i, 0), value, role);
     }
 
   return true;
@@ -801,7 +804,8 @@ bool ctkDICOMModel::setParentData(const QModelIndex &index, const QVariant &valu
 
     for(int i=0; i<index.model()->rowCount(index); i++)
       {
-      Node* childNode = d->nodeFromIndex(index.child(i,0));
+      QModelIndex childIndex = ctk::modelChildIndex(this, index, i, 0);
+      Node* childNode = d->nodeFromIndex(childIndex);
       if(childNode->Data[Qt::CheckStateRole].toUInt() == Qt::Checked)
         {
         checkedExist = true;

--- a/Libs/DICOM/Widgets/ctkDICOMItemView.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMItemView.cpp
@@ -27,6 +27,7 @@
 // CTK includes
 #include "ctkLogger.h"
 #include "ctkQImageView.h"
+#include "ctkUtils.h"
 
 // ctkDICOMCore includes
 #include "ctkDICOMFilterProxyModel.h"
@@ -148,12 +149,12 @@ void ctkDICOMItemViewPrivate::onPatientModelSelected(const QModelIndex &index){
     if(model){
         QModelIndex patientIndex = index;
         model->fetchMore(patientIndex);
-        QModelIndex studyIndex = patientIndex.child(0,0);
+        QModelIndex studyIndex = ctk::modelChildIndex(model, patientIndex, 0, 0);
         model->fetchMore(studyIndex);
-        QModelIndex seriesIndex = studyIndex.child(0,0);
+        QModelIndex seriesIndex = ctk::modelChildIndex(model, studyIndex, 0, 0);
         model->fetchMore(seriesIndex);
         int imageCount = model->rowCount(seriesIndex);
-        QModelIndex imageIndex = seriesIndex.child(imageCount/2,0);
+        QModelIndex imageIndex = ctk::modelChildIndex(model, seriesIndex, imageCount/2, 0);
 
         this->setImage(imageIndex);
     }else{
@@ -170,10 +171,10 @@ void ctkDICOMItemViewPrivate::onStudyModelSelected(const QModelIndex &index){
     if(model){
         QModelIndex studyIndex = index;
         model->fetchMore(studyIndex);
-        QModelIndex seriesIndex = studyIndex.child(0,0);
+        QModelIndex seriesIndex = ctk::modelChildIndex(model, studyIndex, 0, 0);
         model->fetchMore(seriesIndex);
         int imageCount = model->rowCount(seriesIndex);
-        QModelIndex imageIndex = seriesIndex.child(imageCount/2,0);
+        QModelIndex imageIndex = ctk::modelChildIndex(model, seriesIndex, imageCount/2, 0);
 
         this->setImage(imageIndex);
     }else{
@@ -191,7 +192,7 @@ void ctkDICOMItemViewPrivate::onSeriesModelSelected(const QModelIndex &index){
         QModelIndex seriesIndex = index;
         model->fetchMore(seriesIndex);
         int imageCount = model->rowCount(seriesIndex);
-        QModelIndex imageIndex = seriesIndex.child(imageCount/2,0);
+        QModelIndex imageIndex = ctk::modelChildIndex(model, seriesIndex, imageCount/2, 0);
 
         this->setImage(imageIndex);
     }else{

--- a/Libs/DICOM/Widgets/ctkDICOMThumbnailListWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMThumbnailListWidget.cpp
@@ -32,6 +32,7 @@
 
 // ctk includes
 #include "ctkLogger.h"
+#include "ctkUtils.h"
 
 // ctkWidgets includes
 #include "ctkFlowLayout.h"
@@ -106,11 +107,11 @@ void ctkDICOMThumbnailListWidgetPrivate
 
     for(int i=0; i<studyCount; i++)
       {
-      QModelIndex studyIndex = patientIndex.child(i, 0);
-      QModelIndex seriesIndex = studyIndex.child(0, 0);
+      QModelIndex studyIndex = ctk::modelChildIndex(model, patientIndex, i, 0);
+      QModelIndex seriesIndex = ctk::modelChildIndex(model, studyIndex, 0, 0);
       model->fetchMore(seriesIndex);
       const int imageCount = model->rowCount(seriesIndex);
-      QModelIndex imageIndex = seriesIndex.child(imageCount/2, 0);
+      QModelIndex imageIndex = ctk::modelChildIndex(model, seriesIndex, imageCount/2, 0);
       QString study = model->data(studyIndex, Qt::DisplayRole).toString();
       this->addThumbnailWidget(imageIndex, studyIndex, study);
       }
@@ -134,10 +135,10 @@ void ctkDICOMThumbnailListWidgetPrivate
 
   for(int i=0; i<seriesCount; i++)
     {
-    QModelIndex seriesIndex = studyIndex.child(i, 0);
+    QModelIndex seriesIndex = ctk::modelChildIndex(model, studyIndex, i, 0);
     model->fetchMore(seriesIndex);
     int imageCount = model->rowCount(seriesIndex);
-    QModelIndex imageIndex = seriesIndex.child(imageCount/2, 0);
+    QModelIndex imageIndex = ctk::modelChildIndex(model, seriesIndex, imageCount/2, 0);
     this->addThumbnailWidget(imageIndex, seriesIndex, model->data(seriesIndex, Qt::DisplayRole).toString());
     }
 }
@@ -160,7 +161,7 @@ void ctkDICOMThumbnailListWidgetPrivate
   logger.debug(QString("Thumbs: %1").arg(imageCount));
   for (int i = 0 ; i < imageCount ; i++ )
     {
-    QModelIndex imageIndex = seriesIndex.child(i,0);
+    QModelIndex imageIndex = ctk::modelChildIndex(model, seriesIndex, i, 0);
 
     this->addThumbnailWidget(imageIndex, imageIndex, QString("Image %1").arg(i));
     }


### PR DESCRIPTION
This commit introduces ctk::modelChildIndex() function so that the
same code compiles without deprecation warnings pre and post Qt 5.8.

It fixes warnings like the following:

```
  /path/to/S-r/CTK/Libs/DICOM/Core/ctkDICOMModel.cpp:745:32: warning: 'child' is deprecated: Use QAbstractItemModel::index [-Wdeprecated-declarations]
        this->setChildData(index.child(i,0), value, role);
                                 ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qabstractitemmodel.h:71:5: note: 'child' has been explicitly marked deprecated here
      QT_DEPRECATED_X("Use QAbstractItemModel::index") inline QModelIndex child(int row, int column) const;
      ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
  #  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                  ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
  #    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
                                                        ^
```

References:
* https://doc.qt.io/qt-5/qmodelindex-obsolete.html#child 

* Commit deprecating the function: https://github.com/qt/qtbase/commit/8dc45d5b7cd9637f28b2d872a834266b991bf434#diff-42185f7432a3738dc6ee6f3b1a0cc5db9d698da9f424f55b43c2070007b7fef7
* .. and the corresponding trivial (1 line) implementation is [here for 4,8](https://github.com/qt/qtbase/commit/8dc45d5b7cd9637f28b2d872a834266b991bf434#diff-42185f7432a3738dc6ee6f3b1a0cc5db9d698da9f424f55b43c2070007b7fef7L422-L423) or [here for 5.15](https://github.com/qt/qtbase/blob/5.15.2/src/corelib/itemmodels/qabstractitemmodel.h#L454)