### PR TITLE
ENH: Add support for PBR material properties in material property widgets

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKSurfaceMaterialPropertyWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKSurfaceMaterialPropertyWidget.h
@@ -56,10 +56,13 @@ protected:
 
   virtual void onColorChanged(const QColor& newColor);
   virtual void onOpacityChanged(double newOpacity);
+  virtual void onInterpolationModeChanged(ctkMaterialPropertyWidget::InterpolationMode newMode);
   virtual void onAmbientChanged(double newAmbient);
   virtual void onDiffuseChanged(double newDiffuse);
   virtual void onSpecularChanged(double newSpecular);
   virtual void onSpecularPowerChanged(double newSpecularPower);
+  virtual void onMetallicChanged(double newMetallic);
+  virtual void onRoughnessChanged(double newRoughness);
   virtual void onBackfaceCullingChanged(bool newBackfaceCulling);
 
 private:

--- a/Libs/Widgets/Resources/UI/ctkMaterialPropertyWidget.ui
+++ b/Libs/Widgets/Resources/UI/ctkMaterialPropertyWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>248</width>
-    <height>212</height>
+    <width>301</width>
+    <height>284</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,16 @@
    <property name="fieldGrowthPolicy">
     <enum>QFormLayout::ExpandingFieldsGrow</enum>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item row="0" column="0">
@@ -70,14 +79,14 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="AmbientLabel">
      <property name="text">
       <string>Ambient:</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="ctkSliderWidget" name="AmbientSliderSpinBox">
      <property name="singleStep">
       <double>0.010000000000000</double>
@@ -87,14 +96,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="DiffuseLabel">
      <property name="text">
       <string>Diffuse:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="4" column="1">
     <widget class="ctkSliderWidget" name="DiffuseSliderSpinBox">
      <property name="singleStep">
       <double>0.010000000000000</double>
@@ -107,14 +116,14 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="SpecularLabel">
      <property name="text">
       <string>Specular:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="ctkSliderWidget" name="SpecularSliderSpinBox">
      <property name="singleStep">
       <double>0.010000000000000</double>
@@ -124,7 +133,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="SpecularPowerLabel">
      <property name="toolTip">
       <string>Specular power</string>
@@ -134,7 +143,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="ctkSliderWidget" name="SpecularPowerSliderSpinBox">
      <property name="decimals">
       <number>1</number>
@@ -150,28 +159,28 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="BackfaceCullingLabel">
      <property name="text">
       <string>Backface Culling:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="9" column="1">
     <widget class="QCheckBox" name="BackfaceCullingCheckBox">
      <property name="text">
       <string/>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="10" column="0">
     <widget class="QLabel" name="PreviewLabel">
      <property name="text">
       <string>Preview:</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="10" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="ctkMaterialPropertyPreviewLabel" name="MaterialPropertyPreviewLabel">
@@ -245,6 +254,77 @@
      </item>
     </layout>
    </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="MetallicLabel">
+     <property name="text">
+      <string>Metallic:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="RoughnessLabel">
+     <property name="text">
+      <string>Roughness:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="ctkSliderWidget" name="MetallicSliderSpinBox">
+     <property name="singleStep">
+      <double>0.010000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="ctkSliderWidget" name="RoughnessSliderSpinBox">
+     <property name="singleStep">
+      <double>0.010000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="InterpolationModeLabel">
+     <property name="text">
+      <string>Mode:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="InterpolationModeComboBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>Flat</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Gouraud</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Phong</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>PBR</string>
+      </property>
+     </item>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -273,12 +353,12 @@
    <slot>setAmbient(double)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>168</x>
-     <y>67</y>
+     <x>257</x>
+     <y>96</y>
     </hint>
     <hint type="destinationlabel">
-     <x>116</x>
-     <y>209</y>
+     <x>119</x>
+     <y>280</y>
     </hint>
    </hints>
   </connection>
@@ -289,12 +369,12 @@
    <slot>setDiffuse(double)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>202</x>
