### PR TITLE
BUG: Fix ctkFlowLayout regression related to minimum size computation

### DIFF
--- a/Libs/Widgets/ctkFlowLayout.cpp
+++ b/Libs/Widgets/ctkFlowLayout.cpp
@@ -414,7 +414,12 @@ QSize ctkFlowLayout::minimumSize() const
       }
     size = size.expandedTo(item->minimumSize());
     }
-  size += this->contentsRect().size();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  size = size.grownBy(this->contentsMargins());
+#else
+  QMargins margins = this->contentsMargins();
+  size += QSize(margins.left() + margins.right(), margins.top() + margins.bottom());
+#endif
   return size;
 }
 
@@ -475,7 +480,12 @@ QSize ctkFlowLayout::sizeHint() const
   size += QSize((countX-1) * this->horizontalSpacing(),
                 (countY-1) * this->verticalSpacing());
   // Add margins
-  size += this->contentsRect().size();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  size = size.grownBy(this->contentsMargins());
+#else
+  QMargins margins = this->contentsMargins();
+  size += QSize(margins.left() + margins.right(), margins.top() + margins.bottom());
+#endif
   return size;
 }
 


### PR DESCRIPTION
This commit fixes a regression introduced in e66324212 (`COMP: Fix deprecated warning related to QWidget::getContentsMargins()`).

Since functions `QWidget::contentsRect()` and `QWidget::contentsMargins()` are not equivalent, the logic associated with `ctkFlowLayout::minimumSize()` and `ctkFlowLayout::sizeHint()` was incorrect.

Fixes https://github.com/Slicer/Slicer/issues/7108

Reported by @cpinter 