### PR TITLE
ENH: Improve error log model API to allow log display in console

### DIFF
--- a/Libs/Core/ctkErrorLogAbstractModel.h
+++ b/Libs/Core/ctkErrorLogAbstractModel.h
@@ -142,7 +142,16 @@ public Q_SLOTS:
   /// Remove all log entries from model
   void clear();
 
-  /// \sa logEntryGrouping(), asynchronousLogging()
+  /// Call addEntry method via a connection (the same way as message handlers call it).
+  /// It is recommended to use this method instead of addEntry to ensure messages are logged in correct order.
+  /// Directly calling addEntry would make that log entry processed immedately, getting ahead of entries that
+  /// message handlers add via a queued connection.
+  void postEntry(const QDateTime& currentDateTime, const QString& threadId,
+    ctkErrorLogLevel::LogLevel logLevel, const QString& origin, const ctkErrorLogContext& context, const QString& text);
+
+  /// Add a log entry immediately. In general, it is more appropriate to call postEntry() instead, to ensure
+  /// logging of entries in the correct order.
+  /// \sa postEntry(), logEntryGrouping(), asynchronousLogging()
   void addEntry(const QDateTime& currentDateTime, const QString& threadId,
                 ctkErrorLogLevel::LogLevel logLevel, const QString& origin,
                 const ctkErrorLogContext &context, const QString& text);
@@ -150,8 +159,23 @@ public Q_SLOTS:
 Q_SIGNALS:
   void logLevelFilterChanged();
 
+  /// Called when an entry is added.
+  /// Since an entryAdded() signal with more parameters was added, this signal is somewhat redundant,
+  /// but it is kept for backward compatibility.
   /// \sa addEntry()
   void entryAdded(ctkErrorLogLevel::LogLevel logLevel);
+
+  /// Called when an entry is added.
+  /// \sa addEntry()
+  void entryAdded(const QDateTime& currentDateTime, const QString& threadId,
+    ctkErrorLogLevel::LogLevel logLevel, const QString& origin,
+    const ctkErrorLogContext& context, const QString& text);
+
+  /// For internal use only. It is connected to addEntry via a direct or queued connection
+  /// (depending on asynchronousLogging flag).
+  void entryPosted(const QDateTime& currentDateTime, const QString& threadId,
+    ctkErrorLogLevel::LogLevel logLevel,
+    const QString& origin, const ctkErrorLogContext& context, const QString& text);
 
 protected:
   QScopedPointer<ctkErrorLogAbstractModelPrivate> d_ptr;

--- a/Libs/Core/ctkErrorLogLevel.cpp
+++ b/Libs/Core/ctkErrorLogLevel.cpp
@@ -42,3 +42,10 @@ QString ctkErrorLogLevel::logLevelAsString(ctkErrorLogLevel::LogLevel logLevel)
   Q_ASSERT(QString("LogLevel").compare(logLevelEnum.name()) == 0);
   return QLatin1String(logLevelEnum.valueToKey(logLevel));
 }
+
+// --------------------------------------------------------------------------
+ctkErrorLogLevel::LogLevel ctkErrorLogLevel::logLevelFromString(const QString& logLevelStr)
+{
+  QMetaEnum logLevelEnum = ctkErrorLogLevel::staticMetaObject.enumerator(0);
+  return ctkErrorLogLevel::LogLevel(logLevelEnum.keyToValue(logLevelStr.toLocal8Bit()));
+}

--- a/Libs/Core/ctkErrorLogLevel.h
+++ b/Libs/Core/ctkErrorLogLevel.h
@@ -54,6 +54,7 @@ public:
   QString operator ()(LogLevel logLevel);
 
   static QString logLevelAsString(ctkErrorLogLevel::LogLevel logLevel);
+  static ctkErrorLogLevel::LogLevel logLevelFromString(const QString& logLevelStr);
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS(ctkErrorLogLevel::LogLevels)
 

--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -815,6 +815,10 @@ void ctkConsolePrivate::internalExecuteCommand()
       indent = regExp.cap(1);
       }
     }
+
+  // Give a chance for log messages to appear before displaying the new prompt.
+  qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+
   this->promptForInput(indent);
   this->MessageOutputSize = 0;
 }


### PR DESCRIPTION
These changes allow applications to capture all log messages from the error log model (messages can be injected by calling `postEntry`; and captured by using the new `entryAdded` signal) and display them in the console. See  for example: https://github.com/Slicer/Slicer/pull/5156#issuecomment-1278471951

- Added `postEntry` method to log events directly, without going through a message handler, but using the same connection mechanism as message handlers (to ensure logging of messages in the correct order).
- Added `entryAdded` signal that provides full log entry information (not just the log level as the existing signal). This can be used for displaying log messages in an additional widget, such as the Python console.
- Modified ctkConsole's command execution method to allow displaying messages that are logged during execution before showing the next command prompt.