### PR TITLE
ENH: Remove irrelevant translatable strings

### DIFF
--- a/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerMainWindow.cpp
+++ b/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerMainWindow.cpp
@@ -440,7 +440,7 @@ void ctkCLModuleExplorerMainWindow::checkXMLPressed()
     moduleManager.setValidationMode(previousMode);
     QWidget* widget = QApplication::activeModalWidget();
     if (widget == NULL) widget = QApplication::activeWindow();
-    QMessageBox::critical(widget, QObject::tr("Failed while checking XML:"), except.message());
+    QMessageBox::critical(widget, tr("Failed while checking XML:"), except.message());
   }
 }
 

--- a/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerProgressWidget.ui
+++ b/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerProgressWidget.ui
@@ -11,19 +11,28 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Progress</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
     <number>2</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
     <widget class="QLabel" name="ProgressTitle">
      <property name="text">
-      <string>TextLabel</string>
+      <string notr="true">TextLabel</string>
      </property>
     </widget>
    </item>
@@ -39,7 +48,7 @@
      <item>
       <widget class="QToolButton" name="PauseButton">
        <property name="text">
-        <string>...</string>
+        <string>Pause</string>
        </property>
        <property name="icon">
         <iconset resource="resources/ctkCmdLineModuleExplorer.qrc">
@@ -56,7 +65,7 @@
      <item>
       <widget class="QToolButton" name="CancelButton">
        <property name="text">
-        <string>...</string>
+        <string>Cancel</string>
        </property>
        <property name="icon">
         <iconset resource="resources/ctkCmdLineModuleExplorer.qrc">
@@ -82,7 +91,7 @@
    <item>
     <widget class="QLabel" name="ProgressText">
      <property name="text">
-      <string>TextLabel</string>
+      <string notr="true">TextLabel</string>
      </property>
     </widget>
    </item>

--- a/Applications/ctkDICOMHost/ctkDICOMHostMainWidget.ui
+++ b/Applications/ctkDICOMHost/ctkDICOMHostMainWidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>DICOM Hosts</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/Applications/ctkDICOMObjectViewer/ctkDICOMObjectViewerMain.cpp
+++ b/Applications/ctkDICOMObjectViewer/ctkDICOMObjectViewerMain.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
   else
     {
     s = QFileDialog::getOpenFileName( 0,
-     QFileDialog::tr("Choose an image file"), ".",
+     "Choose an image file", ".",
      "DCM (*)"
      );
     if( s.size() == 0 )

--- a/Applications/ctkEventBusDemo/ctkEventBusDemoMainWindow.ui
+++ b/Applications/ctkEventBusDemo/ctkEventBusDemoMainWindow.ui
@@ -29,7 +29,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>EventBus Demo App</string>
+   <string>EventBus Demo</string>
   </property>
   <widget class="QWidget" name="centralWidget">
    <widget class="QWidget" name="layoutWidget">
@@ -47,21 +47,21 @@
        <item>
         <widget class="QLineEdit" name="hostLineEdit">
          <property name="text">
-          <string>127.0.0.1</string>
+          <string notr="true">127.0.0.1</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QLineEdit" name="portLineEdit">
          <property name="text">
-          <string>8000</string>
+          <string notr="true">8000</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QPushButton" name="connectButton">
          <property name="text">
-          <string>connect</string>
+          <string>Connect</string>
          </property>
         </widget>
        </item>

--- a/Applications/ctkPluginBrowser/ctkPluginBrowserMainWindow.ui
+++ b/Applications/ctkPluginBrowser/ctkPluginBrowserMainWindow.ui
@@ -11,14 +11,23 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MainWindow</string>
+   <string>Plugin Browser</string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <property name="spacing">
      <number>0</number>
     </property>
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
    </layout>
@@ -29,7 +38,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>23</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -56,7 +65,16 @@
      <property name="spacing">
       <number>0</number>
      </property>
-     <property name="margin">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>
@@ -111,7 +129,16 @@
      <property name="spacing">
       <number>0</number>
      </property>
-     <property name="margin">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>
@@ -139,7 +166,16 @@
      <property name="spacing">
       <number>0</number>
      </property>
-     <property name="margin">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>
@@ -164,7 +200,16 @@
      <property name="spacing">
       <number>0</number>
      </property>
-     <property name="margin">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>
@@ -173,7 +218,16 @@
         <property name="spacing">
          <number>0</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -182,7 +236,16 @@
            <property name="spacing">
             <number>2</number>
            </property>
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -194,7 +257,7 @@
               </size>
              </property>
              <property name="text">
-              <string>...</string>
+              <string>Link services</string>
              </property>
              <property name="icon">
               <iconset resource="ctkPluginBrowserResources.qrc">
@@ -248,7 +311,16 @@
      <property name="spacing">
       <number>0</number>
      </property>
-     <property name="margin">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>

--- a/Applications/ctkPluginGenerator/ctkPluginGeneratorMain.cpp
+++ b/Applications/ctkPluginGenerator/ctkPluginGeneratorMain.cpp
@@ -50,9 +50,9 @@ int main(int argv, char** argc)
     license.open(QIODevice::ReadOnly);
     QString licenseText = license.readAll();
     bool ok;
-    QString organization = QInputDialog::getText(0, qApp->translate("OrganizationInputDialog", "CTK Plugin Generator"),
-                                                 qApp->translate("OrganizationInputDialog", "Enter the name of your organization:"),
-                                                 QLineEdit::Normal, qApp->translate("OrganizationInputDialog", "<your-organization>"), &ok);
+    QString organization = QInputDialog::getText(0, ctkPluginGenerator::tr("CTK Plugin Generator"),
+      ctkPluginGenerator::tr("Enter the name of your organization:"),
+      QLineEdit::Normal, ctkPluginGenerator::tr("<your-organization>"), &ok);
     if (!ok)
     {
       exit(0);

--- a/Applications/ctkPluginGenerator/ctkPluginGeneratorMainWindow.ui
+++ b/Applications/ctkPluginGenerator/ctkPluginGeneratorMainWindow.ui
@@ -31,7 +31,16 @@
       </property>
       <widget class="QWidget" name="editPage">
        <layout class="QVBoxLayout" name="verticalLayout_4">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -41,7 +50,16 @@
           </property>
           <widget class="QWidget" name="widget_5" native="true">
            <layout class="QVBoxLayout" name="verticalLayout_3">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <item>
@@ -112,7 +130,16 @@ p, li { white-space: pre-wrap; }
                <property name="spacing">
                 <number>0</number>
                </property>
-               <property name="margin">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
                 <number>0</number>
                </property>
                <item>
@@ -130,7 +157,7 @@ p, li { white-space: pre-wrap; }
                   </font>
                  </property>
                  <property name="text">
-                  <string>TextLabel</string>
+                  <string notr="true">TextLabel</string>
                  </property>
                 </widget>
                </item>
@@ -180,7 +207,7 @@ p, li { white-space: pre-wrap; }
                   </palette>
                  </property>
                  <property name="text">
-                  <string>TextLabel</string>
+                  <string notr="true">TextLabel</string>
                  </property>
                 </widget>
                </item>
@@ -208,7 +235,16 @@ p, li { white-space: pre-wrap; }
         <enum>Qt::LeftToRight</enum>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_5">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -218,7 +254,16 @@ p, li { white-space: pre-wrap; }
           </property>
           <widget class="QWidget" name="widget_2" native="true">
            <layout class="QVBoxLayout" name="verticalLayout_6">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <item>
@@ -252,7 +297,16 @@ p, li { white-space: pre-wrap; }
           </widget>
           <widget class="QWidget" name="widget_6" native="true">
            <layout class="QVBoxLayout" name="verticalLayout_7">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <item>
@@ -292,7 +346,16 @@ p, li { white-space: pre-wrap; }
     <item>
      <widget class="QWidget" name="widget" native="true">
       <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -350,7 +413,16 @@ p, li { white-space: pre-wrap; }
     <item>
      <widget class="QWidget" name="widget_3" native="true">
       <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -398,7 +470,7 @@ p, li { white-space: pre-wrap; }
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>25</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -431,6 +503,10 @@ p, li { white-space: pre-wrap; }
    <class>ctkDirectoryButton</class>
    <extends>QWidget</extends>
    <header>ctkDirectoryButton.h</header>
+   <container>1</container>
+   <slots>
+    <signal>directoryChanged(QString)</signal>
+   </slots>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Applications/ctkPluginGenerator/ctkPluginGeneratorOptionsDialog.ui
+++ b/Applications/ctkPluginGenerator/ctkPluginGeneratorOptionsDialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Options</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/Applications/ctkQtTesting/ctkQtTestingMainWindow.ui
+++ b/Applications/ctkQtTesting/ctkQtTestingMainWindow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MainWindow</string>
+   <string>Qt Testing</string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QHBoxLayout" name="horizontalLayout">

--- a/Libs/CommandLineModules/Backend/LocalProcess/ctkCmdLineModuleProcessTask.cpp
+++ b/Libs/CommandLineModules/Backend/LocalProcess/ctkCmdLineModuleProcessTask.cpp
@@ -1,22 +1,22 @@
 /*=============================================================================
-  
+
   Library: CTK
-  
+
   Copyright (c) German Cancer Research Center,
     Division of Medical and Biological Informatics
-    
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-  
+
 =============================================================================*/
 
 #include "ctkCmdLineModuleProcessTask.h"
@@ -105,7 +105,7 @@ void ctkCmdLineModuleProcessTask::run()
   }
   else
   {
-    this->setProgressValueAndText(1002, QObject::tr("Finished."));
+    this->setProgressValueAndText(1002, tr("Finished."));
   }
   this->reportFinished();
 }

