### PR TITLE
STYLE: Remove obsolete CTK_NULLPTR macro not needed with C++ >= 11

### DIFF
--- a/Libs/Core/ctkCompilerDetections_p.h
+++ b/Libs/Core/ctkCompilerDetections_p.h
@@ -32,11 +32,6 @@
 /*
  * C++11 keywords and expressions
  */
-#ifdef Q_NULLPTR
-# define CTK_NULLPTR Q_NULLPTR
-#else
-# define CTK_NULLPTR NULL
-#endif
 
 #if (__cplusplus >= 201103L) || ( defined(_MSC_VER) && _MSC_VER >= 1700 )
 # define CTK_OVERRIDE override

--- a/Libs/Core/ctkErrorLogAbstractModel.cpp
+++ b/Libs/Core/ctkErrorLogAbstractModel.cpp
@@ -588,7 +588,7 @@ ctkErrorLogAbstractMessageHandler* ctkErrorLogAbstractModel::msgHandler(const QS
   Q_D(const ctkErrorLogAbstractModel);
   if (!d->RegisteredHandlers.keys().contains(handlerName))
     {
-    return CTK_NULLPTR;
+    return nullptr;
     }
   return d->RegisteredHandlers[handlerName];
 }

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -78,7 +78,7 @@ ctkDICOMDatabasePrivate::ctkDICOMDatabasePrivate(ctkDICOMDatabase& o)
   , LoggedExecVerbose(false)
   , DisplayedFieldsTableAvailable(false)
   , UseShortStoragePath(true)
-  , ThumbnailGenerator(CTK_NULLPTR)
+  , ThumbnailGenerator(nullptr)
   , TagCacheVerified(false)
   , SchemaVersion("0.7.0")
 {

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -136,7 +136,7 @@ public:
   /// \return true if schema was updated
   Q_INVOKABLE bool updateSchema(
     const char* schemaFile = ctkDICOMDatabase::defaultSchemaFile(),
-    const char* newDatabaseDir = CTK_NULLPTR);
+    const char* newDatabaseDir = nullptr);
 
   /// Update the database schema only if the versions don't match
   /// \param schemaFile SQL file containing schema definition
@@ -147,7 +147,7 @@ public:
   /// \return true if schema was updated
   Q_INVOKABLE bool updateSchemaIfNeeded(
     const char* schemaFile = ctkDICOMDatabase::defaultSchemaFile(),
-    const char* newDatabaseDir = CTK_NULLPTR);
+    const char* newDatabaseDir = nullptr);
 
   /// Return the schema version needed by the current version of this code
   Q_INVOKABLE QString schemaVersion();

--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGenerator.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGenerator.cpp
@@ -40,7 +40,7 @@ static ctkLogger logger("org.commontk.dicom.DICOMDisplayedFieldGenerator" );
 //------------------------------------------------------------------------------
 ctkDICOMDisplayedFieldGeneratorPrivate::ctkDICOMDisplayedFieldGeneratorPrivate(ctkDICOMDisplayedFieldGenerator& o)
   : q_ptr(&o)
-  , Database(CTK_NULLPTR)
+  , Database(nullptr)
 {
 }
 

--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRuleFactory.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRuleFactory.cpp
@@ -34,7 +34,7 @@
 #include <QSqlQuery>
 
 //----------------------------------------------------------------------------
-ctkDICOMDisplayedFieldGeneratorRuleFactory *ctkDICOMDisplayedFieldGeneratorRuleFactory::Instance = CTK_NULLPTR;
+ctkDICOMDisplayedFieldGeneratorRuleFactory *ctkDICOMDisplayedFieldGeneratorRuleFactory::Instance = nullptr;
 
 //----------------------------------------------------------------------------
 class ctkDICOMDisplayedFieldGeneratorRuleFactoryCleanup
