### PR TITLE
BUG: Fix strange auto scaling of the plot

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
@@ -427,7 +427,7 @@ void ctkVTKChartView::mouseDoubleClickEvent(QMouseEvent* event)
 {
   if (event->button() == Qt::MidButton)
     {
-    this->setAxesToChartBounds();
+    this->chart()->RecalculateBounds();
     }
   this->Superclass::mouseDoubleClickEvent(event);
 }


### PR DESCRIPTION
Hi everyone,
It appears that the double middle mouse click produces very strange behaviors in CTK and 3DSlicer.
I propose to call the auto-scaling function of the base class