### PR TITLE
Add elide option to ctkPushButton and make ctkDirectoryButton elided by default

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkDirectoryButtonTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkDirectoryButtonTest1.cpp
@@ -37,17 +37,23 @@
 int ctkDirectoryButtonTest1(int argc, char * argv [] )
 {
   QApplication app(argc, argv);
-  
+
+  Qt::TextElideMode elideMode = Qt::ElideRight; // Qt::ElideNone
+
   QWidget topLevel;
   ctkDirectoryButton button;
-  
+  button.setElideMode(elideMode);
+
   QIcon defaultIcon = button.style()->standardIcon(QStyle::SP_DirIcon);
   QIcon icon = button.style()->standardIcon(QStyle::SP_MessageBoxQuestion);
   QIcon icon2 = button.style()->standardIcon(QStyle::SP_DesktopIcon);
 
   ctkDirectoryButton button2(".");
+  button2.setElideMode(elideMode);
   ctkDirectoryButton button3(icon, "..");
+  button3.setElideMode(elideMode);
   ctkDirectoryButton button4;
+  button4.setElideMode(elideMode);
   button4.setAcceptMode(QFileDialog::AcceptSave);
   button4.setOptions(button4.options() | ctkDirectoryButton::DontUseNativeDialog);
 
@@ -58,7 +64,7 @@ int ctkDirectoryButtonTest1(int argc, char * argv [] )
   layout->addRow("Top (..) directory with icon:", &button3);
   layout->addRow("Writable directory only:", &button4);
   topLevel.setLayout(layout);
-  
+
   button.setCaption("Select a directory");
   if (button.caption() != "Select a directory")
     {
@@ -94,7 +100,7 @@ int ctkDirectoryButtonTest1(int argc, char * argv [] )
     std::cerr << "ctkDirectoryButton::setIcon() failed." << std::endl;
     return EXIT_FAILURE;
     }
-  
+
 #ifdef USE_QFILEDIALOG_OPTIONS
   button.setOptions(QFileDialog::ShowDirsOnly | QFileDialog::ReadOnly);
   if (button.options() != (QFileDialog::ShowDirsOnly |
@@ -102,7 +108,7 @@ int ctkDirectoryButtonTest1(int argc, char * argv [] )
 #else
   button.setOptions(ctkDirectoryButton::ShowDirsOnly |
                     ctkDirectoryButton::ReadOnly);
-  
+
   if (button.options() != (ctkDirectoryButton::ShowDirsOnly |
                            ctkDirectoryButton::ReadOnly))
 #endif
@@ -116,7 +122,7 @@ int ctkDirectoryButtonTest1(int argc, char * argv [] )
 
   button.setDirectory(QDir::home().absolutePath());
   if ( QDir(button.directory()) != QDir::home() ||
-       spyDirectoryChanged.count() != 1 || 
+       spyDirectoryChanged.count() != 1 ||
        spyDirectorySelected.count() != 1)
     {
     std::cerr<< "ctkDirectoryButton::setDirectory failed" << button.directory().toStdString() << std::endl;
@@ -129,7 +135,7 @@ int ctkDirectoryButtonTest1(int argc, char * argv [] )
   button.setDirectory(QDir::home().absolutePath());
 
   if ( QDir(button.directory()) != QDir::home() ||
-       spyDirectoryChanged.count() != 0 || 
+       spyDirectoryChanged.count() != 0 ||
        spyDirectorySelected.count() != 1)
     {
     std::cerr<< "ctkDirectoryButton::setDirectory failed" << button.directory().toStdString() << std::endl;

--- a/Libs/Widgets/Testing/Cpp/ctkPushButtonTest.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkPushButtonTest.cpp
@@ -22,6 +22,7 @@
 #include <QApplication>
 #include <QHBoxLayout>
 #include <QSignalSpy>
+#include <QStyle>
 #include <QTimer>
 
 #if (QT_VERSION < 0x50000)
@@ -42,6 +43,85 @@ private slots:
   void testDefaults();
 };
 
+//-----------------------------------------------------------------------------
+class ctkButtonModeSwitcher : public QObject
+{
+  Q_OBJECT
+
+public:
+  ctkButtonModeSwitcher(ctkPushButton* aButton)
+    : button(aButton)
+    , mode(0)
+  {
+  }
+
+public slots:
+
+  void nextMode()
+  {
+    switch (mode)
+    {
+    case 0:
+      button->setText("text on the right side of button, icon is on the left side of the text (0)");
+      button->setIconAlignment(Qt::AlignHCenter);
+      button->setButtonTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+      break;
+    case 1:
+      button->setText("text on the right side of button, icon is on the left of the button (1)");
+      button->setIconAlignment(Qt::AlignLeft);
+      button->setButtonTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+      break;
+    case 2:
+      button->setText("text on the right side of button, icon is on the right of the button (2)");
+      button->setIconAlignment(Qt::AlignRight);
+      button->setButtonTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+      break;
+
+    case 3:
+      button->setText("text is the left side of button, icon is on the right side of the text (3)"); //!!!! moves! bad
+      button->setIconAlignment(Qt::AlignHCenter);
+      button->setButtonTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+      break;
+    case 4:
+      button->setText("text is the left side of button, icon is left of the button (4)");
+      button->setIconAlignment(Qt::AlignLeft);
+      button->setButtonTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+      break;
+    case 5:
+      button->setText("text is the left side of button, icon is right of the button (5)");
+      button->setIconAlignment(Qt::AlignRight);
+      button->setButtonTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+      break;
+
+    case 6:
+      button->setText("text is centered, icon is left of the text (6)");
+      button->setIconAlignment(Qt::AlignHCenter);
+      button->setButtonTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+      break;
+    case 7:
+      button->setText("text is centered, icon is left of the button (7)");
+      button->setIconAlignment(Qt::AlignLeft);
+      button->setButtonTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+      break;
+    case 8:
+      button->setText("text is centered, icon is right of the button (8)");
+      button->setIconAlignment(Qt::AlignRight);
+      button->setButtonTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+      break;
+    default:
+      mode = 0;
+      button->setElideMode(button->elideMode() == Qt::ElideMiddle ? Qt::ElideNone : Qt::ElideMiddle);
+      nextMode();
+      return;
+    }
+    this->mode++;
+  }
+private:
+  ctkPushButton* button;
+  int mode;
+};
+
+
 // ----------------------------------------------------------------------------
 void ctkPushButtonTester::testDefaults()
 {
@@ -49,10 +129,9 @@ void ctkPushButtonTester::testDefaults()
   QApplication::setStyle( new QCleanlooksStyle );
 #endif
 
-  ctkPushButton button("this is a long text so that elide mode of the button can be tested");
-  button.setElideMode(Qt::ElideMiddle);
+  ctkPushButton button("This is a long text. Click to to see more alignment modes.");
 
-  QCOMPARE(button.buttonTextAlignment(), Qt::AlignHCenter|Qt::AlignVCenter);
+  QCOMPARE(button.buttonTextAlignment(), Qt::AlignHCenter | Qt::AlignVCenter);
   QCOMPARE(button.iconAlignment(), Qt::AlignLeft|Qt::AlignVCenter);
 
   button.show();
@@ -62,6 +141,16 @@ void ctkPushButtonTester::testDefaults()
 #else
   QTest::qWaitForWindowShown(&button);
 #endif
+
+  button.setElideMode(Qt::ElideMiddle);
+
+  button.setIcon(qApp->style()->standardIcon(QStyle::SP_MessageBoxWarning));
+  button.show();
+
+  ctkButtonModeSwitcher switcher(&button);
+  QObject::connect(&button, SIGNAL(clicked()), &switcher, SLOT(nextMode()));
+
+  // Uncomment the next line for interactive testing.
   //qApp->exec();
 }
 

--- a/Libs/Widgets/Testing/Cpp/ctkPushButtonTest.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkPushButtonTest.cpp
@@ -49,7 +49,8 @@ void ctkPushButtonTester::testDefaults()
   QApplication::setStyle( new QCleanlooksStyle );
 #endif
 
-  ctkPushButton button("text");
+  ctkPushButton button("this is a long text so that elide mode of the button can be tested");
+  button.setElideMode(Qt::ElideMiddle);
 
   QCOMPARE(button.buttonTextAlignment(), Qt::AlignHCenter|Qt::AlignVCenter);
   QCOMPARE(button.iconAlignment(), Qt::AlignLeft|Qt::AlignVCenter);

--- a/Libs/Widgets/ctkDirectoryButton.cpp
+++ b/Libs/Widgets/ctkDirectoryButton.cpp
@@ -22,13 +22,13 @@
 #include <QDebug>
 #include <QFileSystemModel>
 #include <QHBoxLayout>
-#include <QPushButton>
 #include <QSortFilterProxyModel>
 #include <QStyle>
 
 // CTK includes
 #include "ctkDirectoryButton.h"
 #include "ctkFileDialog.h"
+#include "ctkPushButton.h"
 
 //-----------------------------------------------------------------------------
 class ctkDirectoryButtonPrivate
@@ -44,7 +44,7 @@ public:
   void updateDisplayText();
 
   QDir         Directory;
-  QPushButton* PushButton;
+  ctkPushButton* PushButton;
   QString      DialogCaption;
   QString      DisplayText;
 #ifdef USE_QFILEDIALOG_OPTIONS
@@ -74,7 +74,8 @@ ctkDirectoryButtonPrivate::ctkDirectoryButtonPrivate(ctkDirectoryButton& object)
 void ctkDirectoryButtonPrivate::init()
 {
   Q_Q(ctkDirectoryButton);
-  this->PushButton = new QPushButton(q);
+  this->PushButton = new ctkPushButton(q);
+  this->PushButton->setElideMode(Qt::ElideMiddle);  // truncate the middle of the path if does not fit
   QObject::connect(this->PushButton, SIGNAL(clicked()), q, SLOT(browse()));
   QHBoxLayout* l = new QHBoxLayout(q);
   l->addWidget(this->PushButton);
@@ -309,4 +310,23 @@ void ctkDirectoryButton::browse()
     return;
     }
   this->setDirectory(dir);
+}
+
+//-----------------------------------------------------------------------------
+void ctkDirectoryButton::setElideMode(Qt::TextElideMode newElideMode)
+{
+  Q_D(ctkDirectoryButton);
+  if (d->PushButton->elideMode() == newElideMode)
+  {
+    return;
+  }
+  d->PushButton->setElideMode(newElideMode);
+  this->update();
+}
+
+//-----------------------------------------------------------------------------
+Qt::TextElideMode ctkDirectoryButton::elideMode()const
+{
+  Q_D(const ctkDirectoryButton);
+  return d->PushButton->elideMode();
 }

--- a/Libs/Widgets/ctkDirectoryButton.cpp
+++ b/Libs/Widgets/ctkDirectoryButton.cpp
@@ -76,12 +76,13 @@ void ctkDirectoryButtonPrivate::init()
   Q_Q(ctkDirectoryButton);
   this->PushButton = new ctkPushButton(q);
   this->PushButton->setElideMode(Qt::ElideMiddle);  // truncate the middle of the path if does not fit
+  this->PushButton->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed, QSizePolicy::PushButton));
   QObject::connect(this->PushButton, SIGNAL(clicked()), q, SLOT(browse()));
   QHBoxLayout* l = new QHBoxLayout(q);
   l->addWidget(this->PushButton);
   l->setContentsMargins(0,0,0,0);
   q->setLayout(l);
-  q->setSizePolicy(QSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed, QSizePolicy::ButtonBox));
+  q->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed, QSizePolicy::ButtonBox));
 }
 
 //-----------------------------------------------------------------------------
