### PR TITLE
DOC: Fix remaining doxy/source comment typos

### DIFF
--- a/Applications/Testing/Cpp/dcmqrscp.cfg.in
+++ b/Applications/Testing/Cpp/dcmqrscp.cfg.in
@@ -21,7 +21,7 @@ HostTable BEGIN
 # DICOM Application Entities.  A symbolic name can represent a single
 # application entity or it can represent a group of application entities.
 # Each DICOM application entity is defined by a triple consisting of 
-# Application Entitiy Title, host name and TCP/IP port number.
+# Application Entity Title, host name and TCP/IP port number.
 #
 # Entry Format: SymbolicName = ( AETitle, HostName, Portnumber ), ...   |
 #               SymbolicName = SymbolicName, ...

--- a/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerMainWindow.cpp
+++ b/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerMainWindow.cpp
@@ -133,7 +133,7 @@ ctkCLModuleExplorerMainWindow::ctkCLModuleExplorerMainWindow(QWidget *parent) :
   // Due to Qt bug 12152, we cannot listen to the "paused" signal because it is
   // not emitted directly when the QFuture is paused. Instead, it is emitted after
   // resuming the future, after the "resume" signal has been emitted... we use
-  // a polling aproach instead.
+  // a polling approach instead.
   pollPauseTimer.setInterval(300);
   connect(&pollPauseTimer, SIGNAL(timeout()), SLOT(checkModulePaused()));
   connect(&currentFutureWatcher, SIGNAL(resumed()), SLOT(currentModuleResumed()));

