### PR TITLE
ENH: Improve navigation in DICOM browser tables

### DIFF
--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMTableView.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMTableView.ui
@@ -88,6 +88,9 @@
    </item>
    <item>
     <widget class="QTableView" name="tblDicomDatabaseView">
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
+     </property>
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>

--- a/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
@@ -114,6 +114,7 @@ void ctkDICOMTableViewPrivate::init()
   this->leSearchBox->setShowSearchIcon(true);
 
   this->tblDicomDatabaseView->viewport()->installEventFilter(q);
+  this->tblDicomDatabaseView->installEventFilter(q);
 
   this->dicomSQLFilterModel->setSourceModel(&this->dicomSQLModel);
   this->dicomSQLFilterModel->setFilterKeyColumn(-1);
@@ -572,6 +573,31 @@ bool ctkDICOMTableView::eventFilter(QObject *obj, QEvent *event)
       if (!d->tblDicomDatabaseView->indexAt(pos).isValid())
       {
         return true;
+      }
+    }
+  }
+  else if (obj == d->tblDicomDatabaseView)
+  {
+    if (event->type() == QEvent::KeyPress)
+    {
+      QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+      QAbstractItemModel* itemModel = d->tblDicomDatabaseView->model();
+      if (keyEvent != nullptr && itemModel->rowCount() > 0)
+      {
+        if (keyEvent->key() == Qt::Key_Home)
+        {
+          //d->tblDicomDatabaseView->setCurrentIndex(itemModel->index(0, 0));
+          d->tblDicomDatabaseView->selectRow(0);
+          d->tblDicomDatabaseView->scrollToTop();
+          return true;
+        }
+        else if (keyEvent->key() == Qt::Key_End)
+        {
+          //d->tblDicomDatabaseView->setCurrentIndex(itemModel->index(itemModel->rowCount() - 1, 0));
+          d->tblDicomDatabaseView->selectRow(itemModel->rowCount() - 1);
+          d->tblDicomDatabaseView->scrollToBottom();
+          return true;
+        }
       }
     }
   }


### PR DESCRIPTION
DICOM patient/study/series tables use entire selection, so for users they appear as lists, and so users expect that they can use Home/End key to navigate to the top/bottom of the list.

This commit makes Home/End key jumps to top/bottom of the table (the keys did not change the selection before) and makes Tab/Shift+Tab key goes to next/previous table (instead of going to next/previous cell within a row).

Fixes https://github.com/Slicer/Slicer/issues/6078