### PR TITLE
ENH: Improve ctkLanguageComboBox

### DIFF
--- a/CMakeExternals/CTKData.cmake
+++ b/CMakeExternals/CTKData.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED CTKData_DIR)
     set(location_args GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
                       GIT_TAG ${revision_tag})
   else()
-    set(location_args GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/commontk/CTKData.git"
+    set(location_args GIT_REPOSITORY "https://github.com/commontk/CTKData.git"
                       GIT_TAG ${revision_tag})
   endif()
 

--- a/Libs/Widgets/Plugins/CMakeLists.txt
+++ b/Libs/Widgets/Plugins/CMakeLists.txt
@@ -80,12 +80,6 @@ set(PLUGIN_SRCS
   ctkRangeSliderPlugin.h
   ctkRangeWidgetPlugin.cpp
   ctkRangeWidgetPlugin.h
-  ctkThumbnailLabelPlugin.cpp
-  ctkThumbnailLabelPlugin.h
-  ctkTransferFunctionViewPlugin.cpp
-  ctkTransferFunctionViewPlugin.h
-  ctkTreeComboBoxPlugin.cpp
-  ctkTreeComboBoxPlugin.h
   ctkSearchBoxPlugin.cpp
   ctkSearchBoxPlugin.h
   ctkSettingsPanelPlugin.cpp
@@ -94,6 +88,12 @@ set(PLUGIN_SRCS
   ctkSettingsDialogPlugin.h
   ctkSliderWidgetPlugin.cpp
   ctkSliderWidgetPlugin.h
+  ctkThumbnailLabelPlugin.cpp
+  ctkThumbnailLabelPlugin.h
+  ctkTransferFunctionViewPlugin.cpp
+  ctkTransferFunctionViewPlugin.h
+  ctkTreeComboBoxPlugin.cpp
+  ctkTreeComboBoxPlugin.h
   ctkWorkflowButtonBoxWidgetPlugin.cpp
   ctkWorkflowButtonBoxWidgetPlugin.h
   ctkWorkflowWidgetStepPlugin.cpp

--- a/Libs/Widgets/Plugins/ctkWidgetsPlugins.h
+++ b/Libs/Widgets/Plugins/ctkWidgetsPlugins.h
@@ -51,6 +51,7 @@
 #include "ctkExpandableWidgetPlugin.h"
 #include "ctkFittedTextBrowserPlugin.h"
 #include "ctkFontButtonPlugin.h"
+#include "ctkLanguageComboBoxPlugin.h"
 #include "ctkMaterialPropertyPreviewLabelPlugin.h"
 #include "ctkMaterialPropertyWidgetPlugin.h"
 #include "ctkMatrixWidgetPlugin.h"
@@ -107,6 +108,7 @@ public:
             << new ctkExpandableWidgetPlugin
             << new ctkFittedTextBrowserPlugin
             << new ctkFontButtonPlugin
+            << new ctkLanguageComboBoxPlugin
             << new ctkMaterialPropertyPreviewLabelPlugin
             << new ctkMaterialPropertyWidgetPlugin
             << new ctkMatrixWidgetPlugin

--- a/Libs/Widgets/ctkLanguageComboBox.h
+++ b/Libs/Widgets/ctkLanguageComboBox.h
@@ -95,10 +95,7 @@ public:
   void setDefaultLanguage(const QString& language);
 
   /// Set the \a directory with all the translation files.
-  /// The list of available languages will be populated based on
-  /// the discovered translation files.
-  /// The default language will still be the first item in the menu.
-  /// Empty by default.
+  /// \sa setDirectories
   QString directory()const;
   void setDirectory(const QString& dir);
 
@@ -107,6 +104,8 @@ public:
   /// the discovered translation files.
   /// The default language will still be the first item in the menu.
   /// Empty by default.
+  /// If translation files are added/removed from the directories then
+  /// refreshFromDirectories() slot can be used to update the displayed list.
   QStringList directories()const;
   void setDirectories(const QStringList& dir);
 
@@ -128,6 +127,10 @@ public Q_SLOTS:
   /// Set the current language
   /// \sa currentLanguage, currentLanguage()
   void setCurrentLanguage(const QString& language);
+
+  /// Refresh the list of languages from the currently set directories.
+  /// \sa setDirectories()
+  void refreshFromDirectories();
 
 protected slots:
   void onLanguageChanged(int index);


### PR DESCRIPTION
Make ctkLanguageComboBox available in Qt Designer.
Add `refreshFromDirectories()` slot to update language list (e.g., when language files are added/removed).
Remove unnecessary `onLanguageChanged()` signals emitted while the language list is being updated.