### PR TITLE
Improve ctk & qt python packages to avoid segfault when imported from standalone python

### DIFF
--- a/Libs/Scripting/Python/Core/Python/ctk/__init__.py.in
+++ b/Libs/Scripting/Python/Core/Python/ctk/__init__.py.in
@@ -5,11 +5,21 @@ its namespace."""
 
 __kits_to_load = [ @CTK_PYTHON_WRAPPED_LIBRARIES@ ]
 
+import os
+import sys
+_standalone_python = "python" in str.lower(os.path.split(sys.executable)[-1])
+
 # Set to True when debugging
 _CTK_VERBOSE_IMPORT = False
 
 kits = []
 for kit in __kits_to_load:
+  # Since importing a PythonQt-based module outside of a Qt application
+  # leads to a segfault, skip the import if it happens in a standalone
+  # python interpreter.
+  # See https://github.com/commontk/CTK/pull/520
+  if _standalone_python:
+    continue
   try:
     exec("from CTK%sPythonQt import *" % kit)
     kits.append(kit)
@@ -103,6 +113,6 @@ if _lib == 'Widgets':
   decorates_ctkWorkflowWidgetStep_initialize_method()
 
 # Removing things the user shouldn't have to see.
-del __kits_to_load, _lib, _CTK_VERBOSE_IMPORT
+del __kits_to_load, _lib, _standalone_python, _CTK_VERBOSE_IMPORT
 del add_methodclass_to_ctkWorkflowStep_or_ctkWorkflowWidgetStep
 del add_methodclass_to_ctkWorkflowWidgetStep, decorates_ctkWorkflowWidgetStep_initialize_method

--- a/Libs/Scripting/Python/Core/Python/qt/__init__.py.in
+++ b/Libs/Scripting/Python/Core/Python/qt/__init__.py.in
@@ -5,18 +5,28 @@ its namespace."""
 
 __kits_to_load = [ @QT_PYTHON_WRAPPED_LIBRARIES@ ]
 
+import os
+import sys
+_standalone_python = "python" in str.lower(os.path.split(sys.executable)[-1])
+
 # Set to True when debugging
 _CTK_VERBOSE_IMPORT = False
 
 for kit in __kits_to_load:
+  # Since importing a PythonQt-based module outside of a Qt application
+  # leads to a segfault, skip the import if it happens in a standalone
+  # python interpreter.
+  # See https://github.com/commontk/CTK/pull/520
+  if _standalone_python:
+    continue
   try:
     exec("from PythonQt.Qt%s import *" % kit)
   except ImportError as detail:
     if _CTK_VERBOSE_IMPORT:
       print(detail)
 
-if "QObject" not in locals():
+if "QObject" not in locals() and not _standalone_python:
   from PythonQt.private import QObject
 
 # Removing things the user shouldn't have to see.
-del __kits_to_load, _CTK_VERBOSE_IMPORT
+del __kits_to_load, _standalone_python, _CTK_VERBOSE_IMPORT

--- a/Libs/Scripting/Python/Core/Python/qt/__init__.py.in
+++ b/Libs/Scripting/Python/Core/Python/qt/__init__.py.in
@@ -9,11 +9,11 @@ __kits_to_load = [ @QT_PYTHON_WRAPPED_LIBRARIES@ ]
 _CTK_VERBOSE_IMPORT = False
 
 for kit in __kits_to_load:
-   try:
-     exec("from PythonQt.Qt%s import *" % kit)
-   except ImportError as detail:
-     if _CTK_VERBOSE_IMPORT:
-       print(detail)
+  try:
+    exec("from PythonQt.Qt%s import *" % kit)
+  except ImportError as detail:
+    if _CTK_VERBOSE_IMPORT:
+      print(detail)
 
 if "QObject" not in locals():
   from PythonQt.private import QObject


### PR DESCRIPTION
Since importing a PythonQt-based module outside of a Qt application leads to a segfault, skip the import if it happens in a standalone python interpreter.

This issue was discovered while working on the following:
* https://github.com/Slicer/Slicer/pull/6876
* https://github.com/Slicer/Slicer/issues/6875

Note that we may revisit this once the integration of the following pull-request has been finalized:
* https://github.com/commontk/CTK/pull/520


