### PR TITLE
STYLE: Remove use of obsolete HAVE_QT5 macro

### DIFF
--- a/Libs/Core/Testing/Cpp/ctkDummyPlugin.h
+++ b/Libs/Core/Testing/Cpp/ctkDummyPlugin.h
@@ -34,9 +34,7 @@ class CTK_DUMMY_EXPORT ctkDummyPlugin: public QObject//, public ctkDummyInterfac
 {
   Q_OBJECT
 //  Q_INTERFACES(ctkDummyInterface)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.commontk.DummyPlugin")
-#endif
 public:
   ctkDummyPlugin(QObject* parent = 0);
   ~ctkDummyPlugin();

--- a/Libs/DICOM/Widgets/Plugins/ctkDICOMWidgetsPlugins.h
+++ b/Libs/DICOM/Widgets/Plugins/ctkDICOMWidgetsPlugins.h
@@ -23,11 +23,7 @@
 
 // Qt includes
 #include <QtGlobal>
-#ifndef HAVE_QT5
-#include <QDesignerCustomWidgetCollectionInterface>
-#else
 #include <QtUiPlugin/QDesignerCustomWidgetCollectionInterface>
-#endif
 
 // CTK includes
 #include "ctkDICOMWidgetsPluginsExport.h"
@@ -41,9 +37,7 @@ class CTK_DICOM_WIDGETS_PLUGINS_EXPORT ctkDICOMWidgetsPlugins
   , public QDesignerCustomWidgetCollectionInterface
 {
   Q_OBJECT
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.commontk.DICOM")
-#endif
   Q_INTERFACES(QDesignerCustomWidgetCollectionInterface);
 
 public:

--- a/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
@@ -266,12 +266,7 @@ void ctkDICOMQueryRetrieveWidget::query()
 
     d->QueriesByServer[d->CurrentServer] = query;
 
-#ifdef HAVE_QT5
     for (const auto & StudyAndSeriesInstanceUIDPair : query->studyAndSeriesInstanceUIDQueried() )
-#else
-    typedef QPair<QString,QString> StudyAndSeriesInstanceUIDPairType;
-    Q_FOREACH(const StudyAndSeriesInstanceUIDPairType & StudyAndSeriesInstanceUIDPair, query->studyAndSeriesInstanceUIDQueried())
-#endif
       {
       d->QueriesByStudyUID[StudyAndSeriesInstanceUIDPair.first] = query;
       d->StudyAndSeriesInstanceUIDPairList.push_back(qMakePair( StudyAndSeriesInstanceUIDPair.first, StudyAndSeriesInstanceUIDPair.second ));
@@ -296,19 +291,6 @@ void ctkDICOMQueryRetrieveWidget::query()
   d->ProgressDialog = 0;
   d->CurrentQuery = 0;
 }
-
-//----------------------------------------------------------------------------
-#ifndef HAVE_QT5
-namespace {
-  struct FindBySeriesUID {
-    QString seriesUID;
-    FindBySeriesUID(const QString& uid) : seriesUID(uid) {}
-    bool operator () (const QPair<QString, QString>& element) const {
-      return element.second == seriesUID;
-    }
-  };
-}
-#endif
 
 //----------------------------------------------------------------------------
 void ctkDICOMQueryRetrieveWidget::retrieve()
@@ -363,14 +345,8 @@ void ctkDICOMQueryRetrieveWidget::retrieve()
       }
 
     // Get the study UID of the current series to be retrieved
-#ifdef HAVE_QT5
     auto currentStudyAndSeriesUIDPair = std::find_if( d->StudyAndSeriesInstanceUIDPairList.begin(), d->StudyAndSeriesInstanceUIDPairList.end(),
         [&seriesUID]( const QPair<QString, QString>& element ) { return element.second == seriesUID; } );
-#else
-    typedef QList< QPair<QString,QString> > StudyAndSeriesInstanceUIDPairList;
-    StudyAndSeriesInstanceUIDPairList::iterator currentStudyAndSeriesUIDPair =
-      std::find_if(d->StudyAndSeriesInstanceUIDPairList.begin(), d->StudyAndSeriesInstanceUIDPairList.end(), FindBySeriesUID(seriesUID));
-#endif
     QString studyUID = currentStudyAndSeriesUIDPair->first;
 
     // Get information which server we want to get the study from and prepare request accordingly

--- a/Libs/PluginFramework/Testing/FrameworkTestPlugins/app_test/ctkTestAppActivator_p.h
+++ b/Libs/PluginFramework/Testing/FrameworkTestPlugins/app_test/ctkTestAppActivator_p.h
@@ -33,9 +33,7 @@ class ctkTestAppActivator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "app_test")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginA1_test/ctkTestPluginAActivator_p.h
+++ b/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginA1_test/ctkTestPluginAActivator_p.h
@@ -32,9 +32,7 @@ class ctkTestPluginAActivator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "pluginA1_test")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginA2_test/ctkTestPluginA2Activator_p.h
+++ b/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginA2_test/ctkTestPluginA2Activator_p.h
@@ -33,9 +33,7 @@ class ctkTestPluginA2Activator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "pluginA2_test")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginA_test/ctkTestPluginAActivator_p.h
+++ b/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginA_test/ctkTestPluginAActivator_p.h
@@ -32,9 +32,7 @@ class ctkTestPluginAActivator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "pluginA_test")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginSL1_test/ctkActivatorSL1_p.h
+++ b/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginSL1_test/ctkActivatorSL1_p.h
@@ -36,9 +36,7 @@ class ctkActivatorSL1 :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "pluginSL1_test")
-#endif
   Q_PROPERTY(bool serviceAdded READ serviceAdded)
   Q_PROPERTY(bool serviceRemoved READ serviceRemoved)
 

