### PR TITLE
COMP: Fix CTK QtTesting library build

### DIFF
--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -44,6 +44,7 @@ macro(ctkMacroSetupQt)
     endif()
 
     if(CTK_APP_ctkCommandLineModuleExplorer
+      OR CTK_LIB_QtTesting
       OR CTK_LIB_CommandLineModules/Core
       OR CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTXMLPATTERNS
       )


### PR DESCRIPTION
This commit fixes a regression introduced in c0c8e41db (ENH: Improve setting of CTK_QT5_COMPONENTS based on actual requirements) adding XmlPatterns as a requirement if CTK_LIB_QtTesting is enabled.