### PR TITLE
COMP: Update PythonQt version with generated Qt 5.15 wrappers

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -82,7 +82,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
 
   ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
   if(CTK_QT_VERSION VERSION_EQUAL "5")
-    set(revision_tag c4a5a155b2942d4b003862c3317105b4a1ea6755) # patched-9
+    set(revision_tag d653718d75c497576986dea4cc8e10a54705e8d5) # patched-11
   else()
     message(FATAL_ERROR "Support for Qt${CTK_QT_VERSION} is not implemented")
   endif()
@@ -98,7 +98,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
     set(location_args GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
                       GIT_TAG ${revision_tag})
   else()
-    set(location_args GIT_REPOSITORY "https://github.com/commontk/PythonQt.git"
+    set(location_args GIT_REPOSITORY "https://github.com/jamesobutler/PythonQt.git"
                       GIT_TAG ${revision_tag})
   endif()
 


### PR DESCRIPTION
This updates CTK to use a recent Python Qt version with a generator that works for Qt 5.15 and includes Qt 5.15 wrapping. To do this I first took the latest of https://github.com/MeVisLab/pythonqt (as of https://github.com/MeVisLab/pythonqt/commit/d0ddad60fe81b882e76c5f8fc5e2347ab28490d0) and then rebased the customizations at https://github.com/jamesobutler/PythonQt/tree/patched-9 which is currently being used in CTK and also included https://github.com/commontk/PythonQt/commit/14fa99a66aa6d1fcc95d084515834dcdb3c6ab46 which was one additional CommonTK customization. The CommonTK customizations are mostly about adding CMake support. 

The base of `patched-9` is https://github.com/MeVisLab/pythonqt/commit/c07f09fddb9cbb85395578d9836c371635221036 from June 25th 2019, while the new base https://github.com/MeVisLab/pythonqt/commit/d0ddad60fe81b882e76c5f8fc5e2347ab28490d0 is from December 13th 2023.

@jcfr I propose a few changes for the https://github.com/commontk/PythonQt repo which will need your support as I do not have write access to make the changes myself.

- [ ] Adopt https://github.com/jamesobutler/PythonQt/tree/patched-11 as a new `patched-11` branch within the https://github.com/commontk/PythonQt repo. 
- [ ] Update https://github.com/commontk/PythonQt/tree/welcome specifying that `patched-11` is based off of https://github.com/MeVisLab/pythonqt/commit/d0ddad60fe81b882e76c5f8fc5e2347ab28490d0
- [ ] Following the above, update this PR with the PythonQt repo and commit hash back to one in the CommonTK organization.

Further work to be considered:
- [ ] Contribute the CMake based build system commits to the upstream https://github.com/MeVisLab/pythonqt as there has been public mention of supporting a CMake build system (see https://github.com/MeVisLab/pythonqt/pull/128#pullrequestreview-1677848592 and https://github.com/MeVisLab/pythonqt/pull/79#issuecomment-1364495287)
- [ ] Following the above, switch to CommonTK using https://github.com/MeVisLab/pythonqt or possibly reforking it so that there is a clear upstream reference in GitHub to https://github.com/MeVisLab/pythonqt. Previously the upstream source was hosted on sourceforge which is why https://github.com/commontk/PythonQt is not listed as a fork in GitHub.