--- a/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginSL3_test/ctkActivatorSL3_p.h
+++ b/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginSL3_test/ctkActivatorSL3_p.h
@@ -37,9 +37,7 @@ class ctkActivatorSL3 :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "pluginSL3_test")
-#endif
   Q_PROPERTY(bool serviceAdded READ serviceAdded)
   Q_PROPERTY(bool serviceRemoved READ serviceRemoved)
 

--- a/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginSL4_test/ctkActivator_p.h
+++ b/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginSL4_test/ctkActivator_p.h
@@ -31,9 +31,7 @@ class ctkActivator :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator ctkFooService)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "pluginSL4_test")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginS_test/ctkTestPluginSActivator_p.h
+++ b/Libs/PluginFramework/Testing/FrameworkTestPlugins/pluginS_test/ctkTestPluginSActivator_p.h
@@ -33,9 +33,7 @@ class ctkTestPluginSActivator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "pluginS_test")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/MetaTypeTestPlugins/pluginAttrPwd_test/ctkTestPluginMTAttrPwdActivator_p.h
+++ b/Libs/PluginFramework/Testing/MetaTypeTestPlugins/pluginAttrPwd_test/ctkTestPluginMTAttrPwdActivator_p.h
@@ -30,9 +30,7 @@ class ctkTestPluginMTAttrPwdActivator :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "pluginAttrPwd_test")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/org.commontk.configadmintest/ctkConfigAdminTestActivator_p.h
+++ b/Libs/PluginFramework/Testing/org.commontk.configadmintest/ctkConfigAdminTestActivator_p.h
@@ -31,9 +31,7 @@ class ctkConfigAdminTestActivator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_configadmintest")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/org.commontk.eventadmintest.perf/ctkEventAdminTestPerfActivator_p.h
+++ b/Libs/PluginFramework/Testing/org.commontk.eventadmintest.perf/ctkEventAdminTestPerfActivator_p.h
@@ -31,9 +31,7 @@ class ctkEventAdminTestPerfActivator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_eventadmintest_perf")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/org.commontk.eventadmintest/ctkEventAdminTestActivator_p.h
+++ b/Libs/PluginFramework/Testing/org.commontk.eventadmintest/ctkEventAdminTestActivator_p.h
@@ -31,9 +31,7 @@ class ctkEventAdminTestActivator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_eventadmintest")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/org.commontk.metatypetest/ctkMetaTypeTestActivator_p.h
+++ b/Libs/PluginFramework/Testing/org.commontk.metatypetest/ctkMetaTypeTestActivator_p.h
@@ -31,9 +31,7 @@ class ctkMetaTypeTestActivator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_metatypetest")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/org.commontk.pluginfwtest.perf/ctkPluginFrameworkTestPerfActivator_p.h
+++ b/Libs/PluginFramework/Testing/org.commontk.pluginfwtest.perf/ctkPluginFrameworkTestPerfActivator_p.h
@@ -31,9 +31,7 @@ class ctkPluginFrameworkTestPerfActivator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_pluginfwtest_perf")
-#endif
 
 public:
 