--- a/Libs/CommandLineModules/Backend/LocalProcess/ctkCmdLineModuleProcessTask.h
+++ b/Libs/CommandLineModules/Backend/LocalProcess/ctkCmdLineModuleProcessTask.h
@@ -46,6 +46,7 @@ struct ctkCmdLineModuleProcessTaskPrivate;
 class CTK_CMDLINEMODULEBACKENDLP_EXPORT ctkCmdLineModuleProcessTask
     : public ctkCmdLineModuleFutureInterface, public QRunnable
 {
+  Q_DECLARE_TR_FUNCTIONS(ctkCmdLineModuleProcessTask)
 
 public:
 

--- a/Libs/CommandLineModules/Core/ctkCmdLineModuleConcurrentHelpers.cpp
+++ b/Libs/CommandLineModules/Core/ctkCmdLineModuleConcurrentHelpers.cpp
@@ -70,7 +70,7 @@ ctkCmdLineModuleReferenceResult ctkCmdLineModuleConcurrentRegister::operator()(c
   }
   catch (...)
   {
-    QString errorMessage = QObject::tr("Module %1 failed with an unknown exception.").arg(moduleUrl.toString());
+    QString errorMessage = QString("Module %1 failed with an unknown exception.").arg(moduleUrl.toString());
     if (this->Debug)
     {
       qDebug() << errorMessage;

--- a/Libs/CommandLineModules/Core/ctkCmdLineModuleUtils.cpp
+++ b/Libs/CommandLineModules/Core/ctkCmdLineModuleUtils.cpp
@@ -42,22 +42,22 @@ QString ctkCmdLineModuleUtils::errorMessagesFromModuleRegistration(
       const ctkCmdLineModuleReferenceResult& moduleRefResult = listIter.next();
       if (!moduleRefResult.m_Reference)
       {
-        errorMsg += (QObject::tr("Failed to register module:\n%1\n\ndue to:\n%2\n\n").arg(moduleRefResult.m_Url.toString()).arg(moduleRefResult.m_RuntimeError));
+        errorMsg += (ctkCmdLineModuleManager::tr("Failed to register module:\n%1\n\ndue to:\n%2\n\n").arg(moduleRefResult.m_Url.toString()).arg(moduleRefResult.m_RuntimeError));
       }
       else if (!moduleRefResult.m_Reference.xmlValidationErrorString().isEmpty() &&
              validationMode == ctkCmdLineModuleManager::STRICT_VALIDATION)
       {
-        errorMsg += (QObject::tr("Failed to register module:\n%1\n\ndue to xml validation error:\n%2\n\n").arg(moduleRefResult.m_Url.toString()).arg(moduleRefResult.m_Reference.xmlValidationErrorString()));
+        errorMsg += (ctkCmdLineModuleManager::tr("Failed to register module:\n%1\n\ndue to xml validation error:\n%2\n\n").arg(moduleRefResult.m_Url.toString()).arg(moduleRefResult.m_Reference.xmlValidationErrorString()));
       }
     }
     // These exceptions should never happen, as at this point we are iterating over a fixed list of results, and not processing exceptions.
     catch (const ctkCmdLineModuleRunException& e)
     {
-      errorMsg += QObject::tr("Failed to register module:\n") + e.location().toString() + "\n\ndue to:\n" + e.message() + "\n\n";
+      errorMsg += (ctkCmdLineModuleManager::tr("Failed to register module:\n%1\n\ndue to:\n%2\n\n").arg(e.location().toString()).arg(e.message()));
     }
     catch (const std::exception& e)
     {
-      errorMsg += QObject::tr("Failed to register module:\n\n\ndue to:\n") + e.what() + "\n\n";
+      errorMsg += (ctkCmdLineModuleManager::tr("Failed to register module:\n\n\ndue to:\n%1\n\n").arg(e.what()));
     }
   }
   return errorMsg;
@@ -93,7 +93,7 @@ void ctkCmdLineModuleUtils::messageBoxForModuleRegistration(
   {
     QWidget* widget = QApplication::activeModalWidget();
     if (widget == NULL) widget = QApplication::activeWindow();
-    QMessageBox::critical(widget, QObject::tr("Failed to register modules"), errorMsg);
+    QMessageBox::critical(widget, ctkCmdLineModuleManager::tr("Failed to register modules"), errorMsg);
   }
 }
 

--- a/Libs/DICOM/Core/ctkDICOMModel.cpp
+++ b/Libs/DICOM/Core/ctkDICOMModel.cpp
@@ -122,24 +122,25 @@ ctkDICOMModelPrivate::~ctkDICOMModelPrivate()
 //------------------------------------------------------------------------------
 void ctkDICOMModelPrivate::init()
 {
+  // Do not translate these strings (later they are used in the database query)
   QMap<int, QVariant> data;
-  data[Qt::DisplayRole] = ctkDICOMModel::tr("Name");
+  data[Qt::DisplayRole] = "Name";
   this->Headers << data;
-  data[Qt::DisplayRole] = ctkDICOMModel::tr("Age");
+  data[Qt::DisplayRole] = "Age";
   this->Headers << data;
-  data[Qt::DisplayRole] = ctkDICOMModel::tr("Scan");
+  data[Qt::DisplayRole] = "Scan";
   this->Headers << data;
-  data[Qt::DisplayRole] = ctkDICOMModel::tr("Date");
+  data[Qt::DisplayRole] = "Date";
   this->Headers << data;
-  data[Qt::DisplayRole] = ctkDICOMModel::tr("Subject ID");
+  data[Qt::DisplayRole] = "Subject ID";
   this->Headers << data;
-  data[Qt::DisplayRole] = ctkDICOMModel::tr("Number");
+  data[Qt::DisplayRole] = "Number";
   this->Headers << data;
-  data[Qt::DisplayRole] = ctkDICOMModel::tr("Institution");
+  data[Qt::DisplayRole] = "Institution";
   this->Headers << data;
-  data[Qt::DisplayRole] = ctkDICOMModel::tr("Referrer");
+  data[Qt::DisplayRole] = "Referrer";
   this->Headers << data;
-  data[Qt::DisplayRole] = ctkDICOMModel::tr("Performer");
+  data[Qt::DisplayRole] = "Performer";
   this->Headers << data;
 }
 

--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMAppWidget.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMAppWidget.ui
@@ -302,7 +302,7 @@
              <string>Previous study</string>
             </property>
             <property name="text">
-             <string>&lt;&lt;&lt;</string>
+             <string notr="true">&lt;&lt;&lt;</string>
             </property>
            </widget>
           </item>
@@ -324,7 +324,7 @@
              <string>Previous series</string>
             </property>
             <property name="text">
-             <string>&lt;&lt;</string>
+             <string notr="true">&lt;&lt;</string>
             </property>
            </widget>
           </item>
@@ -346,7 +346,7 @@
              <string>Previous image</string>
             </property>
             <property name="text">
-             <string>&lt;</string>
+             <string notr="true">&lt;</string>
             </property>
            </widget>
           </item>
@@ -368,7 +368,7 @@
              <string>Next image</string>
             </property>
             <property name="text">
-             <string>&gt;</string>
+             <string notr="true">&gt;</string>
             </property>
            </widget>
           </item>
@@ -390,7 +390,7 @@
              <string>Next series</string>
             </property>
             <property name="text">
-             <string>&gt;&gt;</string>
+             <string notr="true">&gt;&gt;</string>
             </property>
            </widget>
           </item>
@@ -412,7 +412,7 @@
              <string>Next study</string>
             </property>
             <property name="text">
-             <string>&gt;&gt;&gt;</string>
+             <string notr="true">&gt;&gt;&gt;</string>
             </property>
            </widget>
           </item>
@@ -522,12 +522,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ctkDICOMQueryWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkDICOMQueryWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>ctkDirectoryButton</class>
    <extends>QWidget</extends>
    <header>ctkDirectoryButton.h</header>
@@ -535,6 +529,12 @@
    <slots>
     <signal>directoryChanged(QString)</signal>
    </slots>
+  </customwidget>
+  <customwidget>
+   <class>ctkDICOMQueryWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkDICOMQueryWidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>ctkDICOMThumbnailListWidget</class>

--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMBrowser.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMBrowser.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>ctkDICOMBrowser</string>
+   <string>DICOM Browser</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="leftMargin">
@@ -35,7 +35,7 @@
    <item>
     <widget class="QToolBar" name="ToolBar">
      <property name="windowTitle">
-      <string>toolBar</string>
+      <string>DICOM Browser Toolbar</string>
      </property>
      <property name="floatable">
       <bool>true</bool>
@@ -106,14 +106,14 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="ctkDICOMTableManager" name="dicomTableManager" native="true">
+      <widget class="ctkDICOMTableManager" name="dicomTableManager">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="dynamicTableLayout" stdset="0">
+       <property name="dynamicTableLayout">
         <bool>true</bool>
        </property>
        <property name="m_DynamicLayout" stdset="0">
@@ -211,7 +211,7 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkDirectoryButton" name="DirectoryButton" native="true"/>
+    <widget class="ctkDirectoryButton" name="DirectoryButton"/>
    </item>
   </layout>
   <action name="ActionImport">

--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMListenerWidget.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMListenerWidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>DICOM Listener</string>
   </property>
  </widget>
  <resources/>

--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMObjectListWidget.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMObjectListWidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>DICOM metadata</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMQueryWidget.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMQueryWidget.ui
@@ -7,14 +7,23 @@
     <x>0</x>
     <y>0</y>
     <width>279</width>
-    <height>159</height>
+    <height>296</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Query</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -135,7 +144,7 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_5">
          <item>
-          <widget class="ctkModalityWidget" name="ModalityWidget" native="true">
+          <widget class="ctkModalityWidget" name="ModalityWidget">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
              <horstretch>0</horstretch>
@@ -154,15 +163,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ctkDateRangeWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkDateRangeWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>ctkModalityWidget</class>
    <extends>QWidget</extends>
    <header>ctkModalityWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkDateRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkDateRangeWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMTableManager.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMTableManager.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>DICOM</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMTableView.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMTableView.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>DICOM Data</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/Libs/PluginFramework/Testing/MetaTypeTestPlugins/pluginAttrPwd_test/ctkTestPluginMTAttrPwdActivator.cpp
+++ b/Libs/PluginFramework/Testing/MetaTypeTestPlugins/pluginAttrPwd_test/ctkTestPluginMTAttrPwdActivator.cpp
@@ -40,5 +40,3 @@ void ctkTestPluginMTAttrPwdActivator::stop(ctkPluginContext* context)
 #if QT_VERSION < QT_VERSION_CHECK(5,0,0)
 Q_EXPORT_PLUGIN2(pluginAttrPwd_test, ctkTestPluginMTAttrPwdActivator)
 #endif
-
-

--- a/Libs/QtTesting/Resources/UI/ctkEventTranslatorPlayerWidget.ui
+++ b/Libs/QtTesting/Resources/UI/ctkEventTranslatorPlayerWidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MainWindow</string>
+   <string>Event Player</string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QHBoxLayout" name="horizontalLayout">

--- a/Libs/Visualization/VTK/Widgets/Resources/UI/ctkVTKDiscretizableColorTransferWidget.ui
+++ b/Libs/Visualization/VTK/Widgets/Resources/UI/ctkVTKDiscretizableColorTransferWidget.ui
@@ -14,7 +14,16 @@
    <string>Color Transfer Function</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item row="1" column="3">
@@ -86,30 +95,30 @@
     </widget>
    </item>
    <item row="7" column="1" colspan="3">
-    <widget class="ctkRangeWidget" name="rangeSlider" native="true"/>
+    <widget class="ctkRangeWidget" name="rangeSlider"/>
    </item>
    <item row="2" column="1">
     <widget class="QLabel" name="maxOpacityLabel">
      <property name="text">
-      <string>1</string>
+      <string notr="true">1</string>
      </property>
     </widget>
    </item>
    <item row="3" column="1" rowspan="3">
-    <widget class="ctkDoubleSlider" name="opacitySlider" native="true">
-     <property name="value" stdset="0">
+    <widget class="ctkDoubleSlider" name="opacitySlider">
+     <property name="value">
       <double>1.000000000000000</double>
      </property>
-     <property name="singleStep" stdset="0">
+     <property name="singleStep">
       <double>0.100000000000000</double>
      </property>
-     <property name="pageStep" stdset="0">
+     <property name="pageStep">
       <double>0.200000000000000</double>
      </property>
-     <property name="minimum" stdset="0">
+     <property name="minimum">
       <double>0.000001000000000</double>
      </property>
-     <property name="maximum" stdset="0">
+     <property name="maximum">
       <double>1.000000000000000</double>
      </property>
     </widget>
@@ -120,7 +129,7 @@
    <item row="6" column="1">
     <widget class="QLabel" name="minOpacityLabel">
      <property name="text">
-      <string>0</string>
+      <string notr="true">0</string>
      </property>
     </widget>
    </item>

--- a/Libs/Visualization/VTK/Widgets/Resources/UI/ctkVTKScalarBarWidget.ui
+++ b/Libs/Visualization/VTK/Widgets/Resources/UI/ctkVTKScalarBarWidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>vtkScalarBarWidget</string>
+   <string>Scalar bar properties</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <property name="margin">

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
@@ -240,22 +240,22 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
     QStyle::SP_FileDialogDetailedView, CTK_NULLPTR, optionButton));
 
   QLabel* nanLabel = new QLabel(ctkVTKDiscretizableColorTransferWidget::tr("NaN values"));
