### PR TITLE
ENH: Add option on using system library

### DIFF
--- a/CMakeExternals/DCMTK.cmake
+++ b/CMakeExternals/DCMTK.cmake
@@ -13,6 +13,10 @@ ExternalProject_Include_Dependencies(${proj}
   USE_SYSTEM_VAR ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj}
   )
 
+# Let the user to chose wheather to use libs installed in the system
+option(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj} "Use installed ${proj} library in the system" OFF)
+mark_as_advanced(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+
 if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   unset(DCMTK_DIR CACHE)
   find_package(DCMTK REQUIRED)

--- a/CMakeExternals/ITK.cmake
+++ b/CMakeExternals/ITK.cmake
@@ -13,6 +13,10 @@ ExternalProject_Include_Dependencies(${proj}
   USE_SYSTEM_VAR ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj}
   )
 
+# Let the user to chose wheather to use libs installed in the system
+option(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj} "Use installed ${proj} library in the system" OFF)
+mark_as_advanced(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+
 if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   unset(ITK_DIR CACHE)
   find_package(ITK REQUIRED NO_MODULE)

--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -13,6 +13,10 @@ ExternalProject_Include_Dependencies(${proj}
   USE_SYSTEM_VAR ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj}
   )
 
+# Let the user to chose wheather to use libs installed in the system
+option(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj} "Use installed ${proj} library in the system" OFF)
+mark_as_advanced(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+
 if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   unset(VTK_DIR CACHE)
   find_package(VTK REQUIRED NO_MODULE)


### PR DESCRIPTION
Tested on Windows10, MSVC16, VS2019. 
There are some issues with DCMTK. When compling DCMTK related plugins, it is required to put compiled libraries in some project folder to be able to continue compling.