@@ -88,7 +88,7 @@ void ctkDICOMDisplayedFieldGeneratorRuleFactory::cleanup()
   if (ctkDICOMDisplayedFieldGeneratorRuleFactory::Instance)
   {
     delete ctkDICOMDisplayedFieldGeneratorRuleFactory::Instance;
-    ctkDICOMDisplayedFieldGeneratorRuleFactory::Instance = CTK_NULLPTR;
+    ctkDICOMDisplayedFieldGeneratorRuleFactory::Instance = nullptr;
   }
 }
 

--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRuleFactory.h
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRuleFactory.h
@@ -69,7 +69,7 @@ private:
   static void cleanup();
 
 private:
-  ctkDICOMDisplayedFieldGeneratorRuleFactory(QObject* parent=CTK_NULLPTR);
+  ctkDICOMDisplayedFieldGeneratorRuleFactory(QObject* parent=nullptr);
   ~ctkDICOMDisplayedFieldGeneratorRuleFactory() CTK_OVERRIDE;
 
   Q_DISABLE_COPY(ctkDICOMDisplayedFieldGeneratorRuleFactory);

--- a/Libs/DICOM/Core/ctkDICOMIndexer.cpp
+++ b/Libs/DICOM/Core/ctkDICOMIndexer.cpp
@@ -290,7 +290,7 @@ void ctkDICOMIndexerPrivateWorker::writeIndexingResultsToDatabase(ctkDICOMDataba
 //------------------------------------------------------------------------------
 ctkDICOMIndexerPrivate::ctkDICOMIndexerPrivate(ctkDICOMIndexer& o)
   : q_ptr(&o)
-  , Database(CTK_NULLPTR)
+  , Database(nullptr)
   , BackgroundImportEnabled(false)
   , FollowSymlinks(true)
 {
@@ -317,7 +317,7 @@ ctkDICOMIndexerPrivate::~ctkDICOMIndexerPrivate()
   this->RequestQueue.setStopRequested(true);
   this->WorkerThread.quit();
   this->WorkerThread.wait();
-  q->setDatabase(CTK_NULLPTR);
+  q->setDatabase(nullptr);
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
@@ -375,7 +375,7 @@ void ctkDICOMQueryRetrieveWidget::retrieve()
 
     // Get information which server we want to get the study from and prepare request accordingly
     QMap<QString, ctkDICOMQuery*>::iterator queryIt = d->QueriesByStudyUID.find(studyUID);
-    ctkDICOMQuery* query = (queryIt == d->QueriesByStudyUID.end() ? CTK_NULLPTR : *queryIt);
+    ctkDICOMQuery* query = (queryIt == d->QueriesByStudyUID.end() ? nullptr : *queryIt);
     if (!query)
       {
       logger.warn("Retrieve of series " + seriesUID + " failed. No query found for study " + studyUID + ".");

--- a/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMTableView.cpp
@@ -634,7 +634,7 @@ bool ctkDICOMTableView::eventFilter(QObject *obj, QEvent *event)
     {
       QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
       QAbstractItemModel* itemModel = d->tblDicomDatabaseView->model();
-      if (keyEvent != CTK_NULLPTR && itemModel->rowCount() > 0)
+      if (keyEvent != nullptr && itemModel->rowCount() > 0)
       {
         if (keyEvent->key() == Qt::Key_Home)
         {

--- a/Libs/Visualization/VTK/Core/ctkVTKScalarsToColorsUtils.cpp
+++ b/Libs/Visualization/VTK/Core/ctkVTKScalarsToColorsUtils.cpp
@@ -55,7 +55,7 @@ void ctk::remapColorScale(
   }
 
   /// Opacity
-  if (rescaledColorTransferFunction->GetScalarOpacityFunction() != CTK_NULLPTR)
+  if (rescaledColorTransferFunction->GetScalarOpacityFunction() != nullptr)
   {
     rescaledColorTransferFunction->GetScalarOpacityFunction()->
       RemoveAllPoints();
@@ -67,7 +67,7 @@ void ctk::remapColorScale(
     rescaledColorTransferFunction->SetScalarOpacityFunction(opacityFunction);
   }
 
-  if (colorTransferFunction->GetScalarOpacityFunction() == CTK_NULLPTR)
+  if (colorTransferFunction->GetScalarOpacityFunction() == nullptr)
   {
     rescaledColorTransferFunction->Build();
     return;
@@ -101,7 +101,7 @@ void ctk::remapColorScale(
 // ----------------------------------------------------------------------------
 void ctk::reverseColorMap(vtkDiscretizableColorTransferFunction* ctf)
 {
-  if (ctf == CTK_NULLPTR)
+  if (ctf == nullptr)
   {
     return;
   }
@@ -127,7 +127,7 @@ void ctk::reverseColorMap(vtkDiscretizableColorTransferFunction* ctf)
 void ctk::setTransparency(vtkDiscretizableColorTransferFunction* ctf,
   double transparency)
 {
-  if (ctf == CTK_NULLPTR)
+  if (ctf == nullptr)
   {
     return;
   }

--- a/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferChart.cpp
+++ b/Libs/Visualization/VTK/Core/vtkDiscretizableColorTransferChart.cpp
@@ -138,8 +138,8 @@ vtkDiscretizableColorTransferChart::vtkDiscretizableColorTransferChart()
   this->SetActionToButton(ZOOM, -1);/// We don't want to zoom
   this->SetActionToButton(PAN, -1);/// Axes are not forced to bounds, disable panning
 
-  this->CompositeHiddenItem = CTK_NULLPTR;
-  this->ControlPoints = CTK_NULLPTR;
+  this->CompositeHiddenItem = nullptr;
+  this->ControlPoints = nullptr;
 
   this->rangeMoving = RangeMoving_NONE;
 
@@ -165,7 +165,7 @@ void vtkDiscretizableColorTransferChart::SetColorTransferFunction(
   vtkDiscretizableColorTransferFunction* function)
 {
   double range[2] = { VTK_DOUBLE_MAX, VTK_DOUBLE_MIN };
-  if (function != CTK_NULLPTR)
+  if (function != nullptr)
   {
     range[0] = function->GetRange()[0];
     range[1] = function->GetRange()[1];
@@ -191,10 +191,10 @@ void vtkDiscretizableColorTransferChart::SetColorTransferFunction(
            << " " << this->CurrentRange[1];
 #endif
 
-  if (function == CTK_NULLPTR)
+  if (function == nullptr)
   {
-    this->CompositeHiddenItem = CTK_NULLPTR;
-    this->ControlPoints = CTK_NULLPTR;
+    this->CompositeHiddenItem = nullptr;
+    this->ControlPoints = nullptr;
 
 #ifdef DEBUG_RANGE
   qDebug() << "DEBUG_RANGE data range = " << this->DataRange[0]
@@ -478,8 +478,8 @@ void vtkDiscretizableColorTransferChart::SetCurrentRange(
 // ----------------------------------------------------------------------------
 void vtkDiscretizableColorTransferChart::RemapColorTransferFunction()
 {
-  if (this->ColorTransferFunction == CTK_NULLPTR
-   || this->ControlPoints == CTK_NULLPTR)
+  if (this->ColorTransferFunction == nullptr
+   || this->ControlPoints == nullptr)
   {
     return;
   }
@@ -583,7 +583,7 @@ vtkDiscretizableColorTransferChart::GetControlPointsItem()
 // ----------------------------------------------------------------------------
 bool vtkDiscretizableColorTransferChart::IsProcessingColorTransferFunction() const
 {
-  if (this->ControlPoints == CTK_NULLPTR)
+  if (this->ControlPoints == nullptr)
   {
     return false;
   }

--- a/Libs/Visualization/VTK/Core/vtkScalarsToColorsContextItem.cpp
+++ b/Libs/Visualization/VTK/Core/vtkScalarsToColorsContextItem.cpp
@@ -127,7 +127,7 @@ void vtkScalarsToColorsContextItem::CopyColorTransferFunction(
 {
   this->ResetColorTransferFunction();
 
-  if (ctf == CTK_NULLPTR)
+  if (ctf == nullptr)
   {
     this->SetVisibleRange(0, 255);
 

--- a/Libs/Visualization/VTK/Core/vtkScalarsToColorsPreviewChart.cpp
+++ b/Libs/Visualization/VTK/Core/vtkScalarsToColorsPreviewChart.cpp
@@ -70,7 +70,7 @@ void vtkScalarsToColorsPreviewChart::SetColorTransferFunction(
   compositeVisibleItem->SetInteractive(false);
   compositeVisibleItem->SetOpacity(1);
   compositeVisibleItem->SelectableOff();
-  if (function == CTK_NULLPTR)
+  if (function == nullptr)
   {
     vtkSmartPointer<vtkColorTransferFunction> ctf =
       vtkSmartPointer<vtkColorTransferFunction>::New();

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsComboBoxTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsComboBoxTest1.cpp
@@ -66,7 +66,7 @@ int ctkVTKScalarsToColorsComboBoxTest1(int argc, char * argv [] )
       "\tCurrent count: " << scalarsToColorsComboBox.count() << "\n";
     return EXIT_FAILURE;
   }
-  scalarsToColorsComboBox.addScalarsToColors(CTK_NULLPTR, "(none)");
+  scalarsToColorsComboBox.addScalarsToColors(nullptr, "(none)");
 
   scalarsToColorsComboBox.show();
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.cpp
@@ -125,12 +125,12 @@ ctkVTKDiscretizableColorTransferWidgetPrivate
   ctkVTKDiscretizableColorTransferWidget& object)
   : q_ptr(&object)
 {
-  this->scalarsToColorsSelector = CTK_NULLPTR;
+  this->scalarsToColorsSelector = nullptr;
 
   // Option menu
-  this->nanButton = CTK_NULLPTR;
-  this->discretizeCheckBox = CTK_NULLPTR;
-  this->nbOfDiscreteValuesSpinBox = CTK_NULLPTR;
+  this->nanButton = nullptr;
+  this->discretizeCheckBox = nullptr;
+  this->nbOfDiscreteValuesSpinBox = nullptr;
 
   this->dataRange[0] = VTK_DOUBLE_MAX;
   this->dataRange[1] = VTK_DOUBLE_MIN;
@@ -191,7 +191,7 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
 
   this->previousOpacityValue = opacitySlider->value();
 
-  this->scalarsToColorsSelector->addScalarsToColors(CTK_NULLPTR, ctkVTKDiscretizableColorTransferWidget::tr("Reset"));
+  this->scalarsToColorsSelector->addScalarsToColors(nullptr, ctkVTKDiscretizableColorTransferWidget::tr("Reset"));
   this->scalarsToColorsSelector->setCurrentIndex(-1);
 
   this->eventLink = vtkSmartPointer<vtkEventQtSlotConnect>::New();
@@ -237,7 +237,7 @@ void ctkVTKDiscretizableColorTransferWidgetPrivate::setupUi(QWidget* widget)
   discretizeLayout->setContentsMargins(0, 0, 0, 0);
 
   optionButton->setIcon(q->style()->standardIcon(
-    QStyle::SP_FileDialogDetailedView, CTK_NULLPTR, optionButton));
+    QStyle::SP_FileDialogDetailedView, nullptr, optionButton));
 
   QLabel* nanLabel = new QLabel(ctkVTKDiscretizableColorTransferWidget::tr("NaN values"));
   this->nanButton = new ctkColorPickerButton;
@@ -346,7 +346,7 @@ ctkVTKDiscretizableColorTransferWidgetPrivate::colorTransferFunctionModifiedCall
   vtkSmartPointer<vtkDiscretizableColorTransferFunction> dctf =
     self->scalarsToColorsContextItem->GetDiscretizableColorTransferFunction();
 
-  if (dctf == CTK_NULLPTR)
+  if (dctf == nullptr)
   {
     return;
   }
@@ -480,7 +480,7 @@ void ctkVTKDiscretizableColorTransferWidget::setHistogramConnection(
 
   if (!input)
   {
-    d->histogramFilter = CTK_NULLPTR;
+    d->histogramFilter = nullptr;
     d->dataMean = 0.;
     return;
   }
@@ -594,7 +594,7 @@ void ctkVTKDiscretizableColorTransferWidget::updateCtfWidgets()
 {
   Q_D(ctkVTKDiscretizableColorTransferWidget);
 
-  if (this->discretizableColorTransferFunction() == CTK_NULLPTR)
+  if (this->discretizableColorTransferFunction() == nullptr)
   {
     this->disableCtfWidgets();
   }
@@ -686,8 +686,8 @@ void ctkVTKDiscretizableColorTransferWidget::updateHistogram()
 
   // fill bins and frequencies
 
-  if (d->histogramFilter == CTK_NULLPTR
-   || d->histogramFilter->GetInputConnection(0, 0) == CTK_NULLPTR)
+  if (d->histogramFilter == nullptr
+   || d->histogramFilter->GetInputConnection(0, 0) == nullptr)
   {
     bins->SetNumberOfTuples(1);
     bins->SetTuple1(0, 0);

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDiscretizableColorTransferWidget.h
@@ -49,7 +49,7 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKDiscretizableColorTransferWidge
   /// \accessors viewBackgroundColor() setViewBackgroundColor()
   Q_PROPERTY(QColor viewBackgroundColor READ viewBackgroundColor WRITE setViewBackgroundColor)
 public:
-  explicit ctkVTKDiscretizableColorTransferWidget(QWidget* parent_ = CTK_NULLPTR);
+  explicit ctkVTKDiscretizableColorTransferWidget(QWidget* parent_ = nullptr);
   virtual ~ctkVTKDiscretizableColorTransferWidget();
 
   enum ResetVisibleRange

--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsComboBox.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsComboBox.cpp
@@ -93,9 +93,9 @@ int ctkVTKScalarsToColorsComboBox::addScalarsToColors(
   vtkScalarsToColors* scFunction, const QString& name)
 {
   QImage img;
-  if (scFunction != CTK_NULLPTR)
+  if (scFunction != nullptr)
   {
-    scFunction->Register(CTK_NULLPTR);
+    scFunction->Register(nullptr);
     img = ctk::scalarsToColorsImage(scFunction, this->iconSize());
   }
   else
@@ -116,7 +116,7 @@ vtkScalarsToColors* ctkVTKScalarsToColorsComboBox::getScalarsToColors(
   QVariant data = itemData(index);
   if (!data.isValid())
   {
-    return CTK_NULLPTR;
+    return nullptr;
   }
 
   vtkScalarsToColors* ctf =
@@ -167,7 +167,7 @@ void ctkVTKScalarsToColorsComboBox::onRowsAboutToBeRemoved(
   for (int i = first; i <= last; ++i)
   {
     vtkScalarsToColors* scFunction = this->getScalarsToColors(i);
-    if (scFunction != CTK_NULLPTR)
+    if (scFunction != nullptr)
     {
       scFunction->Delete();
     }


### PR DESCRIPTION
This commit replaces occurrences of the `CTK_NULLPTR` macro with `nullptr`.

This one-liner was used to perform the update:

```
git grep -l "CTK_NULLPTR" | fgrep -v CMakeLists.txt | fgrep -v .cmake | xargs sed -i '' -e "s/CTK_NULLPTR/nullptr/g"
```

Adapted from Slicer/Slicer@015d346b9 (`STYLE: Replace ITK_NULLPTR with nullptr`)