### PR TITLE
BUG: Ensure that the min/max values can be reached in ctkDoubleSlider and ctkDoubleRangeSlider

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkDoubleRangeSliderTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkDoubleRangeSliderTest1.cpp
@@ -52,12 +52,38 @@ bool checkSlider(const ctkDoubleRangeSlider& slider,
 bool checkSlider(const ctkDoubleRangeSlider& slider,
                  double min, double minVal, double maxVal, double max, double minPos, double maxPos)
 {
-  return qFuzzyCompare(slider.minimum(), min) &&
-    qFuzzyCompare(slider.minimumValue(), minVal) &&
-    qFuzzyCompare(slider.maximumValue(), maxVal) &&
-    qFuzzyCompare(slider.maximum(), max) &&
-    qFuzzyCompare(slider.minimumPosition(), minPos) &&
-    qFuzzyCompare(slider.maximumPosition(), maxPos);
+  bool success = true;
+  if (!qFuzzyCompare(slider.minimum(), min))
+    {
+    std::cerr << "Slider minimum mismatch: expected " << min << " actual " << slider.minimum() << std::endl;
+    success = false;
+    }
+  if (!qFuzzyCompare(slider.minimumValue(), minVal))
+    {
+    std::cerr << "Slider minimumValue mismatch: expected " << minVal << " actual " << slider.minimumValue() << std::endl;
+    success = false;
+    }
+  if (!qFuzzyCompare(slider.maximumValue(), maxVal))
+    {
+    std::cerr << "Slider maximumValue mismatch: expected " << maxVal << " actual " << slider.maximumValue() << std::endl;
+    success = false;
+    }
+  if (!qFuzzyCompare(slider.maximum(), max))
+    {
+    std::cerr << "Slider maximum mismatch: expected " << max << " actual " << slider.maximum() << std::endl;
+    success = false;
+    }
+  if (!qFuzzyCompare(slider.minimumPosition(), minPos))
+    {
+    std::cerr << "Slider minimumPosition mismatch: expected " << minPos << " actual " << slider.minimumPosition() << std::endl;
+    success = false;
+    }
+  if (!qFuzzyCompare(slider.maximumPosition(), maxPos))
+    {
+    std::cerr << "Slider maximumPosition mismatch: expected " << maxPos << " actual " << slider.maximumPosition() << std::endl;
+    success = false;
+    }
+  return success;
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Widgets/Testing/Cpp/ctkRangeWidgetTest.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkRangeWidgetTest.cpp
@@ -223,17 +223,30 @@ void ctkRangeWidgetTester::testSetRange()
 
   QFETCH(double, expectedMinimum);
   QFETCH(double, expectedMaximum);
-  ctkTest::COMPARE(rangeWidget.minimum(), expectedMinimum);
-  ctkTest::COMPARE(rangeWidget.maximum(), expectedMaximum);
 
+  // The slider cannot represent infinitely large range, therefore we skip
+  // testing of range minimum/maximum checks in these cases.
+  bool testRangeMinMax = (expectedMinimum != std::numeric_limits<double>::min()
+    && expectedMinimum != std::numeric_limits<double>::max()
+    && expectedMinimum != std::numeric_limits<double>::infinity()
+    && expectedMinimum != -std::numeric_limits<double>::infinity());
+
+  if (testRangeMinMax)
+    {
+    ctkTest::COMPARE(rangeWidget.minimum(), expectedMinimum);
+    ctkTest::COMPARE(rangeWidget.maximum(), expectedMaximum);
+    }
   const bool minimumChanged = expectedMinimum != 0.;
   const bool maximumChanged = expectedMaximum != 99.;
   QCOMPARE(rangeChangedSpy.count(),(minimumChanged || maximumChanged) ? 1 : 0);
 
   QFETCH(double, expectedLowerValue);
   QFETCH(double, expectedUpperValue);
-  ctkTest::COMPARE(rangeWidget.minimumValue(), expectedLowerValue);
-  ctkTest::COMPARE(rangeWidget.maximumValue(), expectedUpperValue);
+  if (testRangeMinMax)
+    {
+    ctkTest::COMPARE(rangeWidget.minimumValue(), expectedLowerValue);
+    ctkTest::COMPARE(rangeWidget.maximumValue(), expectedUpperValue);
+    }
 
   const bool lowerValueChanged = expectedLowerValue != 25.;
   const bool upperValueChanged = expectedUpperValue != 75.;

--- a/Libs/Widgets/ctkRangeWidget.cpp
+++ b/Libs/Widgets/ctkRangeWidget.cpp
@@ -372,6 +372,7 @@ void ctkRangeWidget::setRange(double min, double max)
   d->SettingSliderRange = true;
   d->Slider->setRange(d->MaximumSpinBox->minimum(), d->MinimumSpinBox->maximum());
   d->SettingSliderRange = false;
+#ifndef QT_NO_DEBUG
   if (!d->useCustomSpinBoxesLimits())
     {
     if (!(d->equal(d->MinimumSpinBox->minimum(), d->Slider->minimum())) ||
@@ -379,9 +380,14 @@ void ctkRangeWidget::setRange(double min, double max)
         !(d->equal(d->Slider->minimumValue(), d->MinimumSpinBox->value())) ||
         !(d->equal(d->Slider->maximumValue(), d->MaximumSpinBox->value())))
       {
-      qWarning("ctkRangeWidget::setRange : slider and spinbox are not synchronized");
+      qWarning() << "ctkRangeWidget::setRange : slider and spinbox are not synchronized "
+        << d->MinimumSpinBox->minimum() << d->Slider->minimum()
+        << d->MaximumSpinBox->maximum() << d->Slider->maximum()
+        << d->Slider->minimumValue() << d->MinimumSpinBox->value()
+        << d->Slider->maximumValue() << d->MaximumSpinBox->value();
       }
     }
+#endif
   d->updateSpinBoxWidth();
   if (!d->useCustomSpinBoxesLimits())
     {

--- a/Libs/Widgets/ctkSettingsDialog.h
+++ b/Libs/Widgets/ctkSettingsDialog.h
@@ -66,6 +66,8 @@ public:
   QSettings* settings()const;
   void setSettings(QSettings* settings);
 
+  /// Get the panel based on its title. The title is the string displayed to
+  /// users therefore it is a localized string (translated to different languages).
   ctkSettingsPanel* panel(const QString& panel)const;
   ctkSettingsPanel* currentPanel()const;
 


### PR DESCRIPTION

The minimum and maximum values were not always reachable in ctkDoubleSlider and ctkDoubleRangeSlider widgets when moved the slider to the minimum or maximum position.

For example:

```
lo = -1024
hi = 2000
step = (hi - lo) / 1000.

thresholdSlider = ctk.ctkRangeWidget()
thresholdSlider.spinBoxAlignment = qt.Qt.AlignTop
thresholdSlider.setRange(lo, hi)
thresholdSlider.singleStep = step
thresholdSlider.show()
# Impossible to reach 2000.0

slider = ctk.ctkDoubleSlider()
slider.minimum = lo
slider.maximum = hi
slider.singleStep = step
slider.show()
slider.connect("valueChanged(double)", lambda v: print(v))
# Impossible to reach 2000.0
```

The problem was that the integer slider range was determined by rounding, which could result in the integer slider range not covering the entire value range.
 Fixed the problem by extending the integer slider range when it did not fully cover the value range. There are no regressions in tests.