### PR TITLE
ENH: Change collapsible arrows to detail the direction of the changing content

### DIFF
--- a/Libs/Widgets/ctkCollapsibleButton.cpp
+++ b/Libs/Widgets/ctkCollapsibleButton.cpp
@@ -592,11 +592,11 @@ void ctkCollapsibleButton::paintEvent(QPaintEvent * _event)
     }
   if (d->Collapsed)
     {
-    style()->drawPrimitive(QStyle::PE_IndicatorArrowRight, &indicatorOpt, &p, this);
+    style()->drawPrimitive(QStyle::PE_IndicatorArrowDown, &indicatorOpt, &p, this);
     }
   else
     {
-    style()->drawPrimitive(QStyle::PE_IndicatorArrowDown, &indicatorOpt, &p, this);
+    style()->drawPrimitive(QStyle::PE_IndicatorArrowUp, &indicatorOpt, &p, this);
     }
 
   // Draw Text

--- a/Libs/Widgets/ctkCollapsibleButton.cpp
+++ b/Libs/Widgets/ctkCollapsibleButton.cpp
@@ -98,20 +98,20 @@ void ctkCollapsibleButtonPrivate::init()
   this->ContentsMidLineWidth = 0;
 
   this->CollapsedHeight = 14;
-  this->ExclusiveMouseOver = false;  
+  this->ExclusiveMouseOver = false;
   this->LookOffWhenChecked = true; // set as a prop ?
-  
+
   this->MaximumHeight = q->maximumHeight();
 
   this->TextAlignment = Qt::AlignLeft | Qt::AlignVCenter;
   this->IndicatorAlignment = Qt::AlignLeft | Qt::AlignVCenter;
 
   q->setSizePolicy(QSizePolicy(QSizePolicy::Minimum,
-                               QSizePolicy::Preferred, 
+                               QSizePolicy::Preferred,
                                QSizePolicy::DefaultType));
   q->setContentsMargins(0, q->buttonSizeHint().height(),0 , 0);
   // by default QAbstractButton changed the background role to Button
-  // we want a regular background 
+  // we want a regular background
   q->setBackgroundRole(QPalette::Window);
 
   QObject::connect(q, SIGNAL(toggled(bool)),
@@ -422,7 +422,7 @@ QSize ctkCollapsibleButton::buttonSizeHint()const
 
   QStyleOptionButton opt;
   opt.initFrom(this);
-  
+
   // indicator
   QSize indicatorSize = QSize(style()->pixelMetric(QStyle::PM_IndicatorWidth, &opt, this),
                               style()->pixelMetric(QStyle::PM_IndicatorHeight, &opt, this));
@@ -431,8 +431,8 @@ QSize ctkCollapsibleButton::buttonSizeHint()const
   int iw = indicatorSize.width() + indicatorSpacing;
   w += iw;
   h = qMax(h, ih);
-  
-  // text 
+
+  // text
   QString string(this->text());
   bool empty = string.isEmpty();
   if (empty)
@@ -466,7 +466,7 @@ QSize ctkCollapsibleButton::minimumSizeHint()const
     {// no layout, means the button is empty ?
     return buttonSize;
     }
-  QSize s = this->QAbstractButton::minimumSizeHint(); 
+  QSize s = this->QAbstractButton::minimumSizeHint();
   return s.expandedTo(buttonSize);
 }
 
@@ -481,7 +481,7 @@ QSize ctkCollapsibleButton::sizeHint()const
     }
   // open
   // QAbstractButton works well only if a layout is set
-  QSize s = this->QAbstractButton::sizeHint(); 
+  QSize s = this->QAbstractButton::sizeHint();
   return s.expandedTo(buttonSize + QSize(0, d->CollapsedHeight));
 }
 
