### PR TITLE
ENH: Virtualize DICOM database

### DIFF
--- a/Libs/DICOM/Core/Resources/dicom-schema.sql
+++ b/Libs/DICOM/Core/Resources/dicom-schema.sql
@@ -27,8 +27,8 @@ INSERT INTO 'SchemaInfo' VALUES('0.8.0');
 
 CREATE TABLE 'Images' (
   'SOPInstanceUID' VARCHAR(64) NOT NULL,
-  'Filename' VARCHAR(1024),
-  'URL' VARCHAR(2048),
+  'Filename' VARCHAR(1024) NULL,
+  'URL' VARCHAR(2048) NULL,
   'SeriesInstanceUID' VARCHAR(64) NOT NULL ,
   'InsertTimestamp' VARCHAR(20) NOT NULL ,
   'DisplayedFieldsUpdatedTimestamp' DATETIME NULL ,
@@ -85,7 +85,7 @@ CREATE TABLE 'Series' (
   'DisplayedFieldsUpdatedTimestamp' DATETIME NULL ,
   PRIMARY KEY ('SeriesInstanceUID') );
 
-CREATE UNIQUE INDEX IF NOT EXISTS 'ImagesFilenameIndex' ON 'Images' ('Filename');
+CREATE INDEX IF NOT EXISTS 'ImagesFilenameIndex' ON 'Images' ('Filename');
 CREATE INDEX IF NOT EXISTS 'ImagesSeriesIndex' ON 'Images' ('SeriesInstanceUID');
 CREATE INDEX IF NOT EXISTS 'SeriesStudyIndex' ON 'Series' ('StudyInstanceUID');
 CREATE INDEX IF NOT EXISTS 'StudiesPatientIndex' ON 'Studies' ('PatientsUID');

--- a/Libs/DICOM/Core/Resources/dicom-schema.sql
+++ b/Libs/DICOM/Core/Resources/dicom-schema.sql
@@ -23,11 +23,12 @@ DROP INDEX IF EXISTS 'SeriesStudyIndex' ;
 DROP INDEX IF EXISTS 'StudiesPatientIndex' ;
 
 CREATE TABLE 'SchemaInfo' ( 'Version' VARCHAR(1024) NOT NULL );
-INSERT INTO 'SchemaInfo' VALUES('0.7.0');
+INSERT INTO 'SchemaInfo' VALUES('0.8.0');
 
 CREATE TABLE 'Images' (
   'SOPInstanceUID' VARCHAR(64) NOT NULL,
   'Filename' VARCHAR(1024) NOT NULL ,
+  'URL' VARCHAR(2048) NOT NULL ,
   'SeriesInstanceUID' VARCHAR(64) NOT NULL ,
   'InsertTimestamp' VARCHAR(20) NOT NULL ,
   'DisplayedFieldsUpdatedTimestamp' DATETIME NULL ,

--- a/Libs/DICOM/Core/Resources/dicom-schema.sql
+++ b/Libs/DICOM/Core/Resources/dicom-schema.sql
@@ -27,8 +27,8 @@ INSERT INTO 'SchemaInfo' VALUES('0.8.0');
 
 CREATE TABLE 'Images' (
   'SOPInstanceUID' VARCHAR(64) NOT NULL,
-  'Filename' VARCHAR(1024) NOT NULL ,
-  'URL' VARCHAR(2048) NOT NULL ,
+  'Filename' VARCHAR(1024),
+  'URL' VARCHAR(2048),
   'SeriesInstanceUID' VARCHAR(64) NOT NULL ,
   'InsertTimestamp' VARCHAR(20) NOT NULL ,
   'DisplayedFieldsUpdatedTimestamp' DATETIME NULL ,

--- a/Libs/DICOM/Core/Resources/dicom-schema.sql
+++ b/Libs/DICOM/Core/Resources/dicom-schema.sql
@@ -86,6 +86,7 @@ CREATE TABLE 'Series' (
   PRIMARY KEY ('SeriesInstanceUID') );
 
 CREATE INDEX IF NOT EXISTS 'ImagesFilenameIndex' ON 'Images' ('Filename');
+CREATE INDEX IF NOT EXISTS 'ImagesFilenameIndex' ON 'Images' ('URL');
 CREATE INDEX IF NOT EXISTS 'ImagesSeriesIndex' ON 'Images' ('SeriesInstanceUID');
 CREATE INDEX IF NOT EXISTS 'SeriesStudyIndex' ON 'Series' ('StudyInstanceUID');
 CREATE INDEX IF NOT EXISTS 'StudiesPatientIndex' ON 'Studies' ('PatientsUID');

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -1378,8 +1378,8 @@ bool ctkDICOMDatabasePrivate::applyDisplayedFieldsChanges( QMap<QString, QMap<QS
     }
     else
     {
-      logger.error("Failed to find study with StudyInstanceUID=" + currentStudyInstanceUid);
-      return false;
+      logger.error("in applyDisplayedFieldsChanges: Failed to find study with StudyInstanceUID=" + currentStudyInstanceUid);
+      continue;
     }
   } // For each study in displayedFieldsMapStudy
 
@@ -1424,8 +1424,8 @@ bool ctkDICOMDatabasePrivate::applyDisplayedFieldsChanges( QMap<QString, QMap<QS
     }
     else
     {
-      logger.error("Failed to find series with SeriesInstanceUID=" + currentSeriesInstanceUid);
-      return false;
+      logger.error("in applyDisplayedFieldsChanges: Failed to find series with SeriesInstanceUID=" + currentSeriesInstanceUid);
+      continue;
     }
   } // For each series in displayedFieldsMapSeries
 

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -965,9 +965,10 @@ void ctkDICOMDatabasePrivate::insert(const ctkDICOMItem& dataset, const QString&
       }
 
       QSqlQuery insertImageStatement(Database);
-      insertImageStatement.prepare("INSERT INTO Images ( 'SOPInstanceUID', 'Filename', 'URL', 'SeriesInstanceUID', 'InsertTimestamp' ) VALUES ( ?, ?, NULL, ?, ? )");
+      insertImageStatement.prepare("INSERT INTO Images ( 'SOPInstanceUID', 'Filename', 'URL', 'SeriesInstanceUID', 'InsertTimestamp' ) VALUES ( ?, ?, ?, ?, ? )");
       insertImageStatement.addBindValue(sopInstanceUID);
       insertImageStatement.addBindValue(storedFilePathInDatabase);
+      insertImageStatement.addBindValue(QString(""));
       insertImageStatement.addBindValue(seriesInstanceUID);
       insertImageStatement.addBindValue(QDateTime::currentDateTime());
       insertImageStatement.exec();
@@ -1112,9 +1113,10 @@ void ctkDICOMDatabase::insert(const QList<ctkDICOMDatabase::IndexingResult>& ind
 
       // Insert image files
       QSqlQuery insertImageStatement(d->Database);
-      insertImageStatement.prepare("INSERT INTO Images ( 'SOPInstanceUID', 'Filename', 'URL', 'SeriesInstanceUID', 'InsertTimestamp' ) VALUES ( ?, ?, NULL, ?, ? )");
+      insertImageStatement.prepare("INSERT INTO Images ( 'SOPInstanceUID', 'Filename', 'URL', 'SeriesInstanceUID', 'InsertTimestamp' ) VALUES ( ?, ?, ?, ?, ? )");
       insertImageStatement.addBindValue(sopInstanceUID);
       insertImageStatement.addBindValue(d->internalPathFromAbsolute(storedFilePath));
+      insertImageStatement.addBindValue(QString(""));
       insertImageStatement.addBindValue(seriesInstanceUID);
       insertImageStatement.addBindValue(QDateTime::currentDateTime());
       insertImageStatement.exec();

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -206,7 +206,7 @@ QStringList ctkDICOMDatabasePrivate::allFilesInDatabase()
 
   while (allFilesQuery.next())
   {
-    allFileNames << this->absolutePathFromInternalIfFile(allFilesQuery.value(0).toString());
+    allFileNames << this->absolutePathFromInternal(allFilesQuery.value(0).toString());
   }
   return allFileNames;
 }
@@ -312,7 +312,7 @@ QStringList ctkDICOMDatabasePrivate::filenames(QString table)
 
   while (allFilesQuery.next())
   {
-    allFileNames << this->absolutePathFromInternalIfFile(allFilesQuery.value(0).toString());
+    allFileNames << this->absolutePathFromInternal(allFilesQuery.value(0).toString());
   }
   return allFileNames;
 }
