### PR TITLE
Ensure virtual functions can be called from derived ctkVTK view pimpl

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
@@ -65,6 +65,9 @@ ctkVTKAbstractViewPrivate::ctkVTKAbstractViewPrivate(ctkVTKAbstractView& object)
 }
 
 // --------------------------------------------------------------------------
+ctkVTKAbstractViewPrivate::~ctkVTKAbstractViewPrivate() = default;
+
+// --------------------------------------------------------------------------
 void ctkVTKAbstractViewPrivate::init()
 {
   Q_Q(ctkVTKAbstractView);

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView_p.h
@@ -52,6 +52,7 @@ protected:
 
 public:
   ctkVTKAbstractViewPrivate(ctkVTKAbstractView& object);
+  virtual ~ctkVTKAbstractViewPrivate();
 
   /// Convenient setup methods
   virtual void init();

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.cpp
@@ -61,6 +61,21 @@ ctkVTKRenderViewPrivate::ctkVTKRenderViewPrivate(ctkVTKRenderView& object)
 }
 
 // --------------------------------------------------------------------------
+ctkVTKRenderViewPrivate::~ctkVTKRenderViewPrivate() = default;
+
+// --------------------------------------------------------------------------
+void ctkVTKRenderViewPrivate::init()
+{
+  this->ctkVTKAbstractViewPrivate::init();
+
+  // The interactor in RenderWindow exists after the renderwindow is set to
+  // the QVTKWidet
+  this->Orientation->SetInteractor(this->RenderWindow->GetInteractor());
+  this->Orientation->SetEnabled(1);
+  this->Orientation->InteractiveOff();
+}
+
+// --------------------------------------------------------------------------
 void ctkVTKRenderViewPrivate::setupCornerAnnotation()
 {
   this->ctkVTKAbstractViewPrivate::setupCornerAnnotation();
@@ -204,18 +219,21 @@ ctkVTKRenderView::ctkVTKRenderView(QWidget* parentWidget)
 {
   Q_D(ctkVTKRenderView);
   d->init();
+}
 
-  // The interactor in RenderWindow exists after the renderwindow is set to
-  // the QVTKWidet
-  d->Orientation->SetInteractor(d->RenderWindow->GetInteractor());
-  d->Orientation->SetEnabled(1);
-  d->Orientation->InteractiveOff();
+// --------------------------------------------------------------------------
+ctkVTKRenderView::ctkVTKRenderView(ctkVTKRenderViewPrivate* pimpl, QWidget* parentWidget)
+  : Superclass(pimpl, parentWidget)
+{
+  // derived classes must call init manually. Calling init() here may results in
+  // actions on a derived public class not yet finished to be created
 }
 
 //----------------------------------------------------------------------------
 ctkVTKRenderView::~ctkVTKRenderView()
 {
 }
+
 //----------------------------------------------------------------------------
 void ctkVTKRenderView::setInteractor(vtkRenderWindowInteractor* newInteractor)
 {

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
@@ -145,7 +145,7 @@ public:
 
   /// Set window interactor
   /// Reimplemented to propagate interaction to Orientation widget
-  virtual void setInteractor(vtkRenderWindowInteractor* interactor);
+  void setInteractor(vtkRenderWindowInteractor* interactor) override;
 
   /// Return pitch, roll or yaw increment (in degree)
   double pitchRollYawIncrement()const;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
@@ -186,6 +186,9 @@ public:
   /// Return zoom factor
   double zoomFactor()const;
 
+protected:
+  ctkVTKRenderView(ctkVTKRenderViewPrivate* pimpl, QWidget* parent);
+
 private:
   Q_DECLARE_PRIVATE(ctkVTKRenderView);
   Q_DISABLE_COPY(ctkVTKRenderView);

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView_p.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView_p.h
@@ -52,8 +52,8 @@ public:
   ctkVTKRenderViewPrivate(ctkVTKRenderView& object);
 
   /// Convenient setup methods
-  virtual void setupCornerAnnotation();
-  virtual void setupRendering();
+  void setupCornerAnnotation() override;
+  void setupRendering() override;
 
   void zoom(double zoomFactor);
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView_p.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView_p.h
@@ -43,15 +43,17 @@ class vtkRenderWindowInteractor;
 
 //-----------------------------------------------------------------------------
 /// \ingroup Visualization_VTK_Widgets
-class ctkVTKRenderViewPrivate : public ctkVTKAbstractViewPrivate
+class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKRenderViewPrivate : public ctkVTKAbstractViewPrivate
 {
   Q_OBJECT
   Q_DECLARE_PUBLIC(ctkVTKRenderView);
 
 public:
   ctkVTKRenderViewPrivate(ctkVTKRenderView& object);
+  virtual ~ctkVTKRenderViewPrivate();
 
   /// Convenient setup methods
+  void init() override;
   void setupCornerAnnotation() override;
   void setupRendering() override;
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.cpp
@@ -51,6 +51,18 @@ ctkVTKSliceViewPrivate::ctkVTKSliceViewPrivate(ctkVTKSliceView& object)
 }
 
 // --------------------------------------------------------------------------
+ctkVTKSliceViewPrivate::~ctkVTKSliceViewPrivate() = default;
+
+// --------------------------------------------------------------------------
+void ctkVTKSliceViewPrivate::init()
+{
+  Q_Q(ctkVTKSliceView);
+  this->ctkVTKAbstractViewPrivate::init();
+
+  q->VTKWidget()->installEventFilter(q);
+}
+
+// --------------------------------------------------------------------------
 void ctkVTKSliceViewPrivate::setupCornerAnnotation()
 {
   this->ctkVTKAbstractViewPrivate::setupCornerAnnotation();
@@ -100,7 +112,14 @@ ctkVTKSliceView::ctkVTKSliceView(QWidget* parentWidget)
 {
   Q_D(ctkVTKSliceView);
   d->init();
-  this->VTKWidget()->installEventFilter(this);
+}
+
+// --------------------------------------------------------------------------
+ctkVTKSliceView::ctkVTKSliceView(ctkVTKSliceViewPrivate* pimpl, QWidget* parentWidget)
+  : Superclass(pimpl, parentWidget)
+{
+  // derived classes must call init manually. Calling init() here may results in
+  // actions on a derived public class not yet finished to be created
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.h
@@ -71,11 +71,11 @@ public:
 
   /// Set background color
   /// \sa vtkLightBoxRendererManager::SetBackgroundColor
-  virtual void setBackgroundColor(const QColor& newBackgroundColor);
+  void setBackgroundColor(const QColor& newBackgroundColor) override;
 
   /// Get background color
   /// \sa setBackgroundColor();
-  virtual QColor backgroundColor()const;
+  QColor backgroundColor()const override;
 
   /// Get highlightedBox color
   /// \sa setHighlightedBoxColor();
@@ -133,7 +133,7 @@ Q_SIGNALS:
   void resized(const QSize& size);
 
 protected:
-  virtual bool eventFilter(QObject *object, QEvent *event);
+  bool eventFilter(QObject *object, QEvent *event) override;
 
 private:
   Q_DECLARE_PRIVATE(ctkVTKSliceView);

--- a/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.h
@@ -133,6 +133,7 @@ Q_SIGNALS:
   void resized(const QSize& size);
 
 protected:
+  ctkVTKSliceView(ctkVTKSliceViewPrivate* pimpl, QWidget* parent);
   bool eventFilter(QObject *object, QEvent *event) override;
 
 private:

--- a/Libs/Visualization/VTK/Widgets/ctkVTKSliceView_p.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKSliceView_p.h
@@ -41,13 +41,17 @@ class vtkRenderWindowInteractor;
 
 //-----------------------------------------------------------------------------
 /// \ingroup Visualization_VTK_Widgets
-class ctkVTKSliceViewPrivate : public ctkVTKAbstractViewPrivate
+class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKSliceViewPrivate : public ctkVTKAbstractViewPrivate
 {
   Q_OBJECT
+  Q_DECLARE_PUBLIC(ctkVTKSliceView);
+
 public:
   ctkVTKSliceViewPrivate(ctkVTKSliceView&);
+  virtual ~ctkVTKSliceViewPrivate();
 
   /// Convenient setup methods
+  void init() override;
   void setupCornerAnnotation() override;
   void setupRendering() override;
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKSliceView_p.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKSliceView_p.h
@@ -48,8 +48,8 @@ public:
   ctkVTKSliceViewPrivate(ctkVTKSliceView&);
 
   /// Convenient setup methods
-  void setupCornerAnnotation();
-  void setupRendering();
+  void setupCornerAnnotation() override;
+  void setupRendering() override;
 
   vtkSmartPointer<vtkLightBoxRendererManager>   LightBoxRendererManager;
   bool                                          RenderPending;


### PR DESCRIPTION
Add protected constructor to `ctkVTKRenderView` and `ctkVTKSliceView` for associating a derived pimpl.

This is required to have the complete virtual function chain executed when virtual function are called in the pimpl `init()` function.

### Notes

While I confirmed that building Slicer against this change did not require any additional changes, it will be allow to move forward with the integration of `ENH: Allow virtual func to be called during MRML(ThreeD|Slice)View pimpl`[^1]

[^1]: https://github.com/Slicer/Slicer/pull/7311/commits/dca4f5dd541c5320ba5900f1a6c034c4cd19ee02

