### PR TITLE
Add ctk::modelChildIndex implementation accepting const model

### DIFF
--- a/Libs/Core/ctkUtils.cpp
+++ b/Libs/Core/ctkUtils.cpp
@@ -519,3 +519,9 @@ QModelIndex ctk::modelChildIndex(QAbstractItemModel* item, const QModelIndex &pa
   return parent.child(row, column);
 #endif
 }
+
+//------------------------------------------------------------------------------
+QModelIndex ctk::modelChildIndex(const QAbstractItemModel* item, const QModelIndex &parent, int row, int column)
+{
+  return ctk::modelChildIndex(const_cast<QAbstractItemModel*>(item), parent, row, column);
+}

--- a/Libs/Core/ctkUtils.cpp
+++ b/Libs/Core/ctkUtils.cpp
@@ -506,16 +506,16 @@ QTextStream& ctk::endl(QTextStream &stream)
 }
 
 //------------------------------------------------------------------------------
-QModelIndex ctk::modelChildIndex(QAbstractItemModel* item, const QModelIndex &parent, int row, int colum)
+QModelIndex ctk::modelChildIndex(QAbstractItemModel* item, const QModelIndex &parent, int row, int column)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 8, 0))
   if (!item)
     {
     return QModelIndex();
     }
-  return item->index(row, colum, parent);
+  return item->index(row, column, parent);
 #else
   Q_UNUSED(item);
-  return parent.child(row, colum);
+  return parent.child(row, column);
 #endif
 }

--- a/Libs/Core/ctkUtils.h
+++ b/Libs/Core/ctkUtils.h
@@ -223,7 +223,7 @@ CTK_CORE_EXPORT QTextStream & endl(QTextStream &stream);
 ///
 /// This method was added so that the same code compiles without deprecation warnings
 /// pre and post Qt 5.8.
-CTK_CORE_EXPORT QModelIndex modelChildIndex(QAbstractItemModel* item, const QModelIndex &parent, int row, int colum);
+CTK_CORE_EXPORT QModelIndex modelChildIndex(QAbstractItemModel* item, const QModelIndex &parent, int row, int column);
 }
 
 #endif

--- a/Libs/Core/ctkUtils.h
+++ b/Libs/Core/ctkUtils.h
@@ -218,12 +218,15 @@ CTK_CORE_EXPORT QTextStream &flush(QTextStream &stream);
 CTK_CORE_EXPORT QTextStream & endl(QTextStream &stream);
 
 
+///@{
 /// \ingroup Core
 /// \brief Returns the child of the model index that is stored in the given row and column.
 ///
 /// This method was added so that the same code compiles without deprecation warnings
 /// pre and post Qt 5.8.
 CTK_CORE_EXPORT QModelIndex modelChildIndex(QAbstractItemModel* item, const QModelIndex &parent, int row, int column);
+CTK_CORE_EXPORT QModelIndex modelChildIndex(const QAbstractItemModel* item, const QModelIndex &parent, int row, int column);
+///}@
 }
 
 #endif


### PR DESCRIPTION
This will avoid explicit use of `const_cast` when function `ctk::modelChildIndex`
is called from const functions.