### PR TITLE
STYLE: Explicitly associate "https" protocol with GitHub external projects

### DIFF
--- a/CMake/ctkDashboardDriverScript.cmake
+++ b/CMake/ctkDashboardDriverScript.cmake
@@ -69,7 +69,7 @@ endforeach()
 
 # If the dashscript doesn't define a GIT_REPOSITORY variable, let's define it here.
 if(NOT DEFINED GIT_REPOSITORY OR GIT_REPOSITORY STREQUAL "")
-  set(GIT_REPOSITORY http://github.com/commontk/CTK.git)
+  set(GIT_REPOSITORY https://github.com/commontk/CTK.git)
 endif()
 
 set(repository ${GIT_REPOSITORY})

--- a/CMakeExternals/Log4Qt.cmake
+++ b/CMakeExternals/Log4Qt.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED Log4Qt_DIR)
     set(location_args GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
                       GIT_TAG ${revision_tag})
   else()
-    set(location_args GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/commontk/Log4Qt.git"
+    set(location_args GIT_REPOSITORY "https://github.com/commontk/Log4Qt.git"
                       GIT_TAG ${revision_tag})
   endif()
 

--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -98,7 +98,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
     set(location_args GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
                       GIT_TAG ${revision_tag})
   else()
-    set(location_args GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/commontk/PythonQt.git"
+    set(location_args GIT_REPOSITORY "https://github.com/commontk/PythonQt.git"
                       GIT_TAG ${revision_tag})
   endif()
 

--- a/CMakeExternals/QtSOAP.cmake
+++ b/CMakeExternals/QtSOAP.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED QtSOAP_DIR)
     set(location_args GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
                       GIT_TAG ${revision_tag})
   else()
-    set(location_args GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/commontk/QtSOAP.git"
+    set(location_args GIT_REPOSITORY "https://github.com/commontk/QtSOAP.git"
                       GIT_TAG ${revision_tag})
   endif()
 

--- a/CMakeExternals/QtTesting.cmake
+++ b/CMakeExternals/QtTesting.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED QtTesting_DIR)
     set(location_args GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
                       GIT_TAG ${revision_tag})
   else()
-    set(location_args GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/commontk/QtTesting.git"
+    set(location_args GIT_REPOSITORY "https://github.com/commontk/QtTesting.git"
                       GIT_TAG ${revision_tag})
   endif()
 

--- a/CMakeExternals/ZMQ.cmake
+++ b/CMakeExternals/ZMQ.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ZMQ_DIR)
     set(location_args GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
                       GIT_TAG ${revision_tag})
   else()
-    set(location_args GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/PatrickCheng/zeromq2.git"
+    set(location_args GIT_REPOSITORY "https://github.com/PatrickCheng/zeromq2.git"
                       GIT_TAG ${revision_tag})
   endif()
 

--- a/CMakeExternals/qRestAPI.cmake
+++ b/CMakeExternals/qRestAPI.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ${proj}_DIR)
     set(location_args GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
                       GIT_TAG ${revision_tag})
   else()
-    set(location_args GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/commontk/qRestAPI.git"
+    set(location_args GIT_REPOSITORY "https://github.com/commontk/qRestAPI.git"
                       GIT_TAG ${revision_tag})
   endif()
 

--- a/CMakeExternals/qxmlrpc.cmake
+++ b/CMakeExternals/qxmlrpc.cmake
@@ -38,7 +38,7 @@ if(NOT DEFINED qxmlrpc_DIR)
     set(location_args GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
                       GIT_TAG ${revision_tag})
   else()
-    set(location_args GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/commontk/qxmlrpc.git"
+    set(location_args GIT_REPOSITORY "https://github.com/commontk/qxmlrpc.git"
                       GIT_TAG ${revision_tag})
   endif()
 


### PR DESCRIPTION
Considering that since March 2022, git protocol is not supported any more
by GitHub, this commit updates external projects to explicitly use "https"
protocol.

See https://github.blog/2021-09-01-improving-git-protocol-security-github/

Co-authored-by: Andras Lasso <lasso@queensu.ca>