-     <y>100</y>
+     <x>291</x>
+     <y>121</y>
     </hint>
     <hint type="destinationlabel">
-     <x>116</x>
-     <y>209</y>
+     <x>119</x>
+     <y>280</y>
     </hint>
    </hints>
   </connection>
@@ -305,12 +385,12 @@
    <slot>setSpecular(double)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>222</x>
-     <y>126</y>
+     <x>300</x>
+     <y>146</y>
     </hint>
     <hint type="destinationlabel">
-     <x>116</x>
-     <y>209</y>
+     <x>119</x>
+     <y>280</y>
     </hint>
    </hints>
   </connection>
@@ -321,12 +401,12 @@
    <slot>setSpecularPower(double)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>234</x>
-     <y>152</y>
+     <x>300</x>
+     <y>171</y>
     </hint>
     <hint type="destinationlabel">
-     <x>116</x>
-     <y>209</y>
+     <x>119</x>
+     <y>280</y>
     </hint>
    </hints>
   </connection>
@@ -341,8 +421,8 @@
      <y>14</y>
     </hint>
     <hint type="destinationlabel">
-     <x>103</x>
-     <y>191</y>
+     <x>119</x>
+     <y>280</y>
     </hint>
    </hints>
   </connection>
@@ -353,12 +433,44 @@
    <slot>setOpacity(double)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>105</x>
-     <y>24</y>
+     <x>194</x>
+     <y>46</y>
     </hint>
     <hint type="destinationlabel">
-     <x>103</x>
+     <x>119</x>
+     <y>280</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>MetallicSliderSpinBox</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>MaterialPropertyPreviewLabel</receiver>
+   <slot>setMetallic(double)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>141</x>
      <y>191</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>109</x>
+     <y>260</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>RoughnessSliderSpinBox</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>MaterialPropertyPreviewLabel</receiver>
+   <slot>setRoughness(double)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>102</x>
+     <y>213</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>104</x>
+     <y>258</y>
     </hint>
    </hints>
   </connection>

--- a/Libs/Widgets/ctkMaterialPropertyPreviewLabel.h
+++ b/Libs/Widgets/ctkMaterialPropertyPreviewLabel.h
@@ -39,29 +39,41 @@ class CTK_WIDGETS_EXPORT ctkMaterialPropertyPreviewLabel : public QFrame
   Q_PROPERTY(double specular READ specular WRITE setSpecular)
   Q_PROPERTY(double specularPower READ specularPower WRITE setSpecularPower)
 
+  Q_PROPERTY(double metallic READ metallic WRITE setMetallic)
+  Q_PROPERTY(double roughness READ roughness WRITE setRoughness)
+
   Q_PROPERTY(QColor color READ color WRITE setColor)
+  Q_PROPERTY(bool interpolationPBR READ interpolationPBR WRITE setInterpolationPBR)
   Q_PROPERTY(double opacity READ opacity WRITE setOpacity)
   Q_PROPERTY(double gridOpacity READ gridOpacity WRITE setGridOpacity)
-public : 
+public :
 
   ctkMaterialPropertyPreviewLabel(QWidget *parent = 0);
+  /// Non-PBR interpolation
   ctkMaterialPropertyPreviewLabel(const QColor& color, double opacity,
     double ambient, double diffuse, double specular, double specularPower,
     QWidget *parent = 0);
+  /// PBR interpolation
+  ctkMaterialPropertyPreviewLabel(const QColor& color, double opacity,
+    double diffuse, double metallic, double roughness,
+    QWidget* parent = 0);
   virtual ~ctkMaterialPropertyPreviewLabel();
-  
+
   double ambient()const;
   double diffuse()const;
   double specular()const;
   double specularPower()const;
-  
+  double metallic()const;
+  double roughness()const;
+
   QColor color()const;
+  bool interpolationPBR()const;
   double opacity()const;
   double gridOpacity()const;
 
   /// Reimplemented to make it square
   virtual int heightForWidth(int w)const;
-  
+
   virtual QSize sizeHint()const;
 public Q_SLOTS:
   /// Valid range: [0,1]
