### PR TITLE
 Fix regression in ctkDateRangeWidget 

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkDateRangeWidgetTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkDateRangeWidgetTest1.cpp
@@ -35,7 +35,11 @@ int ctkDateRangeWidgetTest1(int argc, char * argv [] )
 {
   QApplication app(argc, argv);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QDateTime today = QDate::currentDate().startOfDay();
+#else
   QDateTime today = QDateTime(QDate::currentDate());
+#endif
   QDateTime tomorrow = today.addDays(1);
   QDateTime yesterday = today.addDays(-1);
   QDateTime lastWeek = today.addDays(-7);
@@ -112,8 +116,13 @@ int ctkDateRangeWidgetTest1(int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  dateRange.setDateTimeRange(QDate(-2, -9,12345678).startOfDay(),
+                             QDate(2010, 15, 32).startOfDay());
+#else
   dateRange.setDateTimeRange(QDateTime(QDate(-2, -9,12345678)),
                              QDateTime(QDate(2010, 15, 32)));
+#endif
   if (!dateRange.isAnyDate() ||
       dateRange.startDateTime() == lastMonth ||
       dateRange.endDateTime() == today)

--- a/Libs/Widgets/ctkDateRangeWidget.cpp
+++ b/Libs/Widgets/ctkDateRangeWidget.cpp
@@ -67,7 +67,7 @@ void ctkDateRangeWidgetPrivate::autoselectRadioButton()
   QDate endDate = q->endDateTime().date();
   #if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
   QDateTime startOfDay = q->startDateTime().date().startOfDay();
-  QDateTime endOfDay = q->startDateTime().date().endOfDay();
+  QDateTime endOfDay = q->endDateTime().date().startOfDay();
   #else
   QDateTime startOfDay = QDateTime(q->startDateTime().date());
   QDateTime endOfDay = QDateTime(q->endDateTime().date());
@@ -200,7 +200,7 @@ void ctkDateRangeWidget::setDateTimeRange(QDateTime startDateTime, QDateTime end
 void ctkDateRangeWidget::setDateRange(QDate startDate, QDate endDate)
 {
   #if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
-  this->setDateTimeRange(startDate.startOfDay(), endDate.endOfDay());
+  this->setDateTimeRange(startDate.startOfDay(), endDate.startOfDay());
   #else
   this->setDateTimeRange(QDateTime(startDate), QDateTime(endDate));
   #endif

--- a/Libs/Widgets/ctkDateRangeWidget.cpp
+++ b/Libs/Widgets/ctkDateRangeWidget.cpp
@@ -27,9 +27,6 @@
 // CTK includes
 #include "ctkDateRangeWidget.h"
 #include "ui_ctkDateRangeWidget.h"
-#include "ctkLogger.h"
-
-static ctkLogger logger("org.commontk.libs.widgets.ctkDateRangeWidget");
 
 //-----------------------------------------------------------------------------
 class ctkDateRangeWidgetPrivate: public Ui_ctkDateRangeWidget
@@ -286,7 +283,6 @@ void ctkDateRangeWidget::setDisplayTime(bool displayTime)
 // -------------------------------------------------------------------------
 bool ctkDateRangeWidget::displayTime()const
 {
-  logger.error("including time in the date range is not supported now");
   Q_D(const ctkDateRangeWidget);
   return d->DisplayTime;
 }

--- a/Libs/Widgets/ctkDateRangeWidget.cpp
+++ b/Libs/Widgets/ctkDateRangeWidget.cpp
@@ -62,13 +62,6 @@ void ctkDateRangeWidgetPrivate::autoselectRadioButton()
   Q_Q(ctkDateRangeWidget);
   QDate startDate = q->startDateTime().date();
   QDate endDate = q->endDateTime().date();
-  #if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
-  QDateTime startOfDay = q->startDateTime().date().startOfDay();
-  QDateTime endOfDay = q->endDateTime().date().startOfDay();
-  #else
-  QDateTime startOfDay = QDateTime(q->startDateTime().date());
-  QDateTime endOfDay = QDateTime(q->endDateTime().date());
-  #endif
   if (this->ForceSelectRange)
     {
     this->SelectRangeRadioButton->setChecked(true);
@@ -77,8 +70,13 @@ void ctkDateRangeWidgetPrivate::autoselectRadioButton()
     {
     this->AnyDateRadioButton->setChecked(true);
     }
-  else if (q->startDateTime() != startOfDay ||
-           q->endDateTime() != endOfDay)
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+  else if (q->startDateTime() != q->startDateTime().date().startOfDay() ||
+           q->endDateTime() != q->endDateTime().date().startOfDay())
+#else
+  else if (q->startDateTime() != QDateTime(q->startDateTime().date()) ||
+           q->endDateTime() != QDateTime(q->endDateTime().date()))
+#endif
     {
     this->SelectRangeRadioButton->setChecked(true);
     }


### PR DESCRIPTION
Additionally:
* Remove obsolete error message in `ctkDateRangeWidget::displayTime`
* Fix `QDateTime` deprecation warnings in `ctkDateRangeWidgetTest1`
* Simplify handling of Qt4 & Qt5 API differences in `ctkDateRangeWidget`