### PR TITLE
Use DCMTK targets if present

### DIFF
--- a/Libs/DICOM/Core/CMakeLists.txt
+++ b/Libs/DICOM/Core/CMakeLists.txt
@@ -88,6 +88,13 @@ set(KIT_resources
 # The following macro will read the target libraries from the file 'target_libraries.cmake'
 ctkFunctionGetTargetLibraries(KIT_target_libraries)
 
+if(TARGET DCMTK::dcmnet AND TARGET DCMTK::dcmjpeg)
+  if(DCMTK_LIBRARIES)
+    list(REMOVE_ITEM KIT_target_libraries ${DCMTK_LIBRARIES})
+  endif()
+  list(APPEND KIT_target_libraries DCMTK::dcmnet DCMTK::dcmjpeg)
+endif()
+
 if(CTK_QT_VERSION VERSION_GREATER "4")
   list(APPEND KIT_target_libraries Qt5::Sql)
 endif()


### PR DESCRIPTION
We recently run into trouble with CTK and MITK when we finally switched most of our dependencies from the old file and directory based dependency handling of CMake pre v2.8.12 to the "modern" CMake target-based approach.

CMake cannot handle the same dependency in both modes in parallel, though, which conflicted with CTK and DCMTK. This patch checks if targets are present and then switch to the target-based approach for CTK's DCMTK dependency. Otherwise, keep the old behavior.