### PR TITLE
COMP: Fix DICOM/Core build ensuring Qt headers can always be included

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRadiotherapySeriesDescriptionRule.h
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRadiotherapySeriesDescriptionRule.h
@@ -22,7 +22,7 @@
 #define __ctkDICOMDisplayedFieldGeneratorRadiotherapySeriesDescriptionRule_h
 
 // Qt includes
-#include <QCoreApplication.h>
+#include <QCoreApplication>
 #include <QStringList>
 
 #include "ctkDICOMDisplayedFieldGeneratorAbstractRule.h"

--- a/Libs/DICOM/Core/ctkDICOMItem.h
+++ b/Libs/DICOM/Core/ctkDICOMItem.h
@@ -27,7 +27,7 @@
 
 #include <dcmtk/dcmdata/dcdatset.h> // DCMTK DcmDataset
 
-#include <QCoreApplication.h>
+#include <QCoreApplication>
 #include <QtCore>
 
 class DcmDataDictionary;


### PR DESCRIPTION
This commit fixes a regression introduced in c819ae737 (BUG: Mark translatable strings in DICOM/Core) through this pull request:
* https://github.com/commontk/CTK/pull/1068