### PR TITLE
COMP: Update ctk_list_to_string to use CMake join implementation if available

### DIFF
--- a/CMake/ctkListToString.cmake
+++ b/CMake/ctkListToString.cmake
@@ -19,6 +19,11 @@
 ###########################################################################
 
 function(ctk_list_to_string separator input_list output_string_var)
+  if(${CMAKE_VERSION} VERSION_EQUAL "3.12" OR ${CMAKE_VERSION} VERSION_GREATER "3.12")
+    string(JOIN "${separator}" _string ${input_list})
+    set(${output_string_var} ${_string} PARENT_SCOPE)
+    return()
+  endif()
   set(_string "")
   cmake_policy(PUSH)
   cmake_policy(SET CMP0007 OLD)


### PR DESCRIPTION
This addresses the following warning:

```
CMake Deprecation Warning at CMake/ctkListToString.cmake:24 (cmake_policy):
  The OLD behavior for policy CMP0007 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
Call Stack (most recent call first):
  CMake/ctkMacroSetupQt.cmake:158 (ctk_list_to_string)
  CMakeLists.txt:421 (ctkMacroSetupQt)
```

The `string(JOIN ...)` sub-command was introduced in CMake 3.12.
See https://cmake.org/cmake/help/v3.27/command/string.html#join