-  nanButton = new ctkColorPickerButton;
-  nanButton->setToolTip(ctkVTKDiscretizableColorTransferWidget::tr("NaN color"));
-  nanColorLayout->addWidget(nanButton);
+  this->nanButton = new ctkColorPickerButton;
+  this->nanButton->setToolTip(ctkVTKDiscretizableColorTransferWidget::tr("NaN color"));
+  nanColorLayout->addWidget(this->nanButton);
   nanColorLayout->addWidget(nanLabel);
 
-  discretizeCheckBox = new QCheckBox;
-  discretizeCheckBox->setText(ctkVTKDiscretizableColorTransferWidget::tr("Discretize"));
-  discretizeCheckBox->setToolTip(ctkVTKDiscretizableColorTransferWidget::tr("Discretize color transfer function"));
-  nbOfDiscreteValuesSpinBox = new QSpinBox;
-  nbOfDiscreteValuesSpinBox->setMinimum(1);
-  nbOfDiscreteValuesSpinBox->setMaximum(255);
-  nbOfDiscreteValuesSpinBox->setToolTip(ctkVTKDiscretizableColorTransferWidget::tr("Number of discrete values"));
-  nbOfDiscreteValuesSpinBox->setEnabled(discretizeCheckBox->isChecked());
+  this->discretizeCheckBox = new QCheckBox;
+  this->discretizeCheckBox->setText(ctkVTKDiscretizableColorTransferWidget::tr("Discretize"));
+  this->discretizeCheckBox->setToolTip(ctkVTKDiscretizableColorTransferWidget::tr("Discretize color transfer function"));
+  this->nbOfDiscreteValuesSpinBox = new QSpinBox;
+  this->nbOfDiscreteValuesSpinBox->setMinimum(1);
+  this->nbOfDiscreteValuesSpinBox->setMaximum(255);
+  this->nbOfDiscreteValuesSpinBox->setToolTip(ctkVTKDiscretizableColorTransferWidget::tr("Number of discrete values"));
+  this->nbOfDiscreteValuesSpinBox->setEnabled(this->discretizeCheckBox->isChecked());
 