@@ -72,13 +84,18 @@ public Q_SLOTS:
   void setSpecular(double newSpecular);
   /// Valid range: [1,inf[
   void setSpecularPower(double newSpecularPower);
-  
+  /// Valid range: [0,1]
+  void setMetallic(double newMetallic);
+  /// Valid range: [0,1]
+  void setRoughness(double newRoughness);
+
   void setColor(const QColor& newColor);
+  void setInterpolationPBR(bool pbr);
   /// Valid range: [0, 1]
   void setOpacity(double newOpacity);
   void setGridOpacity(double newGridOpacity);
 
-protected: 
+protected:
   void paintEvent(QPaintEvent *);
   void draw(QImage& image);
 
@@ -89,4 +106,3 @@ private :
 };
 
 #endif
-

--- a/Libs/Widgets/ctkMaterialPropertyWidget.h
+++ b/Libs/Widgets/ctkMaterialPropertyWidget.h
@@ -39,27 +39,46 @@ class QListWidgetItem;
 class CTK_WIDGETS_EXPORT ctkMaterialPropertyWidget : public QWidget
 {
   Q_OBJECT
+  Q_ENUMS(InterpolationMode)
+
   /// This property holds the color of the material.
   Q_PROPERTY(QColor color  READ color WRITE setColor);
   /// Opacity component of the material property.
   Q_PROPERTY(double opacity READ opacity WRITE setOpacity);
+
+  /// Choose between Flat (no shading), Phong, Gouraud, and physically based rendering (PBR)
+  /// interpolation modes. Set to Gouraud by default.
+  Q_PROPERTY(InterpolationMode interpolationMode READ interpolationMode WRITE setInterpolationMode);
+
   /// This property holds the ambient lighting coefficient,
   /// it is a nondirectional property.
   /// Its range is [0,1], where 0 means no ambient light, and 1 means
   /// full ambient light
   /// Hint: A range of [0.1,0.5] is more realistic.
+  /// Only displayed in non-PBR interpolation mode.
   Q_PROPERTY(double ambient READ ambient WRITE setAmbient);
   /// This property holds the diffuse lighting coefficient.
   /// Its range is [0,1], where 0 means no diffuse light, and 1 means
-  /// full diffuse light
+  /// full diffuse light.
+  /// Used for all (both PBR and non-PBR) interpolation modes.
   Q_PROPERTY(double diffuse READ diffuse WRITE setDiffuse);
   /// This property holds the specular lighting coefficient.
   /// Its range is [0,1], where 0 means no specular light, and 1 means
   /// full specular light
+  /// Only displayed in non-PBR interpolation mode.
   Q_PROPERTY(double specular READ specular WRITE setSpecular);
   /// This property holds the power of specular lighting coefficient.
   /// Its range is [1,50].
+  /// Only displayed in non-PBR interpolation mode.
   Q_PROPERTY(double specularPower READ specularPower WRITE setSpecularPower);
+
+  /// The metalness of the material; values range from 0.0 (non-metal) to 1.0 (metal).
+  /// Only displayed in PBR interpolation mode.
+  Q_PROPERTY(double metallic READ metallic WRITE setMetallic);
+  /// The roughness of the material; values range from 0.0 (smooth) to 1.0 (rough).
+  /// Only displayed in PBR interpolation mode.
+  Q_PROPERTY(double roughness READ roughness WRITE setRoughness);
+
   /// This property controls weither backface culling should be enabled or not
   Q_PROPERTY(bool backfaceCulling READ backfaceCulling WRITE setBackfaceCulling);
   /// Control weither the color is shown to the user. Visible by default
@@ -68,10 +87,22 @@ class CTK_WIDGETS_EXPORT ctkMaterialPropertyWidget : public QWidget
   Q_PROPERTY(bool opacityVisible READ isOpacityVisible WRITE setOpacityVisible);
   /// Control weither the backface culling is shown to the user. Visible by default
   Q_PROPERTY(bool backfaceCullingVisible READ isBackfaceCullingVisible WRITE setBackfaceCullingVisible);
+
+  /// Control weither the interpolation mode selector is shown to the user. Hidden by default.
+  Q_PROPERTY(bool interpolationModeVisible READ isInterpolationModeVisible WRITE setInterpolationModeVisible);
   
 public:
   /// Superclass typedef
   typedef QWidget Superclass;
+
+  // Note: this must match the order of strings in InterpolationModeComboBox
+  enum InterpolationMode
+  {
+    InterpolationFlat = 0,
+    InterpolationGouraud,
+    InterpolationPhong,
+    InterpolationPBR
+  };
 
   /// Constructor
   explicit ctkMaterialPropertyWidget(QWidget* parent = 0);
@@ -82,10 +113,15 @@ public:
   QColor color()const;
   double opacity()const;
 
+  InterpolationMode interpolationMode()const;
+
   double ambient()const;
   double diffuse()const;
   double specular()const;
   double specularPower()const;
+
+  double metallic()const;
+  double roughness()const;
 
   bool backfaceCulling()const;
 
@@ -104,6 +140,8 @@ public:
   void setColorVisible(bool show);
   bool isOpacityVisible()const;
   void setOpacityVisible(bool show);
+  bool isInterpolationModeVisible()const;
+  void setInterpolationModeVisible(bool show);
   bool isBackfaceCullingVisible()const;
   void setBackfaceCullingVisible(bool show);
 
@@ -111,10 +149,15 @@ public Q_SLOTS:
   void setColor(const QColor& newColor);
   void setOpacity(double newOpacity);
 
+  void setInterpolationMode(InterpolationMode interpolationMode);
+
   void setAmbient(double newAmbient);
   void setDiffuse(double newDiffuse);
   void setSpecular(double newSpecular);
   void setSpecularPower(double newSpecularPower);
+
+  void setMetallic(double newMetallic);
+  void setRoughness(double newRoughness);
 
   void setBackfaceCulling(bool enable);
 
@@ -122,20 +165,30 @@ Q_SIGNALS:
   void colorChanged(QColor newColor);
   void opacityChanged(double newOpacity);
 
+  void interpolationModeChanged(int interpolationMode);
+
   void ambientChanged(double newAmbient);
   void diffuseChanged(double newDiffuse);
   void specularChanged(double newSpecular);
   void specularPowerChanged(double newSpecularPower);
 
+  void metallicChanged(double newMetallic);
+  void roughnessChanged(double newRoughness);
+
   void backfaceCullingChanged(bool newBackfaceCulling);
+
 protected Q_SLOTS:
   virtual void onColorChanged(const QColor& newColor);
   virtual void onOpacityChanged(double newOpacity);
+  virtual void onInterpolationModeChanged(int interpolationModeIndex);
 
   virtual void onAmbientChanged(double newAmbient);
   virtual void onDiffuseChanged(double newDiffuse);
   virtual void onSpecularChanged(double newSpecular);
   virtual void onSpecularPowerChanged(double newSpecularPower);
+
+  virtual void onMetallicChanged(double newMetallic);
+  virtual void onRoughnessChanged(double newRoughness);
 
   virtual void onBackfaceCullingChanged(bool newBackFaceCulling);
 


### PR DESCRIPTION
ctkMaterialPropertyWidget can now edit material properties for both non-PBR (Phong, Gouraud) and PBR interpolation.
PBR material properties are `diffuse` (shared with non-PBR modes) and `metallic` and `roughness` (matching names used in VTK and glTF).
An interpolation mode selector is added (hidden by default for backward compatibility) to allow easy switching between interpolation modes.

ctkVTKSurfaceMaterialPropertyWidget is updated to get/set associated properties in VTK.

ctkMaterialPropertyPreviewLabel is updated so that it can display both PBR and non-PBR material settings. Preview of PBR settings is a rough approximation.

Example of PBR rendering in 3D Slicer:

![image](https://user-images.githubusercontent.com/307929/151857670-462cc4bc-dd3d-4499-aa75-af00cf0a0bf5.png)
