### PR TITLE
DOC: Remove obsolete references to Q_EXPORT_PLUGIN2 specific to Qt4

### DIFF
--- a/Libs/PluginFramework/ctkPluginActivator.h
+++ b/Libs/PluginFramework/ctkPluginActivator.h
@@ -47,17 +47,14 @@
  * {
  *   Q_OBJECT
  *   Q_INTERFACES(ctkPluginActivator)
+ *   Q_PLUGIN_METADATA(IID "org_commontk_myplugin")
  *
  * public:
  *   void start(ctkPluginContext* context);
  *   void stop(ctkPluginContext* context);
  * };
  * \endcode
- * And in your implementation file:
- * \code
- * Q_EXPORT_PLUGIN2(mypluginlib, MyPlugin)
- * \endcode
- * where <code>mypluginlib</code> is the basename of your shared plugin library.
+ * where <code>myplugin</code> is the name of your plugin.
  *
  * <p>
  * See the Qt Documentation about <a href="https://doc.qt.io/qt-5/plugins-howto.html">

--- a/Libs/Widgets/ctkIconEnginePlugin_qt5.h
+++ b/Libs/Widgets/ctkIconEnginePlugin_qt5.h
@@ -40,8 +40,6 @@ class ctkIconEnginePrivate;
 /// QCoreApplication::addLibraryPath("MyApp-build/plugins");
 /// \endcode
 /// where the plugin must be located in "MyApp-build/plugins/iconengines"
-/// don't forget to declare in the cpp file:
-///   Q_EXPORT_PLUGIN2(yourpluginName, ctkIconEnginePlugin)
 class CTK_WIDGETS_EXPORT ctkIconEnginePlugin
   : public QIconEnginePlugin
 {


### PR DESCRIPTION
Also update `ctkPluginActivator.h` docstring to document use of `Q_PLUGIN_METADATA`