--- a/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerProgressWidget.cpp
+++ b/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerProgressWidget.cpp
@@ -38,7 +38,7 @@ ctkCmdLineModuleExplorerProgressWidget::ctkCmdLineModuleExplorerProgressWidget(Q
   // Due to Qt bug 12152, we cannot listen to the "paused" signal because it is
   // not emitted directly when the QFuture is paused. Instead, it is emitted after
   // resuming the future, after the "resume" signal has been emitted... we use
-  // a polling aproach instead.
+  // a polling approach instead.
   PollPauseTimer.setInterval(300);
   connect(&PollPauseTimer, SIGNAL(timeout()), SLOT(checkModulePaused()));
 

--- a/Applications/ctkSimplePythonShell/ctkTestWrappedQListOfVTKObject.h
+++ b/Applications/ctkSimplePythonShell/ctkTestWrappedQListOfVTKObject.h
@@ -37,7 +37,7 @@ public:
     {
     }
 
-  /// Example ot slot accepting a VTK object as parameter
+  /// Example of slot accepting a VTK object as parameter
   Q_INVOKABLE int numberOfElementInList(const QList<vtkTable*>& listOfTable)
     {
     return listOfTable.count();

--- a/Applications/ctkSimplePythonShell/ctkTestWrappedVTKSlot.h
+++ b/Applications/ctkSimplePythonShell/ctkTestWrappedVTKSlot.h
@@ -50,7 +50,7 @@ public Q_SLOTS:
     return this->MyTable;
     }
 
-  /// Example ot slot accepting a VTK object as parameter
+  /// Example of slot accepting a VTK object as parameter
   void setTable(vtkTable * newTable)
     {
     this->MyTable = newTable;

--- a/Libs/PluginFramework/CMakeLists.txt
+++ b/Libs/PluginFramework/CMakeLists.txt
@@ -162,7 +162,7 @@ if(CTK_QT_VERSION VERSION_GREATER "4")
 endif()
 
 # Create a MANIFEST.MF resource for the PluginFramework library,
-# pretending that is is a plugin (the system plugin)
+# pretending that it is a plugin (the system plugin)
 ctkFunctionGeneratePluginManifest(KIT_SRCS
   SYMBOLIC_NAME "system.plugin"
   VERSION "0.9.9"

--- a/Libs/PluginFramework/ctkPluginEvent.h
+++ b/Libs/PluginFramework/ctkPluginEvent.h
@@ -40,7 +40,7 @@ class ctkPluginEventData;
  * <code>ctkPluginEvent</code> objects are delivered to slots connected
  * via ctkPluginContext::connectPluginListener() when a change
  * occurs in a plugins's lifecycle. A type code is used to identify
- * the event type for future extendability.
+ * the event type for future extendibility.
  *
  * @see ctkPluginContext#connectPluginListener
  */

--- a/Libs/PluginFramework/ctkPluginException.h
+++ b/Libs/PluginFramework/ctkPluginException.h
@@ -36,7 +36,7 @@
  * A <code>ctkPluginException</code> object is created by the Framework to denote
  * an exception condition in the lifecycle of a plugin.
  * <code>ctkPluginException</code>s should not be created by plugin developers.
- * An enum type is used to identify the exception type for future extendability.
+ * An enum type is used to identify the exception type for future extendibility.
  *
  * <p>
  * This exception conforms to the general purpose exception chaining mechanism.

--- a/Libs/PluginFramework/ctkPluginFrameworkEvent.h
+++ b/Libs/PluginFramework/ctkPluginFrameworkEvent.h
@@ -41,7 +41,7 @@ class ctkPluginFrameworkEventData;
  * <code>ctkPluginFrameworkEvent</code> objects are delivered to slots connected
  * via ctkPluginContext::connectFrameworkListener when a general event occurs
  * within the plugin environment.
- * A type code is used to identify the event type for future extendability.
+ * A type code is used to identify the event type for future extendibility.
  *
  * @see ctkPluginContext#connectFrameworkListener
  * @see ctkEventBus

--- a/Libs/PluginFramework/ctkServiceEvent.h
+++ b/Libs/PluginFramework/ctkServiceEvent.h
@@ -46,7 +46,7 @@ class ctkServiceEventData;
  * <code>ctkServiceEvent</code> objects are delivered to
  * slots connected via ctkPluginContext::connectServiceListener() when a
  * change occurs in this service's lifecycle. A type code is used to identify
- * the event type for future extendability.
+ * the event type for future extendibility.
  */
 class CTK_PLUGINFW_EXPORT ctkServiceEvent
 {

--- a/Libs/PluginFramework/ctkServiceException.h
+++ b/Libs/PluginFramework/ctkServiceException.h
@@ -35,7 +35,7 @@
  * <p>
  * A <code>ctkServiceException</code> object is created by the Framework or
  * to denote an exception condition in the service. An enum
- * type is used to identify the exception type for future extendability.
+ * type is used to identify the exception type for future extendibility.
  *
  * <p>
  * This exception conforms to the general purpose exception chaining mechanism.

--- a/Libs/PluginFramework/service/cm/ctkConfigurationAdmin.h
+++ b/Libs/PluginFramework/service/cm/ctkConfigurationAdmin.h
@@ -117,7 +117,7 @@ struct CTK_PLUGINFW_EXPORT ctkConfigurationAdmin
 
   /**
    * Configuration property naming the location of the plugin that is
-   * associated with a a <code>ctkConfiguration</code> object. This property can
+   * associated with a <code>ctkConfiguration</code> object. This property can
    * be searched for but must not appear in the configuration dictionary for
    * security reason. The property's value is of type <code>QString</code>.
    */

--- a/Libs/PluginFramework/service/metatype/ctkAttributeDefinition.h
+++ b/Libs/PluginFramework/service/metatype/ctkAttributeDefinition.h
@@ -79,7 +79,7 @@ struct CTK_PLUGINFW_EXPORT ctkAttributeDefinition
    * is used to uniquely identify an attribute. If such an OID exists, (which
    * can be requested at several standard organisations and many companies
    * already have a node in the tree) it can be returned here. Otherwise, a
-   * unique id should be returned which can be a class name combined with a a reverse
+   * unique id should be returned which can be a class name combined with a reverse
    * domain name or generated with a GUID algorithm. Note that all LDAP
    * defined attributes already have an OID. It is strongly advised to define
    * the attributes from existing LDAP schemes which will give the OID. Many

--- a/Plugins/org.commontk.dah.core/ctkDicomAbstractExchangeCache.h
+++ b/Plugins/org.commontk.dah.core/ctkDicomAbstractExchangeCache.h
@@ -120,7 +120,7 @@ public:
   bool notifyDataAvailable(const ctkDicomAppHosting::AvailableData& data, bool lastData);
 
   /**
-   * @brief Clean internal data stucture that keeps the incoming data.
+   * @brief Clean internal data structure that keeps the incoming data.
    *
    * Called when other side is gone (i.e., usually the other side is a hosted app).
    *

--- a/Plugins/org.commontk.dah.core/ctkDicomAvailableDataHelper.h
+++ b/Plugins/org.commontk.dah.core/ctkDicomAvailableDataHelper.h
@@ -110,7 +110,7 @@ bool org_commontk_dah_core_EXPORT appendToAvailableData(ctkDicomAppHosting::Avai
  *
  * Result can be used to retrieve data by calling ctkDicomExchangeInterface::getData.
  *
- * \return alls UUIDs of data for patient inside available data, otherwise empty.
+ * \return all UUIDs of data for patient inside available data, otherwise empty.
  */
 QList<QUuid> org_commontk_dah_core_EXPORT getAllUuids(const ctkDicomAppHosting::Patient& patient);
 
@@ -120,7 +120,7 @@ QList<QUuid> org_commontk_dah_core_EXPORT getAllUuids(const ctkDicomAppHosting::
  *
  * Result can be used to retrieve data by calling ctkDicomExchangeInterface::getData.
  *
- * \return alls UUIDs of all data inside available data, otherwise empty.
+ * \return all UUIDs of all data inside available data, otherwise empty.
  */
 QList<QUuid> org_commontk_dah_core_EXPORT getAllUuids(const ctkDicomAppHosting::AvailableData& availableData);
 

--- a/Plugins/org.commontk.eventadmin/ctkEAConfiguration_p.h
+++ b/Plugins/org.commontk.eventadmin/ctkEAConfiguration_p.h
@@ -84,7 +84,7 @@ class ctkEAAbstractAdapter;
  * If a timeout is configured by default all event handlers are called using the timeout.
  * For performance optimization it is possible to configure event handlers where the
  * timeout handling is not used - this reduces the thread usage from the thread pools
- * as the timout handling requires an additional thread to call the event handler.
+ * as the timeout handling requires an additional thread to call the event handler.
  * However, the application should work without this configuration property. It is a
  * pure optimization!
  * The value is a list of strings (separated by comma) which is assumed to define

--- a/Plugins/org.commontk.eventadmin/ctkEAMetaTypeProvider.cpp
+++ b/Plugins/org.commontk.eventadmin/ctkEAMetaTypeProvider.cpp
@@ -211,7 +211,7 @@ ctkObjectClassDefinitionPtr ctkEAMetaTypeProvider::getObjectClassDefinition(cons
                                                    "Configure event handlers to be called without a timeout. If a timeout is configured by default "
                                                    "all event handlers are called using the timeout. For performance optimization it is possible to "
                                                    "configure event handlers where the timeout handling is not used - this reduces the thread usage "
-                                                   "from the thread pools as the timout handling requires an additional thread to call the event "
+                                                   "from the thread pools as the timeout handling requires an additional thread to call the event "
                                                    "handler. However, the application should work without this configuration property. It is a "
                                                    "pure optimization! The value is a list of strings (separated by comma) which is assumed to define "
                                                    "exact class names.",

--- a/Plugins/org.commontk.eventadmin/dispatch/ctkEALinkedQueue_p.h
+++ b/Plugins/org.commontk.eventadmin/dispatch/ctkEALinkedQueue_p.h
@@ -60,7 +60,7 @@ struct ctkEALinkedNode
  * and takes when the queue is not empty.
  * Normally a put and a take can proceed simultaneously.
  * (Although it does not allow multiple concurrent puts or takes.)
- * This class tends to perform more efficently than
+ * This class tends to perform more efficiently than
  * other ctkEAChannel implementations in producer/consumer
  * applications.
  */

--- a/Plugins/org.commontk.eventadmin/dispatch/ctkEAPooledExecutor_p.h
+++ b/Plugins/org.commontk.eventadmin/dispatch/ctkEAPooledExecutor_p.h
@@ -105,7 +105,7 @@ class ctkEAInterruptibleThread;
  *   Queue sizes and maximum pool sizes can often be traded off for
  *   each other. Using large queues and small pools minimizes CPU
  *   usage, OS resources, and context-switching overhead, but can lead
- *   to artifically low throughput. Especially if tasks frequently
+ *   to artificially low throughput. Especially if tasks frequently
  *   block (for example if they are I/O bound), the underlying
  *   OS may be able to schedule time for more threads than you
  *   otherwise allow. Use of small queues or queueless handoffs
@@ -380,7 +380,7 @@ protected:
   /** The maximum number of threads allowed in pool. **/
   int maximumPoolSize_;
 
-  /** The minumum number of threads to maintain in pool. **/
+  /** The minimum number of threads to maintain in pool. **/
   int minimumPoolSize_;
 
   /**  Current pool size.  **/
@@ -448,7 +448,7 @@ public:
 
   /**
    * Return the minimum number of threads to simultaneously execute.
-   * (Default value is 1).  If fewer than the mininum number are
+   * (Default value is 1).  If fewer than the minimum number are
    * running upon reception of a new request, a new thread is started
    * to handle this request.
    **/
@@ -466,7 +466,7 @@ public:
 
   /**
    * Return the current number of active threads in the pool.  This
-   * number is just a snaphot, and may change immediately upon
+   * number is just a snapshot, and may change immediately upon
    * returning
    **/
   int getPoolSize() const;

--- a/Plugins/org.commontk.eventadmin/dispatch/ctkEASyncMasterThread_p.h
+++ b/Plugins/org.commontk.eventadmin/dispatch/ctkEASyncMasterThread_p.h
@@ -27,9 +27,9 @@
 
 
 /**
- * Used to execute synchronuous tasks. This is not done
+ * Used to execute synchronous tasks. This is not done
  * in the main thread because we need to be able to
- * interrupt the thread waiting on a synchronuous task
+ * interrupt the thread waiting on a synchronous task
  * (for example on a timeout). ctkEAInterruptibleThread
  * provides this capability.
  */

--- a/Plugins/org.commontk.eventadmin/util/ctkEACyclicBarrier_p.h
+++ b/Plugins/org.commontk.eventadmin/util/ctkEACyclicBarrier_p.h
@@ -210,7 +210,7 @@ public:
    * @throws ctkEAInterruptedException if this thread was interrupted
    *         during the barrier. If so, <code>broken</code> status is also set.
    * @throws ctkEATimeoutException if this thread timed out waiting for
-   *         the barrier. If the timeout occured while already in the
+   *         the barrier. If the timeout occurred while already in the
    *         barrier, <code>broken</code> status is also set.
    **/
   int attemptBarrier(long msecs);

--- a/Plugins/org.commontk.eventbus/Testing/Cpp/CMakeLists.txt
+++ b/Plugins/org.commontk.eventbus/Testing/Cpp/CMakeLists.txt
@@ -32,7 +32,7 @@ macro(ctkMacroInitProject test)
     foreach(FILE_NAME_ABS ${implementation_file_list})
       ## extract the base file name.
       get_filename_component(FILE_NAME ${FILE_NAME_ABS} NAME_WE)
-      ## Exclude the main.cpp file (it doesn't ned to be 'mocced')
+      ## Exclude the main.cpp file (it doesn't need to be 'mocced')
       if(NOT ${FILE_NAME} STREQUAL "main")
         ## Assign the moc custom filename
         set(MOC_FILE "${FILE_NAME}.moc")

--- a/Plugins/org.commontk.eventbus/Testing/Cpp/ctkEventBusManagerTest.cpp
+++ b/Plugins/org.commontk.eventbus/Testing/Cpp/ctkEventBusManagerTest.cpp
@@ -28,7 +28,7 @@ public:
     /// constructor.
     testObjectCustom();
 
-    /// Return tha var's value.
+    /// Return the var's value.
     int var() {return m_Var;}
 
     /// register a custom callback
@@ -84,7 +84,7 @@ public:
     /// Create and initialize client
     /*virtual*/ void createClient(QString hostName, unsigned int port);
 
-    /// Return the string variable initializated and updated from the data pipe.
+    /// Return the string variable initialized and updated from the data pipe.
     /*virtual*/ void createServer(unsigned int port);
 
     /// Allow to send a network request.

--- a/Plugins/org.commontk.eventbus/Testing/Cpp/ctkNetworkConnectorQXMLRPCTest.cpp
+++ b/Plugins/org.commontk.eventbus/Testing/Cpp/ctkNetworkConnectorQXMLRPCTest.cpp
@@ -29,7 +29,7 @@ public:
     /// constructor.
     testObjectCustomForNetworkConnectorXMLRPC();
 
-    /// Return tha var's value.
+    /// Return the var's value.
     int var() {return m_Var;}
 
 public Q_SLOTS:

--- a/Plugins/org.commontk.eventbus/Testing/Cpp/ctkNetworkConnectorQtSoapTest.cpp
+++ b/Plugins/org.commontk.eventbus/Testing/Cpp/ctkNetworkConnectorQtSoapTest.cpp
@@ -32,7 +32,7 @@ public:
     /// constructor.
     testObjectCustomForNetworkConnectorSoap();
 
-    /// Return tha var's value.
+    /// Return the var's value.
     int var() {return m_Var;}
 
 public Q_SLOTS:

--- a/Plugins/org.commontk.eventbus/Testing/Cpp/ctkNetworkConnectorTest.cpp
+++ b/Plugins/org.commontk.eventbus/Testing/Cpp/ctkNetworkConnectorTest.cpp
@@ -29,7 +29,7 @@ public:
     /// Create and initialize client
     /*virtual*/ void createClient(const QString hostName, const unsigned int port);
 
-    /// Return the string variable initializated and updated from the data pipe.
+    /// Return the string variable initialized and updated from the data pipe.
     /*virtual*/ void createServer(const unsigned int port);
 
     /// Allow to send a network request.
@@ -122,7 +122,7 @@ private Q_SLOTS:
     void ctkNetworkConnectorAllocationTest();
     /// Test the creation of client and server.
     void ctkNetworkConnectorCreateClientAndServerTest();
-    /// test the function that retrive protocol type
+    /// test the function that retrieve protocol type
     void retrieveProtocolTest();
 
 private:

--- a/Plugins/org.commontk.eventbus/Testing/Cpp/ctkNetworkConnectorZeroMQTest.cpp
+++ b/Plugins/org.commontk.eventbus/Testing/Cpp/ctkNetworkConnectorZeroMQTest.cpp
@@ -29,7 +29,7 @@ public:
     /// constructor.
     testObjectCustomForNetworkConnectorZeroMQ();
 
-    /// Return tha var's value.
+    /// Return the var's value.
     int var() {return m_Var;}
 
 public Q_SLOTS:

--- a/Plugins/org.commontk.eventbus/ctkEventBusManager.cpp
+++ b/Plugins/org.commontk.eventbus/ctkEventBusManager.cpp
@@ -34,7 +34,7 @@ ctkEventBusManager::~ctkEventBusManager() {
     }
     m_NetworkConnectorHash.clear();
 
-    //disconnet detachFromEventBus
+    //disconnect detachFromEventBus
     m_SkipDetach = true;
 
     if(m_LocalDispatcher) {

--- a/Plugins/org.commontk.eventbus/ctkEventBusManager.h
+++ b/Plugins/org.commontk.eventbus/ctkEventBusManager.h
@@ -35,7 +35,7 @@ public:
     static ctkEventBusManager *instance();
 
     /// Add a new event property (observer or event) to the event bus hash.
-    /** Return true if observer has beed added correctly, false otherwise.
+    /** Return true if observer has been added correctly, false otherwise.
     This method check before adding a new observer that it has not already been inserted into the events' Hash with the same id and callback signature.*/
     bool addEventProperty(ctkBusEvent &props) const;
 
@@ -63,7 +63,7 @@ public:
     /// Enable/Disable event logging to allow dumping events notification into the selected logging output stream.
     void enableEventLogging(bool enable = true);
 
-    /// When logging is enabled, allows logging events releted to specific id (require a valid topic).
+    /// When logging is enabled, allows logging events related to specific id (require a valid topic).
     void logEventTopic(const QString topic);
 
     /// When enabled, allows logging all events. It reset the value for m_LogEventId to -1 (the default)

--- a/Plugins/org.commontk.eventbus/ctkEventDispatcher.h
+++ b/Plugins/org.commontk.eventbus/ctkEventDispatcher.h
@@ -31,7 +31,7 @@ public:
     virtual ~ctkEventDispatcher();
 
     /// Add the observer to the events.
-    /** Return true if observer has beed added correctly, false otherwise.
+    /** Return true if observer has been added correctly, false otherwise.
     This method check before adding a new observer that it has not already been inserted into the events' Hash with the same id and callback signature.*/
     bool addObserver(ctkBusEvent &props);
 
@@ -45,7 +45,7 @@ public:
     bool removeSignal(const QObject *obj, const QString topic = "", bool qt_disconnect = true);
 
     /// register custom signals use by objects to raise them events.
-    /** Return true if signal has beed added correctly, false otherwise.
+    /** Return true if signal has been added correctly, false otherwise.
     This method check before adding a new signal that it has not already been inserted into the events' Hash with the same id and signal signature.
     WARNING: due to Qt limitation you cannot use the same signal in different Topics.*/
     bool registerSignal(ctkBusEvent &props);
@@ -76,7 +76,7 @@ protected:
     /// Register MAF global events
     virtual void initializeGlobalEvents();
 
-    /// Interanl method used to remove the given event property.
+    /// Internal method used to remove the given event property.
     bool removeEventItem(ctkBusEvent &props);
 
     /// Return the signal item property associated to the given ID.

--- a/Plugins/org.commontk.eventbus/ctkEventHandlerWrapper_p.h
+++ b/Plugins/org.commontk.eventbus/ctkEventHandlerWrapper_p.h
@@ -84,7 +84,7 @@ public:
     catch (const std::exception& e)
     {
       // TODO logging
-      std::cerr << "Exception occured during publishing " << qPrintable(event.getTopic()) << ": " << e.what() << std::endl;
+      std::cerr << "Exception occurred during publishing " << qPrintable(event.getTopic()) << ": " << e.what() << std::endl;
     }
 
   }

--- a/Plugins/org.commontk.eventbus/ctkNetworkConnectorQtSoap.cpp
+++ b/Plugins/org.commontk.eventbus/ctkNetworkConnectorQtSoap.cpp
@@ -55,7 +55,7 @@ void ctkNetworkConnectorQtSoap::createClient(const QString hostName, const unsig
 
     //registration of the method REMOTE_COMMUNICATION_SOAP at Soap level
     // this method need to reflect the name of the action of the service while QVariant::List are list of
-    // strings, in  which each string represent the correct name of the parameter in the sevice function.
+    // strings, in  which each string represent the correct name of the parameter in the service function.
     registerServerMethod("testArray", parametersForRegisterteredFunction);
 
     //

--- a/Plugins/org.commontk.eventbus/ctkNetworkConnectorZeroMQ.h
+++ b/Plugins/org.commontk.eventbus/ctkNetworkConnectorZeroMQ.h
@@ -65,7 +65,7 @@ protected:
     //here goes zeromq vars
     
 private:
-    //here ges function for zeromq connection
+    //here goes function for zeromq connection
     
     /// stop and destroy the server instance.
     void stopServer();

--- a/Plugins/org.commontk.metatype/ctkAttributeDefinitionImpl.cpp
+++ b/Plugins/org.commontk.metatype/ctkAttributeDefinitionImpl.cpp
@@ -210,7 +210,7 @@ QString ctkAttributeDefinitionImpl::validate(const QString& value) const
       return QString();
   }
 
-  // Addtional validation for STRING.
+  // Additional validation for STRING.
   // PASSWORD is treated like STRING.
   if ((_dataType == QVariant::String || _dataType == QVariant::UserType) && _values.size() > 0 && !_values.contains(value))
   {

--- a/Plugins/org.commontk.metatype/ctkMTDataParser.cpp
+++ b/Plugins/org.commontk.metatype/ctkMTDataParser.cpp
@@ -466,7 +466,7 @@ void ctkMTDataParser::attributeDefinitionHandler(QList<ctkAttributeDefinitionImp
 
   if (ad_cardinality_val == 0)
   {
-    // Attribute DEFAULT has one and only one occurance.
+    // Attribute DEFAULT has one and only one occurrence.
     ad->setDefaultValue(QStringList(ad_defaults_str), false);
   }
   else

--- a/Plugins/org.commontk.metatype/ctkMTLocalizationElement_p.h
+++ b/Plugins/org.commontk.metatype/ctkMTLocalizationElement_p.h
@@ -44,7 +44,7 @@ public:
   void setPluginLocalization(const ctkPluginLocalization& pl);
 
   /**
-   * Method to get the localized text of inputed String.
+   * Method to get the localized text of inputted String.
    */
   QString getLocalized(const QString& key) const;
 

--- a/Utilities/CMake/FindDCMTK.cmake
+++ b/Utilities/CMake/FindDCMTK.cmake
@@ -239,7 +239,7 @@ if(EXISTS ${DCMTK_DIR}/CMakeCache.txt)
   if(NOT EXISTS ${EXTDCMTK_SOURCE_DIR})
     message(FATAL_ERROR
       "DCMTK build directory references
-nonexistant DCMTK source directory ${EXTDCMTK_SOURCE_DIR}")
+non-existent DCMTK source directory ${EXTDCMTK_SOURCE_DIR}")
   endif()
 endif()
 

--- a/Utilities/CMake/FindOpenIGTLink.cmake
+++ b/Utilities/CMake/FindOpenIGTLink.cmake
@@ -17,7 +17,7 @@
 #
 #  USE_OpenIGTLink_FILE - The full path to the UseOpenIGTLink.cmake file.  
 #                 This is provided for backward 
-#                 compatability.  Use OpenIGTLink_USE_FILE
+#                 compatibility.  Use OpenIGTLink_USE_FILE
 #                 instead.
 
 
@@ -77,7 +77,7 @@ if(OpenIGTLink_DIR)
   set(OpenIGTLink_FOUND 1)
   include(${OpenIGTLink_DIR}/OpenIGTLinkConfig.cmake)
 
-  # Set USE_OpenIGTLink_FILE for backward-compatability.
+  # Set USE_OpenIGTLink_FILE for backward-compatibility.
   set(USE_OpenIGTLink_FILE ${OpenIGTLink_USE_FILE})
 else()
   set(OpenIGTLink_FOUND 0)

--- a/Utilities/CMake/FindZMQ.cmake
+++ b/Utilities/CMake/FindZMQ.cmake
@@ -17,7 +17,7 @@
 #
 #  USE_ZMQ_FILE - The full path to the ZMQ.cmake file.  
 #                 This is provided for backward 
-#                 compatability.  Use ZMQ_USE_FILE
+#                 compatibility.  Use ZMQ_USE_FILE
 #                 instead.
 
 
@@ -77,7 +77,7 @@ if(ZMQ_DIR)
   set(ZMQ_FOUND 1)
   include(${ZMQ_DIR}/ZMQConfig.cmake)
 
-  # Set USE_ZMQ_FILE for backward-compatability.
+  # Set USE_ZMQ_FILE for backward-compatibility.
   set(USE_ZMQ_FILE ${ZMQ_USE_FILE})
 else()
   set(ZMQ_FOUND 0)

--- a/Utilities/DGraph/CMakeLists.txt
+++ b/Utilities/DGraph/CMakeLists.txt
@@ -47,7 +47,7 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/${MY_EXPORT_HEADER_PREFIX}Export.h
   )
 
-# Add excutable
+# Add executable
 add_executable(${PROJECT_NAME}
   DGraph.cpp
   ${CTK_SOURCE_DIR}/Libs/Core/ctkDependencyGraph.h


### PR DESCRIPTION
Found via `codespell -q 3  -L ba,fo,noe,ro,te`