### PR TITLE
BUG: Fix ctkDICOMIndexer reverting back to functor signal/slot

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMIndexer.cpp
+++ b/Libs/DICOM/Core/ctkDICOMIndexer.cpp
@@ -297,15 +297,15 @@ ctkDICOMIndexerPrivate::ctkDICOMIndexerPrivate(ctkDICOMIndexer& o)
   ctkDICOMIndexerPrivateWorker* worker = new ctkDICOMIndexerPrivateWorker(&this->RequestQueue);
   worker->moveToThread(&this->WorkerThread);
 
-  connect(&this->WorkerThread, SIGNAL("finished()"), worker, SLOT("deleteLater()"));
-  connect(this, SIGNAL("startWorker()"), worker, SLOT("start()"));
+  connect(&this->WorkerThread, &QThread::finished, worker, &QObject::deleteLater);
+  connect(this, &ctkDICOMIndexerPrivate::startWorker, worker, &ctkDICOMIndexerPrivateWorker::start);
 
   // Progress report
-  connect(worker, SIGNAL("progress(int)"), q_ptr, SLOT("progress(int)"));
-  connect(worker, SIGNAL("progressDetail(QString)"), q_ptr, SLOT("progressDetail(QString)"));
-  connect(worker, SIGNAL("progressStep(QString)"), q_ptr, SLOT("progressStep(QString)"));
-  connect(worker, SIGNAL("updatingDatabase(bool)"), q_ptr, SLOT("updatingDatabase(bool)"));
-  connect(worker, SIGNAL("indexingComplete(int,int,int,int)"), q_ptr, SLOT("indexingComplete(int,int,int,int)"));
+  connect(worker, &ctkDICOMIndexerPrivateWorker::progress, q_ptr, &ctkDICOMIndexer::progress);
+  connect(worker, &ctkDICOMIndexerPrivateWorker::progressDetail, q_ptr, &ctkDICOMIndexer::progressDetail);
+  connect(worker, &ctkDICOMIndexerPrivateWorker::progressStep, q_ptr, &ctkDICOMIndexer::progressStep);
+  connect(worker, &ctkDICOMIndexerPrivateWorker::updatingDatabase, q_ptr, &ctkDICOMIndexer::updatingDatabase);
+  connect(worker, &ctkDICOMIndexerPrivateWorker::indexingComplete, q_ptr, &ctkDICOMIndexer::indexingComplete);
 
   this->WorkerThread.start();
 }
@@ -653,10 +653,10 @@ void ctkDICOMIndexer::waitForImportFinished(int msecTimeout /*=-1*/)
   QTimer timer;
   timer.setSingleShot(true);
   QEventLoop loop;
-  connect(this, SIGNAL("indexingComplete(int,int,int,int)"), &loop, SLOT("quit()"));
+  connect(this, &ctkDICOMIndexer::indexingComplete, &loop, &QEventLoop::quit);
   if (msecTimeout >= 0)
   {
-    connect(&timer, SIGNAL("timeout()"), &loop, SLOT("quit()"));
+    connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
     timer.start(msecTimeout);
   }
   if (!this->isImporting())


### PR DESCRIPTION
This commit reverts 7bb0d9fdb (`COMP: Fix Qt4/C++98 ctkDICOMIndexerPrivate build using literal signal/slot`)

This addresses the following error reported when running ctkDICOMIndexerTest1:

```
QObject::connect: No such signal QThread::"finished()"
QObject::connect: No such signal ctkDICOMIndexerPrivate::"startWorker()"
QObject::connect: No such signal ctkDICOMIndexerPrivateWorker::"progress(int)"
QObject::connect: No such signal ctkDICOMIndexerPrivateWorker::"progressDetail(QString)"
QObject::connect: No such signal ctkDICOMIndexerPrivateWorker::"progressStep(QString)"
QObject::connect: No such signal ctkDICOMIndexerPrivateWorker::"updatingDatabase(bool)"
QObject::connect: No such signal ctkDICOMIndexerPrivateWorker::"indexingComplete(int,int,int,int)"
QObject::connect: No such signal ctkDICOMIndexer::"indexingComplete(int,int,int,int)"
```

For reference, the functor-based connection was introduced in 7f2f24a051 (`ENH: DICOM browser rework`)