### PR TITLE
COMP: Fix build against VTK > 9.1 explicitly including "vtkVersion.h"

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
@@ -34,6 +34,7 @@
 #include <vtkRendererCollection.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkTextProperty.h>
+#include <vtkVersion.h>
 
 //--------------------------------------------------------------------------
 static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkVTKAbstractView");

--- a/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
@@ -38,6 +38,7 @@
 #include <vtkPlot.h>
 #include <vtkRenderWindow.h>
 #include <vtkRenderer.h>
+#include <vtkVersion.h>
 
 //----------------------------------------------------------------------------
 static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkVTKChartView");

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
@@ -63,6 +63,7 @@
 #include <vtkRenderWindowInteractor.h>
 #include <vtkScalarsToColors.h>
 #include <vtkTable.h>
+#include <vtkVersion.h>
 
 //#define DEBUG_RANGE
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKMagnifyView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKMagnifyView.cpp
@@ -34,6 +34,7 @@
 #include <vtkMath.h>
 #include <vtkRenderWindow.h>
 #include <vtkUnsignedCharArray.h>
+#include <vtkVersion.h>
 
 // STD includes
 #include <cmath>


### PR DESCRIPTION
Following kitware/VTK@d933bb849 (vtkDeprecation: remove symbols deprecated
in 9.1), the "vtkDeprecation.h" header (itself including "vtkVersionMacros.h"
was removed from "vtkOpenGLRenderWindow.h". This commit fixes the related
build errors by explicitly including "vtkVersion.h" and ensure that
the macro like VTK_MAJOR_VERSION and VTK_MINOR_VERSION are defined.