-  discretizeLayout->addWidget(discretizeCheckBox);
-  discretizeLayout->addWidget(nbOfDiscreteValuesSpinBox);
+  discretizeLayout->addWidget(this->discretizeCheckBox);
+  discretizeLayout->addWidget(this->nbOfDiscreteValuesSpinBox);
 
   QMenu* optionMenu = new QMenu(optionButton);
   QWidgetAction* nanColorAction = new QWidgetAction(optionButton);
@@ -269,17 +269,17 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
   optionButton->setMenu(optionMenu);
   optionButton->setPopupMode(QToolButton::InstantPopup);
 
-  QObject::connect(nanButton, SIGNAL(clicked()), q, SLOT(setNaNColor()));
+  QObject::connect(this->nanButton, SIGNAL(clicked()), q, SLOT(setNaNColor()));
 
-  QObject::connect(discretizeCheckBox, SIGNAL(toggled(bool)),
+  QObject::connect(this->discretizeCheckBox, SIGNAL(toggled(bool)),
     q, SLOT(setDiscretize(bool)));
 
-  QObject::connect(nbOfDiscreteValuesSpinBox, SIGNAL(valueChanged(int)),
+  QObject::connect(this->nbOfDiscreteValuesSpinBox, SIGNAL(valueChanged(int)),
     q, SLOT(setNumberOfDiscreteValues(int)));
 
   ///Enable nbOfValuesSpinBox only if we use discretize
-  QObject::connect(discretizeCheckBox, SIGNAL(toggled(bool)),
-    nbOfDiscreteValuesSpinBox, SLOT(setEnabled(bool)));
+  QObject::connect(this->discretizeCheckBox, SIGNAL(toggled(bool)),
+    this->nbOfDiscreteValuesSpinBox, SLOT(setEnabled(bool)));
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Widgets/Resources/UI/ctkAddRemoveComboBox.ui
+++ b/Libs/Widgets/Resources/UI/ctkAddRemoveComboBox.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>ctkAddRemoveComboBox</string>
+   <string>Select items</string>
   </property>
   <layout class="QHBoxLayout">
    <property name="spacing">

--- a/Libs/Widgets/Resources/UI/ctkPathListButtonsWidget.ui
+++ b/Libs/Widgets/Resources/UI/ctkPathListButtonsWidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Path list</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="margin">

--- a/Libs/Widgets/Resources/UI/ctkRangeWidget.ui
+++ b/Libs/Widgets/Resources/UI/ctkRangeWidget.ui
@@ -17,10 +17,19 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>ctkSliderSpinBoxWidget</string>
+   <string>Select range</string>
   </property>
   <layout class="QGridLayout" name="GridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item row="0" column="0">

--- a/Libs/Widgets/Resources/UI/ctkScreenshotDialog.ui
+++ b/Libs/Widgets/Resources/UI/ctkScreenshotDialog.ui
@@ -25,7 +25,7 @@
      <item>
       <widget class="QLabel" name="CountDownLabel">
        <property name="text">
-        <string>0 s</string>
+        <string notr="true">0 s</string>
        </property>
       </widget>
      </item>
@@ -45,7 +45,7 @@
      <item>
       <widget class="QLabel" name="ImageFullNameLabel">
        <property name="text">
-        <string>Untitled_0.png</string>
+        <string notr="true">Untitled_0.png</string>
        </property>
       </widget>
      </item>
@@ -107,7 +107,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="ctkPathLineEdit" name="DirectoryPathLineEdit" native="true">
+       <widget class="ctkPathLineEdit" name="DirectoryPathLineEdit">
         <property name="toolTip">
          <string>Select a directory in which screen captures will be saved.</string>
         </property>
@@ -155,11 +155,11 @@
         <property name="toolTip">
          <string>Select an integer scale factor (between 0.5 and 5) for the image file, e.g. a value of &quot;2&quot; will save an image twice the size.</string>
         </property>
-        <property name="decimalsOption">
-         <enum>ctkDoubleSpinBox::FixedDecimals</enum>
-        </property>
         <property name="decimals">
          <number>1</number>
+        </property>
+        <property name="decimalsOption">
+         <set>ctkDoubleSpinBox::FixedDecimals</set>
         </property>
         <property name="minimum">
          <double>0.500000000000000</double>
@@ -284,14 +284,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ctkPathLineEdit</class>
-   <extends>QWidget</extends>
-   <header>ctkPathLineEdit.h</header>
-  </customwidget>
-  <customwidget>
    <class>ctkDoubleSpinBox</class>
    <extends>QWidget</extends>
    <header>ctkDoubleSpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkPathLineEdit</class>
+   <extends>QWidget</extends>
+   <header>ctkPathLineEdit.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/Libs/Widgets/Resources/UI/ctkSliderWidget.ui
+++ b/Libs/Widgets/Resources/UI/ctkSliderWidget.ui
@@ -17,10 +17,19 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>ctkSliderWidget</string>
+   <string>Set value</string>
   </property>
   <layout class="QHBoxLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>

--- a/Libs/Widgets/Resources/UI/ctkThumbnailListWidget.ui
+++ b/Libs/Widgets/Resources/UI/ctkThumbnailListWidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>ThumbnailList</string>
+   <string>Thumbnails</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="margin">

--- a/Libs/Widgets/Testing/Cpp/ctkCheckablePushButtonEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCheckablePushButtonEventTranslatorPlayerTest1.cpp
@@ -106,7 +106,7 @@ int ctkCheckablePushButtonEventTranslatorPlayerTest1(int argc, char * argv [])
 
   // Test case 2
   QWidget widget2(0);
-  ctkCheckablePushButton button1(QObject::tr("Button1"));
+  ctkCheckablePushButton button1("Button1");
 
   button1.setCheckable(true);
 
@@ -120,8 +120,8 @@ int ctkCheckablePushButtonEventTranslatorPlayerTest1(int argc, char * argv [])
 
   // Test case 3
   QWidget widget3(0);
-  ctkCheckablePushButton button2(QObject::tr("Button1"));
-  ctkCheckablePushButton button3(QObject::tr("Button2"));
+  ctkCheckablePushButton button2("Button1");
+  ctkCheckablePushButton button3("Button2");
 
   button2.setCheckable(true);
   button3.setCheckable(true);

--- a/Libs/Widgets/Testing/Cpp/ctkCheckablePushButtonTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCheckablePushButtonTest1.cpp
@@ -39,22 +39,22 @@ int ctkCheckablePushButtonTest1(int argc, char * argv [] )
   QApplication app(argc, argv);
 
   QWidget topLevel;
-  ctkCheckablePushButton button1(QObject::tr("My very long text on button"));
-  ctkCheckablePushButton button2(QObject::tr("Button2"));
-  ctkCheckablePushButton button3(QObject::tr("Button3"));
-  ctkCheckablePushButton button4(QObject::tr("Button4"));
-  ctkCheckablePushButton button5(QObject::tr("Button5"));
-  ctkCheckablePushButton button6(QObject::tr("Button6"));
-  ctkCheckablePushButton button7(QObject::tr("Checkable PushButton"));
-  ctkCheckablePushButton button8(QObject::tr("Connected, Not User Checkable"));
-  ctkCheckablePushButton button9(QObject::tr("Connected, Not User Checkable"));
-  ctkCheckablePushButton button10(QObject::tr("Not Connected, User Checkable"));
-  ctkCheckablePushButton button11(QObject::tr("Not Connected, User Checkable"));
-  ctkCheckablePushButton button12(QObject::tr("Checkbox Not User Checkable\nButton Checkable"));
-  ctkCheckablePushButton button13(QObject::tr("Checkbox and Button User Checkable"));
-  ctkCheckablePushButton button14(QObject::tr("Checkable PushButton with menu"));
-  ctkCheckablePushButton button15(QObject::tr("Checkable PushButton with icon"));
-  ctkCheckablePushButton button16(QObject::tr("Check box controls button toggle state"));
+  ctkCheckablePushButton button1("My very long text on button");
+  ctkCheckablePushButton button2("Button2");
+  ctkCheckablePushButton button3("Button3");
+  ctkCheckablePushButton button4("Button4");
+  ctkCheckablePushButton button5("Button5");
+  ctkCheckablePushButton button6("Button6");
+  ctkCheckablePushButton button7("Checkable PushButton");
+  ctkCheckablePushButton button8("Connected, Not User Checkable");
+  ctkCheckablePushButton button9("Connected, Not User Checkable");
+  ctkCheckablePushButton button10("Not Connected, User Checkable");
+  ctkCheckablePushButton button11("Not Connected, User Checkable");
+  ctkCheckablePushButton button12("Checkbox Not User Checkable\nButton Checkable");
+  ctkCheckablePushButton button13("Checkbox and Button User Checkable");
+  ctkCheckablePushButton button14("Checkable PushButton with menu");
+  ctkCheckablePushButton button15("Checkable PushButton with icon");
+  ctkCheckablePushButton button16("Check box controls button toggle state");
 
   QVBoxLayout *layout= new QVBoxLayout;
   layout->addWidget(&button1);

--- a/Libs/Widgets/Testing/Cpp/ctkCollapsibleButtonEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCollapsibleButtonEventTranslatorPlayerTest1.cpp
@@ -71,11 +71,11 @@ int ctkCollapsibleButtonEventTranslatorPlayerTest1(int argc, char * argv [])
   // Test case 1
   ctkCollapsibleButton* widget = new ctkCollapsibleButton();
   widget->setText("top button");
-  QPushButton * button= new QPushButton(QObject::tr("Button"));
-  ctkCollapsibleButton *collapsibleButton2 = new ctkCollapsibleButton(QObject::tr("Nested Collapsible Button"));
-  ctkCollapsibleButton *collapsibleButton3 = new ctkCollapsibleButton(QObject::tr("CollapsibleButton"));
+  QPushButton * button= new QPushButton("Button");
+  ctkCollapsibleButton *collapsibleButton2 = new ctkCollapsibleButton("Nested Collapsible Button");
+  ctkCollapsibleButton *collapsibleButton3 = new ctkCollapsibleButton("CollapsibleButton");
   collapsibleButton3->setIcon(collapsibleButton3->style()->standardIcon(QStyle::SP_FileDialogDetailedView));
-  QPushButton * button2 = new QPushButton(QObject::tr("Nested PushButton"));
+  QPushButton * button2 = new QPushButton("Nested PushButton");
 
   QVBoxLayout *nestedBox = new QVBoxLayout;
   nestedBox->addWidget(button2);

--- a/Libs/Widgets/Testing/Cpp/ctkCollapsibleButtonTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCollapsibleButtonTest1.cpp
@@ -41,12 +41,12 @@ int ctkCollapsibleButtonTest1(int argc, char * argv [] )
   ctkCollapsibleButton collapsibleButton;
   collapsibleButton.setText("top button");
   QDoubleSpinBox *spinBox = new QDoubleSpinBox;
-  QPushButton * button= new QPushButton(QObject::tr("Button"));
-  ctkCollapsibleButton *collapsibleButton2 = new ctkCollapsibleButton(QObject::tr("Nested Collapsible Button"));
-  ctkCollapsibleButton *collapsibleButton3 = new ctkCollapsibleButton(QObject::tr("CollapsibleButton"));
+  QPushButton * button= new QPushButton("Button");
+  ctkCollapsibleButton *collapsibleButton2 = new ctkCollapsibleButton("Nested Collapsible Button");
+  ctkCollapsibleButton *collapsibleButton3 = new ctkCollapsibleButton("CollapsibleButton");
   // ctkCollapsibleButton::icon is not activated
   collapsibleButton3->setIcon(collapsibleButton3->style()->standardIcon(QStyle::SP_FileDialogDetailedView));
-  QPushButton * button2 = new QPushButton(QObject::tr("Nested PushButton"));
+  QPushButton * button2 = new QPushButton("Nested PushButton");
 
   QVBoxLayout *nestedBox = new QVBoxLayout;
   nestedBox->addWidget(button2);
@@ -89,9 +89,9 @@ int ctkCollapsibleButtonTest1(int argc, char * argv [] )
     std::cerr<< "ctkCollapsibleButton::setChecked failed." << std::endl;
     return EXIT_FAILURE;
     }
-  
+
   collapsibleButton2->setCollapsedHeight(40);
-  
+
   if (collapsibleButton2->collapsedHeight() != 40)
     {
     std::cerr << "ctkCollapsibleButton::setCollapsedHeight failed."

--- a/Libs/Widgets/Testing/Cpp/ctkCollapsibleGroupBoxEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCollapsibleGroupBoxEventTranslatorPlayerTest1.cpp
@@ -81,10 +81,10 @@ int ctkCollapsibleGroupBoxEventTranslatorPlayerTest1(int argc, char * argv [] )
 
   // Test case 1
   QWidget widget(0);
-  ctkCollapsibleGroupBox* groupBox = new ctkCollapsibleGroupBox(QObject::tr("GroupBox"));
-  QRadioButton *radio1 = new QRadioButton(QObject::tr("&Radio button 1"));
-  QRadioButton *radio2 = new QRadioButton(QObject::tr("R&adio button 2"));
-  QRadioButton *radio3 = new QRadioButton(QObject::tr("Ra&dio button 3"));
+  ctkCollapsibleGroupBox* groupBox = new ctkCollapsibleGroupBox("GroupBox");
+  QRadioButton *radio1 = new QRadioButton("&Radio button 1");
+  QRadioButton *radio2 = new QRadioButton("R&adio button 2");
+  QRadioButton *radio3 = new QRadioButton("Ra&dio button 3");
   ctkCollapsibleGroupBox* hiddenGroupBox = new ctkCollapsibleGroupBox;
   hiddenGroupBox->setTitle("Advanced...");
 
@@ -128,4 +128,3 @@ int ctkCollapsibleGroupBoxEventTranslatorPlayerTest1(int argc, char * argv [] )
   etpWidget.show();
   return app.exec();
 }
-

--- a/Libs/Widgets/Testing/Cpp/ctkCollapsibleGroupBoxTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCollapsibleGroupBoxTest1.cpp
@@ -38,10 +38,10 @@ int ctkCollapsibleGroupBoxTest1(int argc, char * argv [] )
   QApplication app(argc, argv);
 
   QWidget topLevel;
-  ctkCollapsibleGroupBox* groupBox = new ctkCollapsibleGroupBox(QObject::tr("GroupBox"));
-  QRadioButton *radio1 = new QRadioButton(QObject::tr("&Radio button 1"));
-  QRadioButton *radio2 = new QRadioButton(QObject::tr("R&adio button 2"));
-  QRadioButton *radio3 = new QRadioButton(QObject::tr("Ra&dio button 3"));
+  ctkCollapsibleGroupBox* groupBox = new ctkCollapsibleGroupBox("GroupBox");
+  QRadioButton *radio1 = new QRadioButton("&Radio button 1");
+  QRadioButton *radio2 = new QRadioButton("R&adio button 2");
+  QRadioButton *radio3 = new QRadioButton("Ra&dio button 3");
   ctkCollapsibleGroupBox* hiddenGroupBox = new ctkCollapsibleGroupBox;
   hiddenGroupBox->setTitle("Advanced...");
 
@@ -121,4 +121,3 @@ int ctkCollapsibleGroupBoxTest1(int argc, char * argv [] )
 
   return app.exec();
 }
