### PR TITLE
ENH: follow symlinks in dicom indexing

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMIndexer.h
+++ b/Libs/DICOM/Core/ctkDICOMIndexer.h
@@ -38,6 +38,7 @@ class CTK_DICOM_CORE_EXPORT ctkDICOMIndexer : public QObject
 {
   Q_OBJECT
   Q_PROPERTY(bool backgroundImportEnabled READ isBackgroundImportEnabled WRITE setBackgroundImportEnabled)
+  Q_PROPERTY(bool followSymlinks READ followSymlinks WRITE setFollowSymlinks)
   Q_PROPERTY(bool importing READ isImporting)
 
 public:
@@ -53,6 +54,12 @@ public:
   /// Disabled by default.
   void setBackgroundImportEnabled(bool);
   bool isBackgroundImportEnabled() const;
+
+  /// If enabled, addDirectory will follow symbolic links
+  /// on systems that support them.
+  /// Enabled by default.
+  void setFollowSymlinks(bool);
+  bool followSymlinks() const;
 
   /// Returns with true if background importing is currently in progress.
   bool isImporting();

--- a/Libs/DICOM/Core/ctkDICOMIndexer_p.h
+++ b/Libs/DICOM/Core/ctkDICOMIndexer_p.h
@@ -43,6 +43,8 @@ public:
     /// Make a copy of the indexed file into the database.
     /// If false then only a link to the existing file is added.
     bool copyFile;
+    /// Follow symlinks on platforms that support it.
+    bool followSymlinks;
   };
 
   DICOMIndexingQueue()
@@ -264,6 +266,7 @@ public:
   QThread WorkerThread;
   ctkDICOMDatabase* Database;
   bool BackgroundImportEnabled;
+  bool FollowSymlinks;
 };
 
 


### PR DESCRIPTION
Enabled by default, but settable as a property.

Fixes #1065