--- a/Libs/PluginFramework/Testing/org.commontk.pluginfwtest/ctkPluginFrameworkTestActivator_p.h
+++ b/Libs/PluginFramework/Testing/org.commontk.pluginfwtest/ctkPluginFrameworkTestActivator_p.h
@@ -31,9 +31,7 @@ class ctkPluginFrameworkTestActivator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_pluginfwtest")
-#endif
 
 public:
 

--- a/Libs/Scripting/Python/Widgets/Plugins/ctkScriptingPythonWidgetsPlugins.h
+++ b/Libs/Scripting/Python/Widgets/Plugins/ctkScriptingPythonWidgetsPlugins.h
@@ -23,11 +23,7 @@
 
 // Qt includes
 #include <QtGlobal>
-#ifndef HAVE_QT5
-#include <QDesignerCustomWidgetCollectionInterface>
-#else
 #include <QtUiPlugin/QDesignerCustomWidgetCollectionInterface>
-#endif
 
 // CTK includes
 #include "ctkScriptingPythonWidgetsPluginsExport.h"
@@ -39,9 +35,7 @@ class CTK_SCRIPTING_PYTHON_WIDGETS_PLUGINS_EXPORT ctkScriptingPythonWidgetsPlugi
   , public QDesignerCustomWidgetCollectionInterface
 {
   Q_OBJECT
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.commontk.Python")
-#endif
   Q_INTERFACES(QDesignerCustomWidgetCollectionInterface);
 
 public:

--- a/Libs/Visualization/VTK/Widgets/Plugins/ctkVTKWidgetsPlugins.h
+++ b/Libs/Visualization/VTK/Widgets/Plugins/ctkVTKWidgetsPlugins.h
@@ -23,11 +23,7 @@
 
 // Qt includes
 #include <QtGlobal>
-#ifndef HAVE_QT5
-#include <QDesignerCustomWidgetCollectionInterface>
-#else
 #include <QtUiPlugin/QDesignerCustomWidgetCollectionInterface>
-#endif
 
 // CTK includes
 #include "ctkVisualizationVTKWidgetsPluginsExport.h"
@@ -53,9 +49,7 @@ class CTK_VISUALIZATION_VTK_WIDGETS_PLUGINS_EXPORT ctkVTKWidgetsPlugins
   , public QDesignerCustomWidgetCollectionInterface
 {
   Q_OBJECT
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.commontk.VTKWidgets")
-#endif
   Q_INTERFACES(QDesignerCustomWidgetCollectionInterface);
 
 public:

--- a/Libs/Widgets/Plugins/ctkWidgetsPlugins.h
+++ b/Libs/Widgets/Plugins/ctkWidgetsPlugins.h
@@ -23,11 +23,7 @@
 
 // Qt includes
 #include <QtGlobal>
-#ifndef HAVE_QT5
-#include <QDesignerCustomWidgetCollectionInterface>
-#else
 #include <QtUiPlugin/QDesignerCustomWidgetCollectionInterface>
-#endif
 
 // CTK includes
 #include "ctkWidgetsPluginsExport.h"
@@ -81,9 +77,7 @@ class CTK_WIDGETS_PLUGINS_EXPORT ctkWidgetsPlugins
 {
   Q_OBJECT
   Q_INTERFACES(QDesignerCustomWidgetCollectionInterface)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.commontk.Widgets")
-#endif
 public:
   QList<QDesignerCustomWidgetInterface*> customWidgets() const
     {

--- a/Plugins/org.commontk.configadmin/ctkConfigurationAdminActivator_p.h
+++ b/Plugins/org.commontk.configadmin/ctkConfigurationAdminActivator_p.h
@@ -41,9 +41,7 @@ class ctkConfigurationAdminActivator :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_configadmin")
-#endif
 
 public:
 

--- a/Plugins/org.commontk.dah.cmdlinemoduleapp/ctkCommandLineModuleAppPlugin_p.h
+++ b/Plugins/org.commontk.dah.cmdlinemoduleapp/ctkCommandLineModuleAppPlugin_p.h
@@ -32,9 +32,7 @@ class ctkCommandLineModuleAppPlugin :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_dah_cmdlinemoduleapp")
-#endif
 
 public:
 

--- a/Plugins/org.commontk.dah.core/ctkDicomAppHostingCorePlugin_p.h
+++ b/Plugins/org.commontk.dah.core/ctkDicomAppHostingCorePlugin_p.h
@@ -30,9 +30,7 @@ class ctkDicomAppHostingCorePlugin :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_dah_core")
-#endif
 
 public:
 

--- a/Plugins/org.commontk.dah.exampleapp/ctkExampleDicomAppPlugin_p.h
+++ b/Plugins/org.commontk.dah.exampleapp/ctkExampleDicomAppPlugin_p.h
@@ -32,9 +32,7 @@ class ctkExampleDicomAppPlugin :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_example_dicomapp")
-#endif
 
 public:
 

--- a/Plugins/org.commontk.dah.examplehost/ctkExampleDicomHostPlugin_p.h
+++ b/Plugins/org.commontk.dah.examplehost/ctkExampleDicomHostPlugin_p.h
@@ -30,9 +30,7 @@ class ctkExampleDicomHostPlugin :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_dah_examplehost")
-#endif
 
 public:
 

--- a/Plugins/org.commontk.dah.host/ctkDicomHostPlugin_p.h
+++ b/Plugins/org.commontk.dah.host/ctkDicomHostPlugin_p.h
@@ -30,9 +30,7 @@ class ctkDicomHostPlugin :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_dah_host")
-#endif
 
 public:
 

--- a/Plugins/org.commontk.dah.hostedapp/ctkDicomAppPlugin_p.h
+++ b/Plugins/org.commontk.dah.hostedapp/ctkDicomAppPlugin_p.h
@@ -33,9 +33,7 @@ class ctkDicomAppPlugin :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_dah_hostedapp")
-#endif
 
 public:
 

--- a/Plugins/org.commontk.eventadmin/ctkEventAdminActivator_p.h
+++ b/Plugins/org.commontk.eventadmin/ctkEventAdminActivator_p.h
@@ -35,9 +35,7 @@ class ctkEventAdminActivator : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_eventadmin")
-#endif
 
 public:
 

--- a/Plugins/org.commontk.log/ctkLogPlugin_p.h
+++ b/Plugins/org.commontk.log/ctkLogPlugin_p.h
@@ -32,9 +32,7 @@ class ctkLogPlugin :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_log")
-#endif
 
 public:
 

--- a/Plugins/org.commontk.metatype/ctkMetaTypeActivator_p.h
+++ b/Plugins/org.commontk.metatype/ctkMetaTypeActivator_p.h
@@ -36,9 +36,7 @@ class ctkMetaTypeActivator :
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_metatype")
-#endif
 
 private:
 

--- a/Plugins/org.commontk.plugingenerator.core/ctkPluginGeneratorCorePlugin_p.h
+++ b/Plugins/org.commontk.plugingenerator.core/ctkPluginGeneratorCorePlugin_p.h
@@ -32,9 +32,7 @@ class ctkPluginGeneratorCorePlugin : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_plugingenerator_core")
-#endif
 
 public:
 

--- a/Plugins/org.commontk.plugingenerator.ui/ctkPluginGeneratorUiPlugin_p.h
+++ b/Plugins/org.commontk.plugingenerator.ui/ctkPluginGeneratorUiPlugin_p.h
@@ -32,9 +32,7 @@ class ctkPluginGeneratorUiPlugin : public QObject,
 {
   Q_OBJECT
   Q_INTERFACES(ctkPluginActivator)
-#ifdef HAVE_QT5
   Q_PLUGIN_METADATA(IID "org_commontk_plugingenerator_ui")
-#endif
 
 public:
 


### PR DESCRIPTION
Also partially revert 299825292 (COMP: Update ctkDICOMQueryRetrieveWidget to fix build against Qt4/C++98).