@@ -505,13 +505,13 @@ void ctkCollapsibleButton::paintEvent(QPaintEvent * _event)
     QRect buttonRect = opt.rect;
     QList<QWidget*> _children = this->findChildren<QWidget*>();
     QList<QWidget*>::ConstIterator it;
-    for (it = _children.constBegin(); it != _children.constEnd(); ++it ) 
+    for (it = _children.constBegin(); it != _children.constEnd(); ++it )
       {
       if ((*it)->underMouse())
         {
-        // the mouse has been moved from the collapsible button to one 
+        // the mouse has been moved from the collapsible button to one
         // of its children. The paint event rect is the child rect, this
-        // is why we have to request another paint event to redraw the 
+        // is why we have to request another paint event to redraw the
         // button to remove the highlight effect.
         if (!_event->rect().contains(buttonRect))
           {// repaint the button rect.
@@ -524,7 +524,7 @@ void ctkCollapsibleButton::paintEvent(QPaintEvent * _event)
       }
     if (d->ExclusiveMouseOver && !exclusiveMouseOver)
       {
-      // the mouse is over the widget, but not over the children. As it 
+      // the mouse is over the widget, but not over the children. As it
       // has been de-highlighted in the past, we should refresh the button
       // rect to re-highlight the button.
       if (!_event->rect().contains(buttonRect))

--- a/Libs/Widgets/ctkCollapsibleGroupBox.cpp
+++ b/Libs/Widgets/ctkCollapsibleGroupBox.cpp
@@ -48,7 +48,7 @@ public:
       const ctkCollapsibleGroupBox* groupBox= qobject_cast<const ctkCollapsibleGroupBox*>(widget);
       if (groupBox)
         {
-        this->Superclass::drawPrimitive(groupBox->isChecked() ? QStyle::PE_IndicatorArrowDown : QStyle::PE_IndicatorArrowRight, opt, p, widget);
+        this->Superclass::drawPrimitive(groupBox->isChecked() ? QStyle::PE_IndicatorArrowUp : QStyle::PE_IndicatorArrowDown, opt, p, widget);
         return;
         }
       }

--- a/Libs/Widgets/ctkCollapsibleGroupBox.cpp
+++ b/Libs/Widgets/ctkCollapsibleGroupBox.cpp
@@ -225,6 +225,7 @@ void ctkCollapsibleGroupBox::expand(bool _expand)
       }
     }
 
+
   if (_expand)
     {
     this->setMaximumHeight(d->MaxHeight);


### PR DESCRIPTION
This contribution is an example of contributing back design changes based on some design research that I have read. I mentioned at a recent Slicer weekly meeting about research based design systems and being willing to contribute back design changes. I encourage reviewers to read the linked nngroup article below.

-----------------------------------------------------------------

This reverts https://github.com/commontk/CTK/commit/952d5dc9de8c409c69cc9724c673327925c23d48 (cc @pieper)

https://www.nngroup.com/articles/accordion-icons/
[Laubheimer and Budiu, 2020]

This research looked at the difference between the following indicators for accordions (ctkCollapsible type widgets) and found the caret (downward-facing-arrow) performed the best.

> Caret (or downward-facing arrow)
> Plus
> Right-facing arrow
> No icon at all

> We placed the accordion icon to the right of its associated label, close to the edge of the screen and right aligned. (We acknowledge that another possible position is to the left of the label — our results may not generalize to that placement.)

^For now I have left the icon on the left side of its associated label, but that could be under consideration as well. This would position that indicator like it is for a combobox.

> Use a caret icon to designate an accordion, whether on desktop or mobile — our study found that of the standard set of icons used in this context, only the caret performed better than either no icon or a nonsense icon at indicating that than it was an accordion.

| `master` | This PR |
|-----------|---------|
|![image](https://github.com/commontk/CTK/assets/15837524/780c1d86-780b-4267-a147-849d176c97c4)|![image](https://github.com/commontk/CTK/assets/15837524/5394aa72-8476-450d-90a0-96c033d63c58)|