### PR TITLE
COMP: Fix CMake 3.26 warning in ctkLinkerAsNeededFlagCheck project

### DIFF
--- a/CMake/ctkLinkerAsNeededFlagCheck/CMakeLists.txt
+++ b/CMake/ctkLinkerAsNeededFlagCheck/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(ctkLinkerAsNeededFlagCheck)
 add_library(A SHARED A.cpp)
 add_library(B SHARED B.cpp)


### PR DESCRIPTION
Starting with CMake 2.26, a warning is reported if "cmake_minimum_required()" is not called before the "project()" command.

See https://cmake.org/cmake/help/v3.26/release/3.26.html#other-changes

It fixes the following warning:

```
CMake Warning (dev) at /path/to/CTK/CMake/ctkLinkerAsNeededFlagCheck/CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Adapted from Slicer/Slicer@968fd241328d3a7b6d5fe632b32db863aabcf90c introduced through:
* https://github.com/Slicer/Slicer/pull/7135