### PR TITLE
BUG: Fix lupdate warnings on translation function calls

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
@@ -145,12 +145,12 @@ void ctkDICOMAppWidgetPrivate::showUpdateSchemaDialog()
     // Set up the Update Schema Progress Dialog
     //
     UpdateSchemaProgress = new QProgressDialog(
-        q->tr("DICOM Schema Update"), "Cancel", 0, 100, q,
+        ctkDICOMAppWidget::tr("DICOM Schema Update"), "Cancel", 0, 100, q,
          Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
 
     // We don't want the progress dialog to resize itself, so we bypass the label
     // by creating our own
-    QLabel* progressLabel = new QLabel(q->tr("Initialization..."));
+    QLabel* progressLabel = new QLabel(ctkDICOMAppWidget::tr("Initialization..."));
     UpdateSchemaProgress->setLabel(progressLabel);
     UpdateSchemaProgress->setWindowModality(Qt::ApplicationModal);
     UpdateSchemaProgress->setMinimumDuration(0);
@@ -187,12 +187,12 @@ void ctkDICOMAppWidgetPrivate::showIndexerDialog()
     //
     // Set up the Indexer Progress Dialog
     //
-    IndexerProgress = new QProgressDialog( q->tr("DICOM Import"), "Cancel", 0, 100, q,
+    IndexerProgress = new QProgressDialog( ctkDICOMAppWidget::tr("DICOM Import"), "Cancel", 0, 100, q,
          Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
 
     // We don't want the progress dialog to resize itself, so we bypass the label
     // by creating our own
-    QLabel* progressLabel = new QLabel(q->tr("Initialization..."));
+    QLabel* progressLabel = new QLabel(ctkDICOMAppWidget::tr("Initialization..."));
     IndexerProgress->setLabel(progressLabel);
     IndexerProgress->setWindowModality(Qt::ApplicationModal);
     IndexerProgress->setMinimumDuration(0);

--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
@@ -268,10 +268,10 @@ void ctkDICOMBrowserPrivate::showUpdateSchemaDialog()
     // Set up the Update Schema Progress Dialog
     //
     UpdateSchemaProgress = new QProgressDialog(
-      q->tr("DICOM Schema Update"), "Cancel", 0, 100, q, Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
+      ctkDICOMBrowser::tr("DICOM Schema Update"), "Cancel", 0, 100, q, Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
 
     // We don't want the progress dialog to resize itself, so we bypass the label by creating our own
-    QLabel* progressLabel = new QLabel(q->tr("Initialization..."));
+    QLabel* progressLabel = new QLabel(ctkDICOMBrowser::tr("Initialization..."));
     UpdateSchemaProgress->setLabel(progressLabel);
     UpdateSchemaProgress->setWindowModality(Qt::ApplicationModal);
     UpdateSchemaProgress->setMinimumDuration(0);
@@ -1391,11 +1391,14 @@ void ctkDICOMBrowser::exportSeries(QString dirPath, QStringList uids)
     // show progress
     if (d->ExportProgress == 0)
     {
-      d->ExportProgress = new QProgressDialog(this->tr("DICOM Export"), "Close", 0, 100, this, Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
+      d->ExportProgress = new QProgressDialog(tr("DICOM Export"), "Close", 0, 100, this, Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
       d->ExportProgress->setWindowModality(Qt::ApplicationModal);
       d->ExportProgress->setMinimumDuration(0);
     }
-    QLabel *exportLabel = new QLabel(this->tr("Exporting series ") + seriesNumber);
+    QLabel *exportLabel = new QLabel(
+      //: %1 is the series number
+      tr("Exporting series %1").arg(seriesNumber)
+    );
     d->ExportProgress->setLabel(exportLabel);
     d->ExportProgress->setValue(0);
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
@@ -191,7 +191,7 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
 
   this->previousOpacityValue = opacitySlider->value();
 
-  this->scalarsToColorsSelector->addScalarsToColors(CTK_NULLPTR, q->tr("Reset"));
+  this->scalarsToColorsSelector->addScalarsToColors(CTK_NULLPTR, ctkVTKDiscretizableColorTransferWidget::tr("Reset"));
   this->scalarsToColorsSelector->setCurrentIndex(-1);
 
   this->eventLink = vtkSmartPointer<vtkEventQtSlotConnect>::New();
@@ -239,19 +239,19 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
   optionButton->setIcon(q->style()->standardIcon(
     QStyle::SP_FileDialogDetailedView, CTK_NULLPTR, optionButton));
 
-  QLabel* nanLabel = new QLabel(q->tr("NaN values"));
+  QLabel* nanLabel = new QLabel(ctkVTKDiscretizableColorTransferWidget::tr("NaN values"));
   nanButton = new ctkColorPickerButton;
-  nanButton->setToolTip(q->tr("NaN color"));
+  nanButton->setToolTip(ctkVTKDiscretizableColorTransferWidget::tr("NaN color"));
   nanColorLayout->addWidget(nanButton);
   nanColorLayout->addWidget(nanLabel);
 
   discretizeCheckBox = new QCheckBox;
-  discretizeCheckBox->setText(q->tr("Discretize"));
-  discretizeCheckBox->setToolTip(q->tr("Discretize color transfer function"));
+  discretizeCheckBox->setText(ctkVTKDiscretizableColorTransferWidget::tr("Discretize"));
+  discretizeCheckBox->setToolTip(ctkVTKDiscretizableColorTransferWidget::tr("Discretize color transfer function"));
   nbOfDiscreteValuesSpinBox = new QSpinBox;
   nbOfDiscreteValuesSpinBox->setMinimum(1);
   nbOfDiscreteValuesSpinBox->setMaximum(255);
-  nbOfDiscreteValuesSpinBox->setToolTip(q->tr("Number of discrete values"));
+  nbOfDiscreteValuesSpinBox->setToolTip(ctkVTKDiscretizableColorTransferWidget::tr("Number of discrete values"));
   nbOfDiscreteValuesSpinBox->setEnabled(discretizeCheckBox->isChecked());
 
   discretizeLayout->addWidget(discretizeCheckBox);

--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsComboBox.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsComboBox.cpp
@@ -62,7 +62,7 @@ void ctkVTKScalarsToColorsComboBoxPrivate::init()
   q->setIconSize(QSize(100, 20));
 
   // Add default raw
-  q->setDefaultText(q->tr("Select a color transfer function..."));
+  q->setDefaultText(ctkVTKScalarsToColorsComboBox::tr("Select a color transfer function..."));
   q->forceDefault(true);
 
   // Connect signals and slots

--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -137,18 +137,18 @@ void ctkConsolePrivate::init()
   this->CommandHistory.append("");
   this->CommandPosition = 0;
 
-  this->RunFileAction = new QAction(q->tr("&Run file"), q);
-  this->RunFileAction->setShortcut(q->tr("Ctrl+g"));
+  this->RunFileAction = new QAction(ctkConsole::tr("&Run file"), q);
+  this->RunFileAction->setShortcut(ctkConsole::tr("Ctrl+g"));
   connect(this->RunFileAction, SIGNAL(triggered()), q, SLOT(runFile()));
   q->addAction(this->RunFileAction);
 
-  QAction* printHelpAction = new QAction(q->tr("Print &help"),q);
-  printHelpAction->setShortcut(q->tr("Ctrl+h"));
+  QAction* printHelpAction = new QAction(ctkConsole::tr("Print &help"),q);
+  printHelpAction->setShortcut(ctkConsole::tr("Ctrl+h"));
   connect(printHelpAction, SIGNAL(triggered()), q, SLOT(printHelp()));
   q->addAction(printHelpAction);
 
   this->RunFileButton = new QPushButton(q);
-  this->RunFileButton->setText(q->tr("&Run script from file"));
+  this->RunFileButton->setText(ctkConsole::tr("&Run script from file"));
   this->RunFileButton->setVisible(false);
 
   QVBoxLayout * layout = new QVBoxLayout(q);

--- a/Libs/Widgets/ctkFittedTextBrowser.cpp
+++ b/Libs/Widgets/ctkFittedTextBrowser.cpp
@@ -37,8 +37,8 @@ ctkFittedTextBrowserPrivate::ctkFittedTextBrowserPrivate(ctkFittedTextBrowser& o
 {
   this->Collapsed = true;
   this->CollapsibleTextSetter = ctkFittedTextBrowserPrivate::Text;
-  this->ShowDetailsText = object.tr("Show details...");
-  this->HideDetailsText = object.tr("Hide details.");
+  this->ShowDetailsText = ctkFittedTextBrowser::tr("Show details...");
+  this->HideDetailsText = ctkFittedTextBrowser::tr("Hide details.");
   QString HideDetailsText;
 }
 

--- a/Libs/Widgets/ctkMenuComboBox.cpp
+++ b/Libs/Widgets/ctkMenuComboBox.cpp
@@ -90,7 +90,7 @@ void ctkMenuComboBoxPrivate::init()
 
   // SearchButton
   this->SearchButton = new QToolButton();
-  this->SearchButton->setText(q->tr("Search"));
+  this->SearchButton->setText(ctkMenuComboBox::tr("Search"));
   this->SearchButton->setIcon(QIcon(":/Icons/search.svg"));
   this->SearchButton->setCheckable(true);
   this->SearchButton->setAutoRaise(true);

--- a/Libs/Widgets/ctkMessageBox.cpp
+++ b/Libs/Widgets/ctkMessageBox.cpp
@@ -75,7 +75,7 @@ void ctkMessageBoxPrivate::init()
   Q_Q(ctkMessageBox);
   this->DontShowAgainCheckBox = new QCheckBox(q);
   this->DontShowAgainCheckBox->setObjectName(QLatin1String("ctk_msgbox_dontshowcheckbox"));
-  this->DontShowAgainCheckBox->setText(q->tr("Don't show this message again"));
+  this->DontShowAgainCheckBox->setText(ctkMessageBox::tr("Don't show this message again"));
   // The height policy being Fixed by default on a checkbox, if the message box icon
   // is bigger than the text+checkbox height, it would be truncated.
   this->DontShowAgainCheckBox->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
@@ -217,7 +217,7 @@ void ctkMessageBox::setDontShowAgainVisible(bool visible)
   if (acceptButton && !acceptButton->text().isEmpty())
     {
     QString dontShowAgainText =
-      this->tr("Don't show this message again and always %1").arg(acceptButton->text());
+      tr("Don't show this message again and always %1").arg(acceptButton->text());
 
     d->DontShowAgainCheckBox->setText(dontShowAgainText);
     }

--- a/Libs/Widgets/ctkSearchBox.cpp
+++ b/Libs/Widgets/ctkSearchBox.cpp
@@ -73,7 +73,7 @@ void ctkSearchBoxPrivate::init()
   Q_Q(ctkSearchBox);
 
   // Set a text by default on the QLineEdit
-  q->setPlaceholderText(q->tr("Search..."));
+  q->setPlaceholderText(ctkSearchBox::tr("Search..."));
 
   QObject::connect(q, SIGNAL(textChanged(QString)),
                    q, SLOT(updateClearButtonState()));

--- a/Libs/Widgets/ctkSettingsDialog.cpp
+++ b/Libs/Widgets/ctkSettingsDialog.cpp
@@ -75,13 +75,13 @@ void ctkSettingsDialogPrivate::init()
   this->setupUi(q);
 
   this->SettingsButtonBox->button(QDialogButtonBox::Ok)->setToolTip(
-    q->tr("Apply settings and close dialog."));
+    ctkSettingsDialog::tr("Apply settings and close dialog."));
   this->SettingsButtonBox->button(QDialogButtonBox::Cancel)->setToolTip(
-    q->tr("Reject settings changes and close dialog."));
+    ctkSettingsDialog::tr("Reject settings changes and close dialog."));
   this->SettingsButtonBox->button(QDialogButtonBox::Reset)->setToolTip(
-    q->tr("Reset settings to their values when the dialog opened"));
+    ctkSettingsDialog::tr("Reset settings to their values when the dialog opened"));
   this->SettingsButtonBox->button(QDialogButtonBox::RestoreDefaults)->setToolTip(
-    q->tr("Restore settings to their default values."
+    ctkSettingsDialog::tr("Restore settings to their default values."
     "To cancel a \"Restore\", you can \"Reset\" the settings."));
   q->setResetButton(false);
 
@@ -167,11 +167,12 @@ void ctkSettingsDialogPrivate::updateRestartRequiredLabel()
   bool restartRequired = !restartRequiredSettings.isEmpty();
   if (restartRequired)
     {
-    QString header = q->tr(
-      "<b style=\"color:red\">Restart required!</b><br>\n<small>"
-      "The application must be restarted to take into account "
-      "the new values of the following properties:\n");
-    QString footer = q->tr("</small>");
+    QString header = "<b style=\"color:red\">" + ctkSettingsDialog::tr("Restart required!") + "</b><br>\n<small>";
+    header += ctkSettingsDialog::tr(
+      "The application must be restarted to take into account the new values of the following properties:"
+    );
+    header += "\n";
+    QString footer = "</small>";
     restartRequiredSettings.push_front(QString());
     this->RestartRequiredLabel->setText( header + restartRequiredSettings.join("<br>&nbsp;&nbsp;") + footer);
     }


### PR DESCRIPTION
Qt lupdate tool throws `Cannot invoke tr() like this` warnings when translation function is called using `q->tr(...)`. The problem is that lupdate cannot determine the class name `tr()` is called on and therefore it does not know the translation context. The solution is to spell out the class name in the call, for example `qSlicerScalarVolumeDisplayWidget::tr(...)`. More details are described here: https://github.com/Slicer/SlicerLanguagePacks/blob/main/DevelopersManual.md

see Slicer/SlicerLanguagePacks#17
see Slicer/SlicerLanguagePacks#12