### PR TITLE
ENH: Update ExternalProjectDependency based on commontk/Artichoke@dff357a

### DIFF
--- a/CMake/ctkMacroCheckExternalProjectDependency.cmake
+++ b/CMake/ctkMacroCheckExternalProjectDependency.cmake
@@ -525,6 +525,10 @@ function(_sb_get_external_project_arguments proj varname)
         )
     endforeach()
   endif()
+  if(CMAKE_VERSION VERSION_EQUAL "3.24" OR CMAKE_VERSION VERSION_GREATER "3.24")
+    # See https://cmake.org/cmake/help/latest/policy/CMP0135.html
+    list(APPEND _ep_arguments DOWNLOAD_EXTRACT_TIMESTAMP 1)
+  endif()
   set(${varname} ${_ep_arguments} PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
List of changes:

```
$ git shortlog ea920eb..dff357a --no-merges
Jean-Christophe Fillion-Robin (5):
      ci: Add GitHub Actions based workflow
      ci: Exclude "IncludeDependencies-DifferentGenerator-Test" with CMake 2.8.x
      DOC: Update README adding GitHub Actions badge
      ci: cancel in-progress GitHub Actions workflow on repeated pushes
      ExternalProjectDependency: Set DOWNLOAD_EXTRACT_TIMESTAMP to 1 if CMake >= 3.24
```