### PR TITLE
ENH: Improve robustness of Python code running in the console

### DIFF
--- a/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
+++ b/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
@@ -701,6 +701,13 @@ void ctkPythonConsole::executeCommand(const QString& command)
 }
 
 //----------------------------------------------------------------------------
+void ctkPythonConsole::executeString(const QString& commands)
+{
+  Q_D(ctkPythonConsole);
+  d->PythonManager->executeString(commands);
+}
+
+//----------------------------------------------------------------------------
 void ctkPythonConsole::reset()
 {
   // Set primary and secondary prompt

--- a/Libs/Scripting/Python/Widgets/ctkPythonConsole.h
+++ b/Libs/Scripting/Python/Widgets/ctkPythonConsole.h
@@ -99,6 +99,7 @@ public Q_SLOTS:
 
 protected:
   virtual void executeCommand(const QString& command);
+  virtual void executeString(const QString& commands);
 
 private:
   Q_DECLARE_PRIVATE(ctkPythonConsole);

--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -1047,7 +1047,7 @@ void ctkConsolePrivate::pasteText(const QString& text)
     return;
     }
 
-  // Execute multiline commands at once, for more more robust command parsing and execution.
+  // Execute multiline commands at once, for more robust command parsing and execution.
   //
   // For example, an empty line in a Python function could not be executed line-by-line, because
   // then empty line would be interpreted as the end of the function.

--- a/Libs/Widgets/ctkConsole.h
+++ b/Libs/Widgets/ctkConsole.h
@@ -267,7 +267,8 @@ public Q_SLOTS:
   /// \sa openFile(), runFile(QString)
   virtual void exec(const QString&);
 
-  /// Exec line by line the content of a file.
+  /// Execute the content of a file.
+  /// The code is printed on the console and executed at once.
   /// \sa openFile(), exec()
   virtual void runFile(const QString& filePath);
 
@@ -297,6 +298,12 @@ protected:
 
   /// Called whenever the user enters a command
   virtual void executeCommand(const QString& Command);
+
+  /// Execute code that may contain multiple commands, at once.
+  /// If the same command is split to lines and executed one by
+  /// one then parsing might fail, therefore whenever it is possible
+  /// this method is preferable for executing multiple commands.
+  virtual void executeString(const QString& commands);
 
 protected:
   ctkConsole(ctkConsolePrivate * pimpl, QWidget* parentObject);

--- a/Libs/Widgets/ctkConsole_p.h
+++ b/Libs/Widgets/ctkConsole_p.h
@@ -211,6 +211,9 @@ public:
 
   QPushButton* RunFileButton;
   QAction* RunFileAction;
+
+  /// Store path of last RunFilefile, to make it easier to re-run the same file again.
+  QString LastRunFile;
 };
 
 


### PR DESCRIPTION
When a complete string of command is executed (either copy-pasting or running from file) then we no longer split the string to lines and execute line by line because that often leads to errors. For example, parsing of this Python code line by line would fail due to the empty line in the function definition:

```
def test1():
    print("one")

    print("two")
    print("three")

def test2():
    print("ok")
```

Also make the console remember the path of the last run Python file to make it easier to run it again.

Before this fix (failure while trying to specify `test1()` function):

![image](https://user-images.githubusercontent.com/307929/197315153-e672c7d5-fd7f-4fc7-bdb2-142eeb3c7a45.png)

After the fix (everything works as expected):

![image](https://user-images.githubusercontent.com/307929/197315196-0d88425e-4480-4d54-8eae-46f44bf6291e.png)