-

--- a/Libs/Widgets/ctkColorDialog.cpp
+++ b/Libs/Widgets/ctkColorDialog.cpp
@@ -60,15 +60,15 @@ void ctkColorDialogPrivate::init()
   QVBoxLayout* mainLay = qobject_cast<QVBoxLayout*>(q->layout());
   QHBoxLayout* topLay = qobject_cast<QHBoxLayout*>(mainLay->itemAt(0)->layout());
   QVBoxLayout* leftLay = qobject_cast<QVBoxLayout*>(topLay->takeAt(0)->layout());
-  
+
   leftLay->setParent(0);
   this->BasicTab = new QWidget(q);
   this->BasicTab->setLayout(leftLay);
 
   this->LeftTabWidget = new QTabWidget(q);
   topLay->insertWidget(0, this->LeftTabWidget);
-  this->LeftTabWidget->addTab(this->BasicTab, QObject::tr("Basic"));
-  
+  this->LeftTabWidget->addTab(this->BasicTab, ctkColorDialog::tr("Basic"));
+
   // If you use a ctkColorDialog, it's probably because you have tabs to add
   // into. Which means that you are likely to want to resize the dialog as
   // well.

--- a/Plugins/org.commontk.eventbus/ctkEventDispatcher.cpp
+++ b/Plugins/org.commontk.eventbus/ctkEventDispatcher.cpp
@@ -170,7 +170,7 @@ bool ctkEventDispatcher::addObserver(ctkBusEvent &props) {
         //bool testRes = this->isLocalSignalPresent(topic);
         itemEventProp = m_SignalsHash.value(topic);
         if(itemEventProp == NULL) {
-            qDebug() << tr("Signal not present for topic %1, create only the entry in CallbacksHash").arg(topic);
+            qDebug() << QString("Signal not present for topic %1, create only the entry in CallbacksHash").arg(topic);
 
             ctkBusEvent *dict = const_cast<ctkBusEvent *>(&props);
             this->m_CallbacksHash.insertMulti(topic, dict);
@@ -180,10 +180,10 @@ bool ctkEventDispatcher::addObserver(ctkBusEvent &props) {
 
         QString observer_sig = CALLBACK_SIGNATURE;
         observer_sig.append(props[SIGNATURE].toString());
-        
+
         QString event_sig = SIGNAL_SIGNATURE;
         event_sig.append((*itemEventProp)[SIGNATURE].toString());
-        
+
         // Add the new observer to the Hash.
         ctkBusEvent *dict = const_cast<ctkBusEvent *>(&props);
         this->m_CallbacksHash.insertMulti(topic, dict);
@@ -191,11 +191,11 @@ bool ctkEventDispatcher::addObserver(ctkBusEvent &props) {
 
         return connect(objSignal, event_sig.toLatin1(), objSlot, observer_sig.toLatin1());
     }
-    
-    qDebug() << tr("Signal not valid for topic: %1").arg(topic);
+
+    qDebug() << QString("Signal not valid for topic: %1").arg(topic);
     QString objValid = objSlot ? "YES":"NO";
-    qDebug() << tr("Object valid Address: %1").arg(objValid);
-    qDebug() << tr("Signature: %1").arg(sig);
+    qDebug() << QString("Object valid Address: %1").arg(objValid);
+    qDebug() << QString("Signature: %1").arg(sig);
     return false;
 }
 
@@ -239,7 +239,7 @@ bool ctkEventDispatcher::removeFromHash(ctkEventsHashType *hash, const QObject *
                     delete i.value();
                     i = hash->erase(i);
                 } else {
-                    qDebug() << tr("Unable to disconnect object %1 on topic %2").arg(obj->objectName(), topic);
+                    qDebug() << QString("Unable to disconnect object %1 on topic %2").arg(obj->objectName(), topic);
                     ++i;
                 }
             } else {
@@ -270,7 +270,7 @@ bool ctkEventDispatcher::removeFromHash(ctkEventsHashType *hash, const QObject *
                     delete i.value();
                     i = hash->erase(i);
                 } else {
-                    qDebug() << tr("Unable to disconnect object %1 from topic %2").arg(obj->objectName(), (*prop)[TOPIC].toString());
+                    qDebug() << QString("Unable to disconnect object %1 from topic %2").arg(obj->objectName(), (*prop)[TOPIC].toString());
                     ++i;
                 }
             } else {
@@ -303,9 +303,9 @@ bool ctkEventDispatcher::registerSignal(ctkBusEvent &props) {
         // Only one signal for a given id can be registered!!
         QObject *obj = props[OBJECT].value<QObject *>();
         if(obj != NULL) {
-            qWarning("%s", tr("Object %1 is trying to register a signal with Topic '%2' that has been already registered!!").arg(obj->metaObject()->className(), topic).toUtf8().data());
+            qWarning("%s", QString("Object %1 is trying to register a signal with Topic '%2' that has been already registered!!").arg(obj->metaObject()->className(), topic).toUtf8().data());
         } else {
-            qWarning("%s", tr("NULL is trying to register a signal with Topic '%2' that has been already registered!!").arg(topic).toUtf8().data());
+            qWarning("%s", QString("NULL is trying to register a signal with Topic '%2' that has been already registered!!").arg(topic).toUtf8().data());
         }
         return false;
     }
@@ -314,7 +314,7 @@ bool ctkEventDispatcher::registerSignal(ctkBusEvent &props) {
     ctkEventItemListType itemEventPropList;
     itemEventPropList = m_CallbacksHash.values(topic);
     if(itemEventPropList.count() == 0) {
-        qDebug() << tr("Callbacks not present for topic %1, create only the entry in SignalsHash").arg(topic);
+        qDebug() << QString("Callbacks not present for topic %1, create only the entry in SignalsHash").arg(topic);
 
         // Add the new signal to the Hash.
         ctkBusEvent *dict = const_cast<ctkBusEvent *>(&props);

--- a/Plugins/org.commontk.eventbus/ctkEventDispatcherLocal.cpp
+++ b/Plugins/org.commontk.eventbus/ctkEventDispatcherLocal.cpp
@@ -92,7 +92,7 @@ void ctkEventDispatcherLocal::notifyEvent(ctkBusEvent &event_dictionary, ctkEven
                              argList->at(5), argList->at(6), argList->at(7), argList->at(8), argList->at(9));
                             break;
                         default:
-                            qWarning("%s", tr("Number of arguments not supported. Max 10 arguments").toUtf8().data());
+                            qWarning("%s", QString("Number of arguments not supported. Max 10 arguments").toUtf8().data());
                     } //switch
                  } else { //use return value
                     switch (argList->count()) {
@@ -144,7 +144,7 @@ void ctkEventDispatcherLocal::notifyEvent(ctkBusEvent &event_dictionary, ctkEven
                              argList->at(5), argList->at(6), argList->at(7), argList->at(8), argList->at(9));
                             break;
                         default:
-                            qWarning("%s", tr("Number of arguments not supported. Max 10 arguments").toUtf8().data());
+                            qWarning("%s", QString("Number of arguments not supported. Max 10 arguments").toUtf8().data());
                     } //switch
                  }
             } else {
@@ -158,4 +158,3 @@ void ctkEventDispatcherLocal::notifyEvent(ctkBusEvent &event_dictionary, ctkEven
         }
     }
 }
