### PR TITLE
Ensure ctk::copyDirRecursively skips hidden file by default

### DIFF
--- a/Libs/Core/ctkUtils.cpp
+++ b/Libs/Core/ctkUtils.cpp
@@ -382,7 +382,7 @@ bool ctk::copyDirRecursively(const QString &srcPath, const QString &dstPath, boo
     return false;
     }
 
-  QDir::Filter hiddenFilter;
+  QDir::Filter hiddenFilter = QDir::Filter();
   if(includeHiddenFiles)
     {
     hiddenFilter = QDir::Hidden;


### PR DESCRIPTION
This commit fixes `ctkUtilsCopyDirRecursivelyTest1`