### PR TITLE
COMP: Fix build against VTK > 9.1 removing use of removed "vtkConfigure.h"

### DIFF
--- a/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
+++ b/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
@@ -24,7 +24,6 @@
 #include <vtkAlgorithmOutput.h>
 #include <vtkCamera.h>
 #include <vtkCellArray.h>
-#include <vtkConfigure.h>
 #include <vtkCornerAnnotation.h>
 #include <vtkImageData.h>
 #include <vtkImageMapper.h>


### PR DESCRIPTION
Following kitware/VTK@d933bb849 (vtkDeprecation: remove symbols deprecated
in 9.1), file "vtkConfigure.h" has been removed.

Since the use of vtkConfigure.h was superseded by the introduction of
vtkVersion.h in c68324047 (ENH: Support VTK6 in CTK) and became obsolete
with the removal of VTK5 support in e419ceeeb (COMP: Remove support
for building against VTK <= 5.8), this commit fixes the build by removing
the include.