@@ -316,12 +317,26 @@ void ctkDirectoryButton::browse()
 void ctkDirectoryButton::setElideMode(Qt::TextElideMode newElideMode)
 {
   Q_D(ctkDirectoryButton);
-  if (d->PushButton->elideMode() == newElideMode)
-  {
-    return;
-  }
   d->PushButton->setElideMode(newElideMode);
+
+  // Allow horizontal shrinking of the button if and only if elide is enabled.
+  // The internal pushbutton is not accessible from outside, therefore we must
+  // adjust the size policy internally.
+
+  QSizePolicy sizePolicy = d->PushButton->sizePolicy();
+  if (newElideMode == Qt::ElideNone)
+    {
+    sizePolicy.setHorizontalPolicy(QSizePolicy::Policy(sizePolicy.horizontalPolicy() & ~QSizePolicy::ShrinkFlag));
+    }
+  else
+    {
+    sizePolicy.setHorizontalPolicy(QSizePolicy::Policy(sizePolicy.horizontalPolicy() | QSizePolicy::ShrinkFlag));
+    }
+
+  d->PushButton->setSizePolicy(sizePolicy);
+
   this->update();
+  this->updateGeometry();
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Widgets/ctkDirectoryButton.h
+++ b/Libs/Widgets/ctkDirectoryButton.h
@@ -61,6 +61,10 @@ class CTK_WIDGETS_EXPORT ctkDirectoryButton: public QWidget
   /// This property holds the icon displayed on the button. QStyle::SP_DirIcon
   /// by default.
   Q_PROPERTY(QIcon icon READ icon WRITE setIcon)
+  /// This property controls how to display long paths.
+  /// By default elide mode is Qt::ElideMiddle (long paths are displayed
+  /// by replacing the center of by ellipses).
+  Q_PROPERTY(Qt::TextElideMode elideMode READ elideMode WRITE setElideMode)
   /// Qt versions prior to 4.7.0 didn't expose QFileDialog::Options in the
   /// public API. We need to create a custom property that will be used when
   /// instanciating a QFileDialog in ctkDirectoryButton::browse()
@@ -141,6 +145,14 @@ public:
 
   /// \sa acceptMode QFileDialog::AcceptMode
   void setAcceptMode(QFileDialog::AcceptMode mode);
+
+  /// setElideMode can elide the text displayed on the button.
+  /// Qt::ElideNone by default (sam as for a regular push button).
+  /// To prevent long paths forcing the button to take a lot of horizontal space,
+  /// set horizontal policy to QSizePolicy::Ignored and set elideMode to
+  /// Qt::ElideMiddle (or anything else than Qt::ElideNone).
+  void setElideMode(Qt::TextElideMode newMode);
+  Qt::TextElideMode elideMode()const; 
 
 public Q_SLOTS:
   /// browse() opens a pop up where the user can select a new directory for the

--- a/Libs/Widgets/ctkDirectoryButton.h
+++ b/Libs/Widgets/ctkDirectoryButton.h
@@ -43,6 +43,7 @@ class ctkDirectoryButtonPrivate;
 class CTK_WIDGETS_EXPORT ctkDirectoryButton: public QWidget
 {
   Q_OBJECT
+
   /// This property holds the accept mode of the dialog.
   /// The action mode defines whether the dialog is for opening or saving files.
   /// By default, this property is set to AcceptOpen.
@@ -51,20 +52,28 @@ class CTK_WIDGETS_EXPORT ctkDirectoryButton: public QWidget
   /// in a readonly one won't be selectable.
   /// AcceptOpen by default.
   Q_PROPERTY(QFileDialog::AcceptMode acceptMode READ acceptMode WRITE setAcceptMode)
+
+  /// This property stores the selected directory.
   Q_PROPERTY(QString directory READ directory WRITE setDirectory NOTIFY directoryChanged USER true)
+
   /// This property holds the title of the file dialog used to select a new directory
   /// If caption is not set, internally use QWidget::tooltip()
   Q_PROPERTY(QString caption READ caption WRITE setCaption)
+
   /// This property holds the text to display on the button. If null (by
   /// default), the current directory path is displayed instead.
   Q_PROPERTY(QString text READ text WRITE setText)
+
   /// This property holds the icon displayed on the button. QStyle::SP_DirIcon
   /// by default.
   Q_PROPERTY(QIcon icon READ icon WRITE setIcon)
+
   /// This property controls how to display long paths.
   /// By default elide mode is Qt::ElideMiddle (long paths are displayed
-  /// by replacing the center of by ellipses).
+  /// by replacing the center of by ellipses) to avoid displaying a long path
+  /// requiring lot of horizontal space.
   Q_PROPERTY(Qt::TextElideMode elideMode READ elideMode WRITE setElideMode)
+
   /// Qt versions prior to 4.7.0 didn't expose QFileDialog::Options in the
   /// public API. We need to create a custom property that will be used when
   /// instanciating a QFileDialog in ctkDirectoryButton::browse()

--- a/Libs/Widgets/ctkPathLineEdit.cpp
+++ b/Libs/Widgets/ctkPathLineEdit.cpp
@@ -298,7 +298,7 @@ ctkPathLineEditPrivate::ctkPathLineEditPrivate(ctkPathLineEdit& object)
   , ComboBox(0)
   , BrowseButton(0)
   , MinimumContentsLength(0)
-  , SizeAdjustPolicy(ctkPathLineEdit::AdjustToContentsOnFirstShow)
+  , SizeAdjustPolicy(ctkPathLineEdit::AdjustToMinimumContentsLength)
   , Filters(QDir::AllEntries | QDir::NoDotAndDotDot
       | QDir::Readable | QDir::Executable)
   , HasValidInput(false)

--- a/Libs/Widgets/ctkPathLineEdit.h
+++ b/Libs/Widgets/ctkPathLineEdit.h
@@ -61,11 +61,14 @@ class ctkPathLineEditPrivate;
 class CTK_WIDGETS_EXPORT ctkPathLineEdit: public QWidget
 {
   Q_OBJECT
-  Q_FLAGS(Filters)
-  Q_PROPERTY ( QString label READ label WRITE setLabel )
 
-  Q_PROPERTY ( Filters filters READ filters WRITE setFilters)
-  Q_PROPERTY ( QString currentPath READ currentPath WRITE setCurrentPath USER true )
+  Q_PROPERTY(QString label READ label WRITE setLabel)
+
+  Q_PROPERTY(Filters filters READ filters WRITE setFilters)
+  Q_FLAGS(Filters)
+
+  Q_PROPERTY(QString currentPath READ currentPath WRITE setCurrentPath USER true)
+
   /// Qt versions prior to 4.7.0 didn't expose QFileDialog::Options in the
   /// public API. We need to create a custom property that will be used when
   /// instanciating a QFileDialog in ctkPathLineEdit::browse()
@@ -100,7 +103,8 @@ class CTK_WIDGETS_EXPORT ctkPathLineEdit: public QWidget
 
   /// This property holds the policy describing how the size of the path line edit widget
   /// changes when the content changes.
-  /// The default value is AdjustToContentsOnFirstShow.
+  /// The default value is AdjustToMinimumContentsLength to prevent displaying
+  /// of a long path making the layout too wide.
   Q_PROPERTY(SizeAdjustPolicy sizeAdjustPolicy READ sizeAdjustPolicy WRITE setSizeAdjustPolicy)
   Q_ENUMS(SizeAdjustPolicy)
 
@@ -228,7 +232,7 @@ public:
   void setMinimumContentsLength(int lenght);
 
   /// Return the combo box internally used by the path line edit
-  QComboBox* comboBox() const;
+  Q_INVOKABLE QComboBox* comboBox() const;
 
   /// The width returned, in pixels, is the length of the file name (with no
   /// path) if any. Otherwise, it's enough for 15 to 20 characters.

--- a/Libs/Widgets/ctkPushButton.cpp
+++ b/Libs/Widgets/ctkPushButton.cpp
@@ -36,6 +36,7 @@ ctkPushButtonPrivate::ctkPushButtonPrivate(ctkPushButton& object)
   this->ButtonTextAlignment = Qt::AlignHCenter | Qt::AlignVCenter;
   this->IconAlignment = Qt::AlignLeft | Qt::AlignVCenter;
   this->IconSpacing = 4;
+  this->ElideMode = Qt::ElideNone;
 }
 
 //-----------------------------------------------------------------------------
@@ -242,6 +243,25 @@ Qt::Alignment ctkPushButton::iconAlignment()const
 }
 
 //-----------------------------------------------------------------------------
+void ctkPushButton::setElideMode(Qt::TextElideMode newElideMode)
+{
+  Q_D(ctkPushButton);
+  if (d->ElideMode == newElideMode)
+  {
+    return;
+  }
+  d->ElideMode = newElideMode;
+  this->update();
+}
+
+//-----------------------------------------------------------------------------
+Qt::TextElideMode ctkPushButton::elideMode()const
+{
+  Q_D(const ctkPushButton);
+  return d->ElideMode;
+}
+
+//-----------------------------------------------------------------------------
 QSize ctkPushButton::minimumSizeHint()const
 {
   Q_D(const ctkPushButton);
@@ -331,6 +351,7 @@ void ctkPushButton::paintEvent(QPaintEvent * _event)
   // all the computations have been made infering the text would be left oriented
   tf &= ~Qt::AlignHCenter & ~Qt::AlignRight;
   tf |= Qt::AlignLeft;
+  QString elidedText = opt.fontMetrics.elidedText(opt.text, d->ElideMode, opt.rect.width());
   this->style()->drawItemText(&p, opt.rect, tf, opt.palette, (opt.state & QStyle::State_Enabled),
-                              opt.text, QPalette::ButtonText);
+                              elidedText, QPalette::ButtonText);
 }

