### PR TITLE
COMP: Fix configuration without explicitly setting CTK_QT_VERSION

### DIFF
--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -20,14 +20,6 @@
 
 #! \ingroup CMakeUtilities
 macro(ctkMacroSetupQt)
-  set(CTK_QT_VERSION "5" CACHE STRING "Expected Qt version")
-  mark_as_advanced(CTK_QT_VERSION)
-
-  set_property(CACHE CTK_QT_VERSION PROPERTY STRINGS 5)
-
-  if(NOT CTK_QT_VERSION VERSION_EQUAL "5")
-    message(FATAL_ERROR "Expected value for CTK_QT_VERSION is '5'")
-  endif()
 
   if(CTK_QT_VERSION VERSION_EQUAL "5")
     cmake_minimum_required(VERSION 2.8.12)
@@ -139,6 +131,4 @@ macro(ctkMacroSetupQt)
   else()
     message(FATAL_ERROR "Support for Qt${CTK_QT_VERSION} is not implemented")
   endif()
-
-  mark_as_superbuild(CTK_QT_VERSION)
 endmacro()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,14 @@ option(CTK_SUPERBUILD "Build ${PROJECT_NAME} and the projects it depends on." ON
 mark_as_advanced(CTK_SUPERBUILD)
 
 #-----------------------------------------------------------------------------
+# Qt version
+#
+set(CTK_QT_VERSION "5" CACHE STRING "Expected Qt version")
+mark_as_advanced(CTK_QT_VERSION)
+set_property(CACHE CTK_QT_VERSION PROPERTY STRINGS 5)
+mark_as_superbuild(CTK_QT_VERSION)
+
+#-----------------------------------------------------------------------------
 # Output directories.
 #
 foreach(type LIBRARY RUNTIME ARCHIVE)


### PR DESCRIPTION
Address a regression introduced in a0e74a080 (COMP: Update CMake files removing support for Qt 4.x) by fixing the following error reported when configuring without explicitly setting `CTK_QT_VERSION`:

```
cmake \
  -DQt5_DIR:PATH=$Qt5_DIR \
  -DCMAKE_BUILD_TYPE:STRING=Release \
  ../CTK

[...]
-- Checking if --no-as-needed linker flag is required - no
-- CTK_LIB_Core_WITH_BFD_SHARED is OFF
-- CTK_LIB_Core_WITH_BFD_STATIC is OFF
CMake Error at Libs/Visualization/VTK/Widgets/target_libraries.cmake:15 (message):
  Support for this Qt is not implemented
Call Stack (most recent call first):
  CMake/ctkMacroTargetLibraries.cmake:131 (include)
  CMake/ctkFunctionGenerateDGraphInput.cmake:78 (ctkFunctionCollectTargetLibraryNames)
  CMakeLists.txt:844 (ctkFunctionGenerateDGraphInput)
[...]
```