### PR TITLE
Install all header for ctkMacroBuildLib

### DIFF
--- a/CMake/ctkMacroBuildLib.cmake
+++ b/CMake/ctkMacroBuildLib.cmake
@@ -210,6 +210,16 @@ ${${MY_EXPORT_CUSTOM_CONTENT_FROM_VARIABLE}}
     ${dynamicHeaders}
     DESTINATION ${CTK_INSTALL_INCLUDE_DIR} COMPONENT Development
     )
+  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/" # source directory
+    DESTINATION ${CTK_INSTALL_INCLUDE_DIR} # target directory
+    FILES_MATCHING # install only matched files
+    PATTERN "*.h" # select header files
+    )
+  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/" # source directory
+    DESTINATION ${CTK_INSTALL_INCLUDE_DIR} # target directory
+    FILES_MATCHING # install only matched files
+    PATTERN "*.tpp" # select header files
+    )
 
 endmacro()
 

--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -20,7 +20,7 @@
 
 #! \ingroup CMakeUtilities
 macro(ctkMacroSetupQt)
-  set(CTK_QT_VERSION "4" CACHE STRING "Expected Qt version")
+  set(CTK_QT_VERSION "5" CACHE STRING "Expected Qt version")
   mark_as_advanced(CTK_QT_VERSION)
 
   set_property(CACHE CTK_QT_VERSION PROPERTY STRINGS 4 5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,12 @@ foreach(file
   CMake/ctkFunctionGetGccVersion.cmake
   CMake/ctkFunctionGetCompilerVisibilityFlags.cmake
   CMake/ctkFunctionCompileSnippets.cmake
+  CMake/ctkFunctionGeneratePluginUseFile.cmake
+  CMake/ctkFunctionExtractPluginTargets.cmake
+  CMake/ctkFunctionGetAllPluginTargets.cmake
+  CMake/ctkFunctionGetTargetDependencies.cmake
+  CMake/ctkFunctionGetPluginDependencies.cmake
+  CMake/ctkMacroSetupPlugins.cmake
   )
   include(${file})
   install(FILES ${file} DESTINATION ${CTK_INSTALL_CMAKE_DIR} COMPONENT Development)


### PR DESCRIPTION
- default qt version set to qt5
- install all headers with `ctkMacroBuildLib` and  maintain the directory heirarchy