--- a/Libs/Widgets/ctkPushButton.h
+++ b/Libs/Widgets/ctkPushButton.h
@@ -33,18 +33,25 @@ class ctkPushButtonPrivate;
 
 /// \ingroup Widgets
 /// Description
-/// ctkPushButton is an advanced QPushButton. It can control the alignment of text and icons.
+/// ctkPushButton is for displaying a QPushButton with an icon and optionally elided text.
+/// Alignment of the text and the icon is highly customizable.
 class CTK_WIDGETS_EXPORT ctkPushButton : public QPushButton
 {
   Q_OBJECT
+
   /// Set the alignment of the text on the button,
   /// Qt::AlignHCenter|Qt::AlignVCenter by default.
   /// \sa textAlignment(), setTextAlignment(), iconAlignment
   Q_PROPERTY(Qt::Alignment buttonTextAlignment READ buttonTextAlignment WRITE setButtonTextAlignment)
+
   /// Set the alignment of the icon with regard to the text.
   /// Qt::AlignLeft|Qt::AlignVCenter by default.
   /// \sa iconAlignment(), setIconAlignment(), textAlignment
   Q_PROPERTY(Qt::Alignment iconAlignment READ iconAlignment WRITE setIconAlignment)
+
+  /// Set the shortening of the button text by eliding.
+  /// Qt::ElideNone by default.
+  /// \sa elideMode(), setElideMode()
   Q_PROPERTY(Qt::TextElideMode elideMode READ elideMode WRITE setElideMode)
 
 public:

--- a/Libs/Widgets/ctkPushButton.h
+++ b/Libs/Widgets/ctkPushButton.h
@@ -45,6 +45,7 @@ class CTK_WIDGETS_EXPORT ctkPushButton : public QPushButton
   /// Qt::AlignLeft|Qt::AlignVCenter by default.
   /// \sa iconAlignment(), setIconAlignment(), textAlignment
   Q_PROPERTY(Qt::Alignment iconAlignment READ iconAlignment WRITE setIconAlignment)
+  Q_PROPERTY(Qt::TextElideMode elideMode READ elideMode WRITE setElideMode)
 
 public:
   ctkPushButton(QWidget *parent = 0);
@@ -68,6 +69,11 @@ public:
 
   virtual QSize minimumSizeHint()const;
   virtual QSize sizeHint()const;
+
+  /// setElideMode can shorten the text displayed on the button.
+  /// Qt::ElideNone by default (same as for a regular push button).
+  void setElideMode(Qt::TextElideMode newMode);
+  Qt::TextElideMode elideMode()const;
 
 protected:
   /// Reimplemented for internal reasons

--- a/Libs/Widgets/ctkPushButton_p.h
+++ b/Libs/Widgets/ctkPushButton_p.h
@@ -42,4 +42,5 @@ public:
   Qt::Alignment ButtonTextAlignment;
   Qt::Alignment IconAlignment;
   int IconSpacing;
+  Qt::TextElideMode ElideMode;
 };

--- a/Libs/Widgets/ctkPushButton_p.h
+++ b/Libs/Widgets/ctkPushButton_p.h
@@ -35,12 +35,13 @@ public:
   void init();
 
   virtual QRect iconRect() const;
-  virtual QSize buttonSizeHint()const;
+  virtual QSize buttonSizeHint(bool computeMinimum)const;
   virtual QStyleOptionButton drawIcon(QPainter* p);
 
   // Tuning of the button look&feel
   Qt::Alignment ButtonTextAlignment;
   Qt::Alignment IconAlignment;
+  /// Whitespace between the text and the icon
   int IconSpacing;
   Qt::TextElideMode ElideMode;
 };


### PR DESCRIPTION
Directory paths are often very long, which can force very wide GUI layouts if the full path is displayed.

To avoid this, ctkDirectoryButton now enables eliding by default (display beginning and end of the path with ... in the middle),
so that if the user sets size policy to Ignored then the button will not be wide and will display a correctly shortened path.

![image](https://user-images.githubusercontent.com/307929/146708299-6a6f8702-ead2-4dbd-b71d-0c8cd3c1f83f.png)
