### PR TITLE
ENH: Set focus proxy on ctkPathLineEdit

### DIFF
--- a/Libs/Widgets/ctkPathLineEdit.cpp
+++ b/Libs/Widgets/ctkPathLineEdit.cpp
@@ -335,6 +335,8 @@ void ctkPathLineEditPrivate::init()
   q->setSizePolicy(QSizePolicy(
                      QSizePolicy::Expanding, QSizePolicy::Fixed,
                      QSizePolicy::LineEdit));
+
+  q->setFocusProxy(this->LineEdit);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
The focus proxy is set to the `QLineEdit`, which is a natural choice.
This way the user of `ctkPathLineEdit` can set its focus policy and
include in a tabbing order as though it's a single widget, without
thinking about the underlying QWidgets internal to `ctkPathLineEdit`.

Related discussion: https://github.com/Slicer/Slicer/pull/6184#issuecomment-1045592937