### PR TITLE
ENH: Improve setting of CTK_QT5_COMPONENTS based on actual requirements

### DIFF
--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -32,20 +32,93 @@ macro(ctkMacroSetupQt)
   if(CTK_QT_VERSION VERSION_EQUAL "5")
     cmake_minimum_required(VERSION 2.8.12)
     find_package(Qt5 COMPONENTS Core)
-    set(CTK_QT5_COMPONENTS Core Xml XmlPatterns Concurrent Sql Test Multimedia)
-    if(CTK_ENABLE_Widgets OR CTK_LIB_Widgets OR CTK_LIB_CommandLineModules/Frontend/QtGui)
-      list(APPEND CTK_QT5_COMPONENTS Widgets OpenGL UiTools)
+
+    set(CTK_QT5_COMPONENTS Core)
+
+    # See https://github.com/commontk/CTK/wiki/Maintenance#updates-of-required-qt-components
+
+    if(CTK_LIB_Widgets
+      OR CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTXML
+      )
+      list(APPEND CTK_QT5_COMPONENTS Xml)
     endif()
-    if(CTK_LIB_CommandLineModules/Frontend/QtWebKit)
+
+    if(CTK_APP_ctkCommandLineModuleExplorer
+      OR CTK_LIB_CommandLineModules/Core
+      OR CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTXMLPATTERNS
+      )
+      list(APPEND CTK_QT5_COMPONENTS XmlPatterns)
+    endif()
+
+    if(CTK_APP_ctkCommandLineModuleExplorer
+      OR CTK_LIB_CommandLineModules/Core
+      OR CTK_LIB_PluginFramework
+      OR CTK_PLUGIN_org.commontk.eventadmin
+      )
+      list(APPEND CTK_QT5_COMPONENTS Concurrent)
+    endif()
+
+    if(CTK_LIB_DICOM/Core
+      OR CTK_LIB_DICOM/Widgets
+      OR Libs/PluginFramework
+      )
+      list(APPEND CTK_QT5_COMPONENTS Sql)
+    endif()
+
+    if(BUILD_TESTING)
+      list(APPEND CTK_QT5_COMPONENTS Test)
+    endif()
+
+    if(CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTMULTIMEDIA)
+      list(APPEND CTK_QT5_COMPONENTS Multimedia)
+    endif()
+
+    if(CTK_ENABLE_Widgets
+      OR CTK_LIB_Widgets
+      OR CTK_LIB_CommandLineModules/Frontend/QtGui
+      OR CTK_LIB_QtTesting
+      )
+      list(APPEND CTK_QT5_COMPONENTS Widgets)
+    endif()
+
+    if(CTK_LIB_Widgets)
+      list(APPEND CTK_QT5_COMPONENTS OpenGL)
+    endif()
+
+    if(CTK_APP_ctkCommandLineModuleExplorer
+      OR CTK_LIB_CommandLineModules/Frontend/QtGui
+      OR CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTUITOOLS
+      )
+      list(APPEND CTK_QT5_COMPONENTS UiTools)
+    endif()
+
+    if(CTK_LIB_CommandLineModules/Frontend/QtWebKit
+      OR CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTWEBKIT
+      OR CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTWEBKITWIDGETS
+      )
       if(TARGET Qt5::WebKitWidgets)
         list(APPEND CTK_QT5_COMPONENTS WebKitWidgets)
       else()
         list(APPEND CTK_QT5_COMPONENTS WebEngineWidgets)
       endif()
     endif()
+
     if(CTK_LIB_XNAT/Core)
       list(APPEND CTK_QT5_COMPONENTS Script)
     endif()
+
+    if(CTK_BUILD_QTDESIGNER_PLUGINS)
+      list(APPEND CTK_QT5_COMPONENTS Designer)
+    endif()
+
+    if(CTK_LIB_XNAT/Core
+      OR CTK_PLUGIN_org.commontk.dah.core
+      OR CTK_PLUGIN_org.commontk.dah.host
+      OR CTK_PLUGIN_org.commontk.dah.hostedapp
+      )
+      list(APPEND CTK_QT5_COMPONENTS Network)
+    endif()
+
     find_package(Qt5 COMPONENTS ${CTK_QT5_COMPONENTS} REQUIRED)
 
     mark_as_superbuild(Qt5_DIR) # Qt 5


### PR DESCRIPTION
This update was done based on the output of the process documented on the CTK wiki page "Maintenance / Updates of Required Qt Components". See https://github.com/commontk/CTK/wiki/Maintenance#updates-of-required-qt-components

### Default configuration

See before/after when configuration CTK with default options

Before:

```
-- Configuring CTK with Qt 5.15.2 (using modules: Core, Xml, XmlPatterns, Concurrent, Sql, Test, Multimedia)
```

After:

```
-- Configuring CTK with Qt 5.15.2 (using modules: Core, Test)
```

### Slicer configuration

_Output based of Slicer/Slicer@77f1e2d06c_

Before:

```
-- Configuring CTK with Qt 5.15.2 (using modules: Core, Xml, XmlPatterns, Concurrent, Sql, Test, Multimedia, Widgets, OpenGL, UiTools)
```

After:

```
-- Configuring CTK with Qt 5.15.2 (using modules: Core, Xml, Sql, Multimedia, Widgets, OpenGL, UiTools, Designer)
```

```diff
Core
Xml
- XmlPatterns
- Concurrent
Sql
- Test
Multimedia
Widgets
OpenGL
UiTools
+ Designer
```