### PR TITLE
DOC: Fix typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,7 +580,7 @@ ctk_app_option(ctkExampleHostedApp
                CTK_ENABLE_DICOMApplicationHosting AND CTK_BUILD_EXAMPLES)
 
 if(FALSE)
-# Since EventBusDemo depends on qmlrpc that is lacking Qt5 support, it is excluded.
+# Since EventBusDemo depends on qxmlrpc that is lacking Qt5 support, it is excluded.
 ctk_app_option(ctkEventBusDemo
                "Build the DICOM example application" OFF
                CTK_ENABLE_PluginFramework AND CTK_BUILD_EXAMPLES)
@@ -685,7 +685,7 @@ ctk_plugin_option(org.commontk.dah.examplehost
 
 # Plug-ins related to the EventBus demo application
 if(FALSE)
-# Since EventBusDemo depends on qmlrpc that is lacking Qt5 support, it is excluded.
+# Since EventBusDemo depends on qxmlrpc that is lacking Qt5 support, it is excluded.
 ctk_plugin_option(org.commontk.eventbus
                   "Build the org.commontk.eventbus plugin." OFF
                   CTK_APP_ctkEventBusDemo)

--- a/Libs/CommandLineModules/Core/ctkCmdLineModuleParameter.h
+++ b/Libs/CommandLineModules/Core/ctkCmdLineModuleParameter.h
@@ -209,7 +209,7 @@ public:
   QStringList fileExtensions() const;
 
   /**
-   * @return The coordinate system (either "lps", "ras", oder "ijk") for the "point" or "region"
+   * @return The coordinate system (either "lps", "ras", or "ijk") for the "point" or "region"
    *         parameter tags.
    */
   QString coordinateSystem() const;

--- a/Libs/Core/ctkCallback.h
+++ b/Libs/Core/ctkCallback.h
@@ -29,7 +29,7 @@
 
 //---------------------------------------------------------------------------
 /// \ingroup Core
-/// The following example prints debug statement everytime the current value
+/// The following example prints debug statement every time the current value
 /// of the slider is changed:
 /// void print() { qDebug() << "signal called"; }
 /// ...

--- a/Libs/Core/ctkErrorLogAbstractModel.h
+++ b/Libs/Core/ctkErrorLogAbstractModel.h
@@ -144,7 +144,7 @@ public Q_SLOTS:
 
   /// Call addEntry method via a connection (the same way as message handlers call it).
   /// It is recommended to use this method instead of addEntry to ensure messages are logged in correct order.
-  /// Directly calling addEntry would make that log entry processed immedately, getting ahead of entries that
+  /// Directly calling addEntry would make that log entry processed immediately, getting ahead of entries that
   /// message handlers add via a queued connection.
   void postEntry(const QDateTime& currentDateTime, const QString& threadId,
     ctkErrorLogLevel::LogLevel logLevel, const QString& origin, const ctkErrorLogContext& context, const QString& text);

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest4.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest4.cpp
@@ -138,7 +138,7 @@ int ctkDICOMDatabaseTest4( int argc, char * argv [] )
 
   if (database.cachedTag(instanceUID, badTag) != QString("__TAG_NOT_IN_INSTANCE__"))
     {
-    std::cerr << "ctkDICOMDatabase: bad tag should have sentinal value in cache" << std::endl;
+    std::cerr << "ctkDICOMDatabase: bad tag should have sentinel value in cache" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Libs/PluginFramework/Testing/org.commontk.eventadmintest/ctkEAScenario1TestSuite.cpp
+++ b/Libs/PluginFramework/Testing/org.commontk.eventadmintest/ctkEAScenario1TestSuite.cpp
@@ -136,7 +136,7 @@ void ctkEAScenario1EventConsumer::handleEvent(const ctkEvent& event)
     /* check if message is null */
     if(!message.isNull())
     {
-      /* its a syncronous message */
+      /* its a synchronous message */
       numOfsynchMessages++;
       /* print that a message is received */
       qDebug() << "received a synchronous event with message:" << message;
@@ -144,7 +144,7 @@ void ctkEAScenario1EventConsumer::handleEvent(const ctkEvent& event)
       int aquiredNumber= message.toInt();
       /* assert that the message is the expected one */
       QVERIFY2(synchMessageExpectedNumber == aquiredNumber,
-               qPrintable(QString("Expected syncronous message number: %1 got: %2 - order NOT conserved")
+               qPrintable(QString("Expected synchronous message number: %1 got: %2 - order NOT conserved")
                .arg(synchMessageExpectedNumber).arg(aquiredNumber)));
 
       /* the next messages of this type should be +1 */
@@ -161,7 +161,7 @@ void ctkEAScenario1EventConsumer::handleEvent(const ctkEvent& event)
         int aquiredNumber= message.toInt();
         /* assert that the message is the expected one */
         QVERIFY2(asynchMessageExpectedNumber==aquiredNumber,
-                 qPrintable(QString("Expected asyncronous message number: %1 got: %2 - order NOT conserved")
+                 qPrintable(QString("Expected asynchronous message number: %1 got: %2 - order NOT conserved")
                  .arg(asynchMessageExpectedNumber).arg(aquiredNumber)));
 
         /* the next messages of this type should be +1 */

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
@@ -123,8 +123,8 @@ bool ctkAbstractPythonManager::initialize()
 //-----------------------------------------------------------------------------
 PythonQtObjectPtr ctkAbstractPythonManager::mainContext()
 {
-  bool initalized = this->initialize();
-  if (initalized)
+  bool initialized = this->initialize();
+  if (initialized)
     {
     return PythonQt::self()->getMainModule();
     }

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
@@ -118,7 +118,7 @@ public:
   static QStringList dir_object(PyObject* object,
                                 bool appendParenthesis = false);
 
-  /// Given a python variable name, it returns the string list splited
+  /// Given a python variable name, it returns the string list split
   /// at every dots which will be outside parenthesis
   /// (It also takes care about the possibility that quotes can include parenthesis)
   static QStringList splitByDotOutsideParenthesis(const QString& pythonVariableName);
@@ -143,7 +143,7 @@ public:
   /// \sa pythonInitialized
   bool isPythonInitialized()const;
 
-  /// Returns True if a python error occured.
+  /// Returns True if a python error occurred.
   /// \sa PythonQt::hadError()
   bool pythonErrorOccured()const;
 

--- a/Libs/Widgets/ctkComboBox.cpp
+++ b/Libs/Widgets/ctkComboBox.cpp
@@ -167,7 +167,7 @@ void ctkComboBoxPrivate::initStyleOption(QStyleOptionComboBox* opt)const
     }
   QRect textRect = q->style()->subControlRect(
     QStyle::CC_ComboBox, opt, QStyle::SC_ComboBoxEditField, q);
-  // TODO substract icon size
+  // TODO subtract icon size
   opt->currentText = opt->fontMetrics.elidedText(opt->currentText,
                                                  this->ElideMode,
                                                  textRect.width());

--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -1056,7 +1056,7 @@ void ctkConsolePrivate::pasteText(const QString& text)
   //
   // For example, an empty line in a Python function could not be executed line-by-line, because
   // then empty line would be interpreted as the end of the function.
-  // In contrast, the empty line would not cause any issue when execuing the whole string at once
+  // In contrast, the empty line would not cause any issue when executing the whole string at once
   // (the empty line would be just ignored).
   //
   // We cannot execute at once if a command is already being edited (some command has been already typed in the current line)

--- a/Libs/Widgets/ctkCoordinatesWidget.h
+++ b/Libs/Widgets/ctkCoordinatesWidget.h
@@ -32,7 +32,7 @@ class ctkCoordinatesWidgetPrivate;
 /// \ingroup Widgets
 ///
 /// ctkCoordinatesWidget is a simple container of dimension coordinates.
-/// For each coordinate a double spinbox is associated, everytime a value is
+/// For each coordinate a double spinbox is associated, every time a value is
 /// modified, the signal valueChanged is fired.
 /// TODO: use pimpl
 class CTK_WIDGETS_EXPORT ctkCoordinatesWidget : public QWidget

--- a/Libs/Widgets/ctkDoubleSpinBox.h
+++ b/Libs/Widgets/ctkDoubleSpinBox.h
@@ -320,7 +320,7 @@ public Q_SLOTS:
   void setReadOnly(bool readOnly);
 
 Q_SIGNALS:
-  /// Emitted everytime the spinbox value is modified
+  /// Emitted every time the spinbox value is modified
   /// \sa QDoubleSpinBox::valueChanged()
   void valueChanged(double);
   void valueChanged(const QString &);

--- a/Libs/Widgets/ctkFlowLayout.h
+++ b/Libs/Widgets/ctkFlowLayout.h
@@ -36,9 +36,9 @@ class ctkFlowLayoutPrivate;
 class CTK_WIDGETS_EXPORT ctkFlowLayout : public QLayout
 {
   Q_OBJECT
-  /// If orientation is Qt::Horizontal, items are layed out from left to right
+  /// If orientation is Qt::Horizontal, items are laid out from left to right
   /// then top to bottom if there is no more horizontal space.
-  /// If orientation is Qt::Vertical, items are layed out from top to bottom
+  /// If orientation is Qt::Vertical, items are laid out from top to bottom
   /// then left to right if there is no more vertical space.
   /// Qt::Horizontal by default
   /// \sa preferredExpandingDirections

--- a/Libs/Widgets/ctkLayoutManager.h
+++ b/Libs/Widgets/ctkLayoutManager.h
@@ -116,7 +116,7 @@ public:
   /// Multiple viewports can be specified by adding a "viewports" XML element and adding multiple
   /// child "layout" elements. Viewport name is specified in the "name" attribute of each "layout" element.
   Q_INVOKABLE void setViewport(QWidget* widget, const QString& viewportName);
-  /// Get viewport widget by nam.
+  /// Get viewport widget by name.
   Q_INVOKABLE QWidget* viewport(const QString& viewportName)const;
   /// Get all viewport names.
   QStringList viewportNames()const;

--- a/Libs/Widgets/ctkPathLineEdit.h
+++ b/Libs/Widgets/ctkPathLineEdit.h
@@ -229,7 +229,7 @@ public:
   void setSizeAdjustPolicy(SizeAdjustPolicy policy);
 
   int minimumContentsLength()const;
-  void setMinimumContentsLength(int lenght);
+  void setMinimumContentsLength(int length);
 
   /// Return the combo box internally used by the path line edit
   Q_INVOKABLE QComboBox* comboBox() const;

--- a/Libs/XNAT/Core/ctkXnatDataModel.h
+++ b/Libs/XNAT/Core/ctkXnatDataModel.h
@@ -33,7 +33,7 @@ class ctkXnatSession;
 /**
  * @ingroup XNAT_Core
  *
- * @brief The ctkXnatDataModel class reprents the root object in a
+ * @brief The ctkXnatDataModel class represents the root object in a
  * XNAT data hierarchy.
  */
 class CTK_XNAT_CORE_EXPORT ctkXnatDataModel : public ctkXnatObject

--- a/Libs/XNAT/Core/ctkXnatSession.h
+++ b/Libs/XNAT/Core/ctkXnatSession.h
@@ -45,7 +45,7 @@ class ctkXnatResource;
 /**
  * @ingroup XNAT_Core
  *
- * @brief The ctkXnatSession class reprents a session object associated
+ * @brief The ctkXnatSession class represents a session object associated
  * with a specific XNAT connection.
  */
 class CTK_XNAT_CORE_EXPORT ctkXnatSession : public QObject


### PR DESCRIPTION
Typos in `CMakeLists.txt` (`qmlrpc` -> `qxmlrpc`) was introduced in 4f6262c4 (`DOC: Add comment documenting why the "eventbus" plugin is disabled with Qt5`) and identified while inspecting the file.

Remaining of typos were identified and/or fixed using codespell using the following script:

```bash
python3 -m venv /tmp/codespell
source /tmp/codespell-venv/bin/activate
pip install codespell

echo "comunication
currentry
fwe
dependees
invokable
maked
numer
noe
objekt
ot
requestor
ser
serie
statics
ta
te
to
ue" > /tmp/.codespellignore

# Dry-run to review
codespell -I /tmp/.codespellignore -$(fd -e h -e hpp -e cpp -e txt -e dox -e cmake)

# Run with "-w" to automatically fixed unambiguous typos
codespell -I /tmp/.codespellignore -w -$(fd -e h -e hpp -e cpp -e txt -e dox -e cmake)
```