### PR TITLE
COMP: Fix CTK PluginFramework library build

### DIFF
--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -61,7 +61,7 @@ macro(ctkMacroSetupQt)
 
     if(CTK_LIB_DICOM/Core
       OR CTK_LIB_DICOM/Widgets
-      OR Libs/PluginFramework
+      OR CTK_LIB_PluginFramework
       )
       list(APPEND CTK_QT5_COMPONENTS Sql)
     endif()


### PR DESCRIPTION
Follow-up c0c8e41db (`ENH: Improve setting of CTK_QT5_COMPONENTS based on actual requirements`) fixing the check adding Sql to the list of components when `CTK_ENABLE_PluginFramework`

## Before

```
$ cmake \
  -DCTK_ENABLE_PluginFramework:BOOL=ON \
  -DCMAKE_BUILD_TYPE:STRING=Release \
  -DQt5_DIR:PATH=$Qt5_DIR -DCTK_QT_VERSION:STRING=5 \
  ../CTK

[...]
-- Configuring CTK with Qt 5.15.2 (using modules: Core, Concurrent, Test, Designer)
-- SuperBuild - First pass
-- SuperBuild - First pass - done
[...]
-- SuperBuild - CTK[OK]
-- Configuring done (2.9s)
-- Generating done (0.0s)
```


## After

```
$ rm -rf *
$ cmake \
  -DCTK_ENABLE_PluginFramework:BOOL=ON \
  -DCMAKE_BUILD_TYPE:STRING=Release \
  -DQt5_DIR:PATH=$Qt5_DIR -DCTK_QT_VERSION:STRING=5 \
  ../CTK

[...]
-- Configuring CTK with Qt 5.15.2 (using modules: Core, Concurrent, Sql, Test, Designer)
-- SuperBuild - First pass
-- SuperBuild - First pass - done
[...]
-- SuperBuild - CTK[OK]
-- Configuring done (2.9s)
-- Generating done (0.0s)
```