### PR TITLE
ENH: Allow instantiation of more CTK objects in Python

### DIFF
--- a/Libs/Core/ctkErrorLogAbstractMessageHandler.cpp
+++ b/Libs/Core/ctkErrorLogAbstractMessageHandler.cpp
@@ -61,8 +61,8 @@ ctkErrorLogAbstractMessageHandlerPrivate::~ctkErrorLogAbstractMessageHandlerPriv
 // ctkErrorLogAbstractMessageHandlerPrivate methods
 
 // --------------------------------------------------------------------------
-ctkErrorLogAbstractMessageHandler::ctkErrorLogAbstractMessageHandler()
-  : Superclass(), d_ptr(new ctkErrorLogAbstractMessageHandlerPrivate)
+ctkErrorLogAbstractMessageHandler::ctkErrorLogAbstractMessageHandler(QObject* parent)
+  : Superclass(parent), d_ptr(new ctkErrorLogAbstractMessageHandlerPrivate)
 {
 }
 

--- a/Libs/Core/ctkErrorLogAbstractMessageHandler.h
+++ b/Libs/Core/ctkErrorLogAbstractMessageHandler.h
@@ -42,7 +42,7 @@ class CTK_CORE_EXPORT ctkErrorLogAbstractMessageHandler : public QObject
 public:
   typedef QObject Superclass;
   /// Disabled by default.
-  ctkErrorLogAbstractMessageHandler();
+  ctkErrorLogAbstractMessageHandler(QObject* parent = 0);
   virtual ~ctkErrorLogAbstractMessageHandler();
 
   virtual QString handlerName()const = 0;

--- a/Libs/Core/ctkErrorLogLevel.cpp
+++ b/Libs/Core/ctkErrorLogLevel.cpp
@@ -24,7 +24,8 @@
 #include <QMetaEnum>
 
 // --------------------------------------------------------------------------
-ctkErrorLogLevel::ctkErrorLogLevel()
+ctkErrorLogLevel::ctkErrorLogLevel(QObject* parent)
+  : Superclass(parent)
 {
   qRegisterMetaType<ctkErrorLogLevel::LogLevel>("ctkErrorLogLevel::LogLevel");
 }

--- a/Libs/Core/ctkErrorLogLevel.h
+++ b/Libs/Core/ctkErrorLogLevel.h
@@ -34,7 +34,8 @@ class CTK_CORE_EXPORT ctkErrorLogLevel : public QObject
   Q_OBJECT
   Q_FLAGS(LogLevel)
 public:
-  ctkErrorLogLevel();
+  typedef QObject Superclass;
+  ctkErrorLogLevel(QObject* parent = 0);
 
   enum LogLevel
     {

--- a/Libs/Core/ctkErrorLogQtMessageHandler.cpp
+++ b/Libs/Core/ctkErrorLogQtMessageHandler.cpp
@@ -44,7 +44,8 @@ QString ctkErrorLogQtMessageHandler::HandlerName = QLatin1String("Qt");
 Q_DECLARE_METATYPE(ctkErrorLogQtMessageHandler*)
 
 // --------------------------------------------------------------------------
-ctkErrorLogQtMessageHandler::ctkErrorLogQtMessageHandler() : Superclass()
+ctkErrorLogQtMessageHandler::ctkErrorLogQtMessageHandler(QObject* parent)
+  : Superclass(parent)
 {
   this->SavedQtMessageHandler = 0;
 

--- a/Libs/Core/ctkErrorLogQtMessageHandler.h
+++ b/Libs/Core/ctkErrorLogQtMessageHandler.h
@@ -39,7 +39,7 @@ class CTK_CORE_EXPORT ctkErrorLogQtMessageHandler : public ctkErrorLogAbstractMe
 public:
   typedef ctkErrorLogAbstractMessageHandler Superclass;
 
-  ctkErrorLogQtMessageHandler();
+  ctkErrorLogQtMessageHandler(QObject* parent = 0);
 
   static QString HandlerName;
 

--- a/Libs/Core/ctkErrorLogTerminalOutput.cpp
+++ b/Libs/Core/ctkErrorLogTerminalOutput.cpp
@@ -69,8 +69,8 @@ ctkErrorLogTerminalOutputPrivate::~ctkErrorLogTerminalOutputPrivate()
 // ctkErrorLogTerminalOutput methods
 
 // --------------------------------------------------------------------------
-ctkErrorLogTerminalOutput::ctkErrorLogTerminalOutput()
-  : d_ptr(new ctkErrorLogTerminalOutputPrivate)
+ctkErrorLogTerminalOutput::ctkErrorLogTerminalOutput(QObject* parent)
+  : Superclass(parent), d_ptr(new ctkErrorLogTerminalOutputPrivate)
 {
 }
 

--- a/Libs/Core/ctkErrorLogTerminalOutput.h
+++ b/Libs/Core/ctkErrorLogTerminalOutput.h
@@ -39,7 +39,8 @@ class CTK_CORE_EXPORT ctkErrorLogTerminalOutput : public QObject
   Q_FLAGS(TerminalOutputs)
 
 public:
-  ctkErrorLogTerminalOutput();
+  typedef QObject Superclass;
+  ctkErrorLogTerminalOutput(QObject* parent = 0);
   virtual ~ctkErrorLogTerminalOutput();
 
   enum TerminalOutput

--- a/Libs/QtTesting/ctkEventTranslatorPlayerWidget.cpp
+++ b/Libs/QtTesting/ctkEventTranslatorPlayerWidget.cpp
@@ -56,8 +56,8 @@ ctkEventTranslatorPlayerWidgetPrivate::~ctkEventTranslatorPlayerWidgetPrivate()
 }
 
 //-----------------------------------------------------------------------------
-ctkEventTranslatorPlayerWidget::ctkEventTranslatorPlayerWidget()
-  :  Superclass()
+ctkEventTranslatorPlayerWidget::ctkEventTranslatorPlayerWidget(QWidget* parent, Qt::WindowFlags flags)
+  : Superclass(parent, flags)
   , d_ptr(new ctkEventTranslatorPlayerWidgetPrivate)
 {
   Q_D(ctkEventTranslatorPlayerWidget);

--- a/Libs/QtTesting/ctkEventTranslatorPlayerWidget.h
+++ b/Libs/QtTesting/ctkEventTranslatorPlayerWidget.h
@@ -55,7 +55,7 @@ class CTK_QTTESTING_EXPORT ctkEventTranslatorPlayerWidget
   Q_OBJECT
 public:
   typedef QMainWindow Superclass;
-  ctkEventTranslatorPlayerWidget();
+  ctkEventTranslatorPlayerWidget(QWidget* parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~ctkEventTranslatorPlayerWidget();
 
   void addTestCase(QWidget* widget, QString fileName, void(*newCallback)(void* data));


### PR DESCRIPTION
CTK objects that only had default constructor (no Object* parameter) were not possible to instantiate in Python:

>>> a=ctk.ctkErrorLogLevel()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
ValueError: No constructors available for ctkErrorLogLevel

The issue is fixed by passing arguments of the superclass constructor.

This pull request (along with https://github.com/commontk/CTK/pull/985) supersedes https://github.com/commontk/CTK/pull/796. Accepting arguments in the constructor (that are passed on to the superclass constructor) is a better solution than accepting wrapping of constructors that don't take any arguments.