@@ -1448,19 +1448,6 @@ QString ctkDICOMDatabasePrivate::internalPathFromAbsolute(const QString& filenam
 }
 
 //------------------------------------------------------------------------------
-QString ctkDICOMDatabasePrivate::absolutePathFromInternalIfFile(const QString& filename)
-{
-  Q_Q(ctkDICOMDatabase);
-  QString returnFileName = filename;
-  if (QUrl(filename).scheme().isEmpty()) // local path, not url
-  {
-    returnFileName = this->absolutePathFromInternal(filename);
-  }
-  return returnFileName;
-}
-
-
-//------------------------------------------------------------------------------
 CTK_GET_CPP(ctkDICOMDatabase, bool, isDisplayedFieldsTableAvailable, DisplayedFieldsTableAvailable);
 CTK_GET_CPP(ctkDICOMDatabase, bool, useShortStoragePath, UseShortStoragePath);
 CTK_SET_CPP(ctkDICOMDatabase, bool, setUseShortStoragePath, UseShortStoragePath);
@@ -2111,7 +2098,7 @@ QStringList ctkDICOMDatabase::filesForSeries(QString seriesUID, int hits/*=-1*/)
   while (query.next())
   {
     QString fileName = query.value(0).toString();
-    fileName = d->absolutePathFromInternalIfFile(fileName);
+    fileName = d->absolutePathFromInternal(fileName);
     allFileNames << fileName;
     if (hits > 0 && allFileNames.size() >= hits)
     {
@@ -2133,7 +2120,7 @@ QString ctkDICOMDatabase::fileForInstance(QString sopInstanceUID)
   QString result;
   if (query.next())
   {
-    result = d->absolutePathFromInternalIfFile(query.value(0).toString());
+    result = d->absolutePathFromInternal(query.value(0).toString());
   }
   return result;
 }
@@ -2579,7 +2566,7 @@ bool ctkDICOMDatabase::allFilesModifiedTimes(QMap<QString, QDateTime>& modifiedT
   bool success = d->loggedExec(allFilesModifiedQuery);
   while (allFilesModifiedQuery.next())
   {
-    QString filename = d->absolutePathFromInternalIfFile(allFilesModifiedQuery.value(0).toString());
+    QString filename = d->absolutePathFromInternal(allFilesModifiedQuery.value(0).toString());
     QDateTime modifiedTime = QDateTime::fromString(allFilesModifiedQuery.value(1).toString(), Qt::ISODate);
     if (modifiedTimeForFilepath.contains(filename) && modifiedTimeForFilepath[filename] <= modifiedTime)
     {
@@ -2668,7 +2655,7 @@ bool ctkDICOMDatabase::removeSeries(const QString& seriesInstanceUID, bool clear
     // check that the file is below our internal storage
     if (QFileInfo(dbFilePath).isRelative())
     {
-      QString absPath = d->absolutePathFromInternalIfFile(dbFilePath);
+      QString absPath = d->absolutePathFromInternal(dbFilePath);
       if (QFile(absPath).remove())
       {
         if (d->LoggedExecVerbose)
@@ -2687,7 +2674,7 @@ bool ctkDICOMDatabase::removeSeries(const QString& seriesInstanceUID, bool clear
       }
     }
     // Remove thumbnail (if exists)
-    QFile thumbnailFile(d->absolutePathFromInternalIfFile(thumbnailPath));
+    QFile thumbnailFile(d->absolutePathFromInternal(thumbnailPath));
     if (thumbnailFile.exists())
     {
       if (!thumbnailFile.remove())

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -175,6 +175,7 @@ public:
   /// This is useful for retrieving first file, for example for getting access to fields within that file
   /// using fileValue() method.
   Q_INVOKABLE QStringList filesForSeries(const QString seriesUID, int hits=-1);
+  Q_INVOKABLE QStringList urlsForSeries(const QString seriesUID, int hits=-1);
 
   Q_INVOKABLE QHash<QString,QString> descriptionsForFile(QString fileName);
   Q_INVOKABLE QString descriptionForSeries(const QString seriesUID);
@@ -267,7 +268,7 @@ public:
   /// When a DICOM file is stored in the database (insert is called with storeFile=true) then
   /// path is constructed from study, series, and SOP instance UID.
   /// If useShortStoragePath is false then the full UIDs are used as subfolder and file name.
-  /// If useShortStoragePath is true (this is the default) then the path is shortened 
+  /// If useShortStoragePath is true (this is the default) then the path is shortened
   /// to approximately 40 characters, by replacing UIDs with hashes generated from them.
   /// UIDs can be 40-60 characters long each, therefore the the total path (including database folder base path)
   /// can exceed maximum path length on some file systems. It is recommended to enable useShortStoragePath
@@ -320,7 +321,14 @@ public:
   /// \brief Access element values for given instance
   /// @param sopInstanceUID A string with the uid for a given instance
   ///                       (corresponding file will be found via the database)
-  /// @param fileName Full path to a dicom file to load.
+  /// @param fileName Full path to a dicom file to load. Note that this string
+  /// can either be a file path or a URL since the database can have one or
+  /// both of these fields as of schema version 0.8.0.  Since the fileValue
+  /// api is widely used, this overload allows either value to be used to retrieve
+  /// values from the tag cache.  If a value is found for the fileName the
+  /// fileName it is returned; if not, the fileName is used as a URL.  If no
+  /// value is found for the URL, the fileName is used as a path to a dicom file
+  /// where the value is looked up.
   /// @param group The group portion of the tag as an integer
   /// @param element The element portion of the tag as an integer
   /// @Returns empty string if element is missing or excluded from storage.

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -190,6 +190,8 @@ public:
   QStringList seriesFieldNames() const;
 
   Q_INVOKABLE QString fileForInstance(const QString sopInstanceUID);
+  Q_INVOKABLE QString urlForInstance(const QString sopInstanceUID);
+  Q_INVOKABLE QString instanceForURL(const QString url);
   Q_INVOKABLE QString seriesForFile(QString fileName);
   Q_INVOKABLE QString instanceForFile(const QString fileName);
   Q_INVOKABLE QDateTime insertDateTimeForInstance(const QString fileName);

--- a/Libs/DICOM/Core/ctkDICOMDatabase_p.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase_p.h
@@ -121,6 +121,9 @@ public:
   /// Convert an absolute path to an internal path (absolute if outside database folder, relative if inside database folder).
   QString internalPathFromAbsolute(const QString& filename);
 
+  /// If not a URL, convert to abolute path
+  QString absolutePathFromInternalIfFile(const QString& filename);
+
   /// Name of the database file (i.e. for SQLITE the sqlite file)
   QString DatabaseFileName;
 

--- a/Libs/DICOM/Core/ctkDICOMDatabase_p.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase_p.h
@@ -121,9 +121,6 @@ public:
   /// Convert an absolute path to an internal path (absolute if outside database folder, relative if inside database folder).
   QString internalPathFromAbsolute(const QString& filename);
 
-  /// If not a URL, convert to abolute path
-  QString absolutePathFromInternalIfFile(const QString& filename);
-
   /// Name of the database file (i.e. for SQLITE the sqlite file)
   QString DatabaseFileName;
 

--- a/Libs/DICOM/Core/ctkDICOMItem.cpp
+++ b/Libs/DICOM/Core/ctkDICOMItem.cpp
@@ -958,12 +958,14 @@ QString ctkDICOMItem::TranslateDefinedTermModality( const QString& dt )
 
 QString ctkDICOMItem::TagKey( const DcmTag& tag )
 {
-  return QString("(%1,%2)").arg( tag.getGroup(), 4, 16, QLatin1Char('0')).arg( tag.getElement(), 4, 16, QLatin1Char('0') );
+  QString groupElement = QString("(%1,%2)").arg( tag.getGroup(), 4, 16, QLatin1Char('0')).arg( tag.getElement(), 4, 16, QLatin1Char('0') );
+  return groupElement.toUpper();
 }
 
 QString ctkDICOMItem::TagKeyStripped( const DcmTag& tag )
 {
-  return QString("%1,%2").arg( tag.getGroup(), 4, 16, QLatin1Char('0')).arg( tag.getElement(), 4, 16, QLatin1Char('0') );
+  QString groupElement = QString("%1,%2").arg( tag.getGroup(), 4, 16, QLatin1Char('0')).arg( tag.getElement(), 4, 16, QLatin1Char('0') );
+  return groupElement.toUpper();
 }
 
 QString ctkDICOMItem::TagDescription( const DcmTag& tag )


### PR DESCRIPTION
This generalizes the ctkDICOMDatabase code to ease hard-coded restrictions about DICOM files always being on disk.  Now the schema includes a `URL` field of the SQLite database so certain file-specific operations are only performed on filePaths while URL are handled independently.  Entries in the `Images` table of the database may now have either a `URL` or a `fileName` or both and new accessors are provided to get `URL`s at the series and instance level.

Also this contains a fix to the ctkDICOMTagCache so that tags are always stored internally as uppercase hex, so a string like "0010,000d" will always be turned into "0010,000D" for storage in the database.  Both forms can be used to query tags.  This avoids the situation where some cache entries were duplicated because different code used either upper or lower case to refer to the same tag.  Using only upper case should improve storage use and improve performance by avoiding unneeded cache misses.