### PR TITLE
COMP: Add vtk < 9.1 guard for vtkConfigure.h

### DIFF
--- a/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
+++ b/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
@@ -24,7 +24,11 @@
 #include <vtkAlgorithmOutput.h>
 #include <vtkCamera.h>
 #include <vtkCellArray.h>
-#include <vtkConfigure.h>
+// Include vtkConfigure.h only if vtk version is < 9.1
+// since it has been deprecated.
+#if !(VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 1)
+  #include <vtkConfigure.h>
+#endif
 #include <vtkCornerAnnotation.h>
 #include <vtkImageData.h>
 #include <vtkImageMapper.h>


### PR DESCRIPTION
vtkConfigure.h has been deprecated and should only
be included if VTK version is < 9.1.