### PR TITLE
COMP: Fix ctkVTKRenderView build error

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
@@ -126,7 +126,7 @@ public Q_SLOTS:
   /// \brief Change camera to look from a given axis to the focal point
   /// Translate/Rotate the camera to look from a given axis
   /// \sa lookFromAxis(const ctkAxesWidget::Axis&)
-  void lookFromAxis(const ctkAxesWidget::Axis& axis, double fov = 10.);
+  void lookFromAxis(const ctkAxesWidget::Axis& axis, double fov);
 
 public:
 


### PR DESCRIPTION
This commit fixes a regression introduced in 2e78ec70 (COMP: Fix -Wunused-parameter in ctkVTKRenderView::lookFromAxis()).

It addresses the following build error:

```
  /path/to/Slicer-Release/CTK/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp: In member function ‘void ctkVTKRenderView::lookFromAxis(const ctkAxesWidget::Axis&, double)’:
  /path/to/Slicer-Release/CTK/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp:499:26: error: call of overloaded ‘lookFromAxis(const ctkAxesWidget::Axis&)’ is ambiguous
    499 |   this->lookFromAxis(axis);
        |                          ^
```