-

--- a/Plugins/org.commontk.eventbus/ctkNetworkConnectorQXMLRPC.cpp
+++ b/Plugins/org.commontk.eventbus/ctkNetworkConnectorQXMLRPC.cpp
@@ -69,7 +69,7 @@ void ctkNetworkConnectorQXMLRPC::createServer(const unsigned int port) {
     m_Server->setProperty("port", port);
 
     // Create a new ID to allow methods registration on new server instance.
-    QString id_name(tr("ctk/remote/eventbus/communication/send/xmlrpc/serverMethods%1").arg(port));
+    QString id_name(QString("ctk/remote/eventbus/communication/send/xmlrpc/serverMethods%1").arg(port));
 
     // Register the signal to the event bus.
     /*mafRegisterRemoteSignal(id_name, this, "registerMethodsServer(mafRegisterMethodsMap)");
@@ -95,7 +95,7 @@ void ctkNetworkConnectorQXMLRPC::stopServer() {
     unsigned int p = m_Server->property("port").toUInt();
     if(p != 0) {
         // get the ID for the previous server;
-        /*QString old_id_name(tr("ctk/remote/eventbus/communication/send/xmlrpc/serverMethods%1").arg(p));
+        /*QString old_id_name(QString("ctk/remote/eventbus/communication/send/xmlrpc/serverMethods%1").arg(p));
         // Remove the old signal.
         ctkBusEvent props;
         props[TOPIC] = old_id_name;
@@ -112,7 +112,7 @@ void ctkNetworkConnectorQXMLRPC::stopServer() {
 
 void ctkNetworkConnectorQXMLRPC::registerServerMethod(mafRegisterMethodsMap registerMethodsList) {
     if(m_Server->isListening()) {
-        qDebug("%s", tr("Server is already listening on port %1").arg(m_Server->property("port").toUInt()).toUtf8().data());
+        qDebug("%s", QString("Server is already listening on port %1").arg(m_Server->property("port").toUInt()).toUtf8().data());
         return;
     }
     // cycle over map:  method name and parameter list
@@ -163,7 +163,7 @@ void ctkNetworkConnectorQXMLRPC::send(const QString event_id, ctkEventArgumentsL
             typeArgument = argList->at(i).name();
             if(typeArgument != "QVariantList") {
                 qDebug() << typeArgument;
-                qWarning("%s", tr("Remote Dispatcher need to have arguments that are QVariantList").toUtf8().data());
+                qWarning("%s", QString("Remote Dispatcher need to have arguments that are QVariantList").toUtf8().data());
                 delete vl;
                 return;
             }
@@ -177,7 +177,7 @@ void ctkNetworkConnectorQXMLRPC::send(const QString event_id, ctkEventArgumentsL
             vl->push_back(var); //only the first parameter represent the whole list of arguments
         }
         if(size == 0) {
-            qWarning("%s", tr("Remote Dispatcher need to have at least one argument that is a QVariantList").toUtf8().data());
+            qWarning("%s", QString("Remote Dispatcher need to have at least one argument that is a QVariantList").toUtf8().data());
             return;
         }
     }
@@ -215,7 +215,7 @@ void ctkNetworkConnectorQXMLRPC::processReturnValue( int requestId, QVariant val
 
 void ctkNetworkConnectorQXMLRPC::processFault( int requestId, int errorCode, QString errorString ) {
     // Log the error.
-    qDebug("%s", tr("Process Fault for requestID %1 with error %2 - %3").arg(QString::number(requestId), QString::number(errorCode), errorString).toUtf8().data());
+    qDebug("%s", QString("Process Fault for requestID %1 with error %2 - %3").arg(QString::number(requestId), QString::number(errorCode), errorString).toUtf8().data());
     ctkEventBusManager::instance()->notifyEvent("ctk/local/eventBus/remoteCommunicationFailed", ctkEventTypeLocal);
 }
 

--- a/Plugins/org.commontk.eventbus/ctkNetworkConnectorQtSoap.cpp
+++ b/Plugins/org.commontk.eventbus/ctkNetworkConnectorQtSoap.cpp
@@ -86,11 +86,11 @@ void ctkNetworkConnectorQtSoap::createClient(const QString hostName, const unsig
     /*request.setMethod("algorithmSIBA");
     request.addMethodArgument("input", "", "input.aim");
     request.addMethodArgument("output", "", "output.aim");
-    
+
     request.addMethodArgument("gaussian", "", "0.42");
     request.addMethodArgument("load", "", "8");
     request.addMethodArgument("iteration", "", "40");
-    
+
     qDebug() << request.toXmlString();
 
     // Submit the request the the web service.
@@ -109,20 +109,20 @@ void ctkNetworkConnectorQtSoap::createClient(const QString hostName, const unsig
 
 
     qDebug("retrieve value...");
-    
+
 }
 
 void ctkNetworkConnectorQtSoap::createServer(const unsigned int port) {
     Q_UNUSED(port);
-    qDebug() << tr("QtSoap doesn't support server side implementation.").toUtf8();
+    qDebug() << "QtSoap doesn't support server side implementation.";
 }
 
 void ctkNetworkConnectorQtSoap::stopServer() {
-    qDebug() << tr("QtSoap doesn't support server side implementation.").toUtf8();
+    qDebug() << "QtSoap doesn't support server side implementation.";
 }
 
 void ctkNetworkConnectorQtSoap::startListen() {
-    qDebug() << tr("QtSoap doesn't support server side implementation.").toUtf8();
+    qDebug() << "QtSoap doesn't support server side implementation.";
 }
 
 QtSoapType *ctkNetworkConnectorQtSoap::marshall(const QString name, const QVariant &parameter) {
@@ -264,7 +264,7 @@ void ctkNetworkConnectorQtSoap::processReturnValue( int requestId, QVariant valu
 
 void ctkNetworkConnectorQtSoap::processFault( int requestId, int errorCode, QString errorString ) {
     // Log the error.
-    qDebug("%s", tr("Process Fault for requestID %1 with error %2 - %3").arg(QString::number(requestId), QString::number(errorCode), errorString).toUtf8().data());
+    qDebug("%s", QString("Process Fault for requestID %1 with error %2 - %3").arg(QString::number(requestId), QString::number(errorCode), errorString).toUtf8().data());
     ctkEventBusManager::instance()->notifyEvent("ctk/local/eventBus/remoteCommunicationFailed", ctkEventTypeLocal);
 }
 
@@ -315,4 +315,3 @@ void ctkNetworkConnectorQtSoap::processRequest( int requestId, QString methodNam
     }
     mafDEL(argList);
 }*/
-

--- a/Plugins/org.commontk.eventbus/ctkTopicRegistry.cpp
+++ b/Plugins/org.commontk.eventbus/ctkTopicRegistry.cpp
@@ -33,7 +33,7 @@ bool ctkTopicRegistry::registerTopic(const QString topic, const QObject *owner) 
         //topic already registered
         const QObject *obj = m_TopicHash.value(topic,NULL);
         QString className(obj->metaObject()->className());
-        qWarning() << QObject::tr("Topic %1 already owned by %2").arg(topic, className);
+        qWarning() << QString("Topic %1 already owned by %2").arg(topic, className);
         return false;
     }
     m_TopicHash.insert(topic,owner);

--- a/Plugins/org.commontk.plugingenerator.ui/ctkPluginGeneratorMainExtension.ui
+++ b/Plugins/org.commontk.plugingenerator.ui/ctkPluginGeneratorMainExtension.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Plugin Generator</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="margin">

--- a/Plugins/org.commontk.plugingenerator.ui/ctkPluginGeneratorManifestExtension.ui
+++ b/Plugins/org.commontk.plugingenerator.ui/ctkPluginGeneratorManifestExtension.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>ctkPluginGeneratorManifestExtension</class>
+ <widget class="QWidget" name="ctkPluginGeneratorManifestExtension">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Manifest</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="2">
@@ -172,7 +172,4 @@
  </widget>
  <resources/>
  <connections/>
- <buttongroups>
-  <buttongroup name="buttonGroup"/>
- </buttongroups>
 </ui>


### PR DESCRIPTION
There were strings marked as translatable that should not have been:
- log messages
- test and example code
- symbols
- placeholder text (that is only visible in Qt designer because its actual content is set at runtime)

These texts were marked as non-translatable to avoid unnecessary burden on translators.