### PR TITLE
Remove Python 2.x support

### DIFF
--- a/CMake/ctkMacroBuildLibWrapper.cmake
+++ b/CMake/ctkMacroBuildLibWrapper.cmake
@@ -34,7 +34,7 @@
 # Function copied from https://github.com/scikit-build/scikit-build/pull/299
 # XXX Update this CMake module to use function from scikit-build to build the wrapper
 function(_ctk_set_python_extension_symbol_visibility _target)
-    set(_modinit_prefix "PyInit_")
+  set(_modinit_prefix "PyInit_")
   if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     set_target_properties(${_target} PROPERTIES LINK_FLAGS
         "/EXPORT:${_modinit_prefix}${_target}"

--- a/CMake/ctkMacroBuildLibWrapper.cmake
+++ b/CMake/ctkMacroBuildLibWrapper.cmake
@@ -34,11 +34,7 @@
 # Function copied from https://github.com/scikit-build/scikit-build/pull/299
 # XXX Update this CMake module to use function from scikit-build to build the wrapper
 function(_ctk_set_python_extension_symbol_visibility _target)
-  if(PYTHON_VERSION_MAJOR VERSION_GREATER 2)
     set(_modinit_prefix "PyInit_")
-  else()
-    set(_modinit_prefix "init")
-  endif()
   if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     set_target_properties(${_target} PROPERTIES LINK_FLAGS
         "/EXPORT:${_modinit_prefix}${_target}"

--- a/CMake/ctkMacroWrapPythonQtModuleInit.cpp.in
+++ b/CMake/ctkMacroWrapPythonQtModuleInit.cpp.in
@@ -8,11 +8,7 @@ static PyMethodDef Py@TARGET_CONFIG@PythonQt_ClassMethods[] = {
 {NULL, NULL, 0, NULL}};
 
 //-----------------------------------------------------------------------------
-#if PY_MAJOR_VERSION >= 3
 extern "C" { Q_DECL_EXPORT PyObject* PyInit_@TARGET_CONFIG@PythonQt(); }
-#else
-extern "C" { Q_DECL_EXPORT void init@TARGET_CONFIG@PythonQt(); }
-#endif
 
 #ifdef __GNUC__
 // Disable warnings related to Py_DECREF() macro
@@ -53,7 +49,6 @@ void copyAttributes(PyObject* orig_module, PyObject* dest_module)
 }
 } // end of anonymous namespace
 //-----------------------------------------------------------------------------
-#if PY_MAJOR_VERSION >= 3
 
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
@@ -67,24 +62,11 @@ static struct PyModuleDef moduledef = {
     NULL,                                      /* m_free */
   };
 
-#endif
 //-----------------------------------------------------------------------------
-#if PY_MAJOR_VERSION >= 3
 PyObject* PyInit_@TARGET_CONFIG@PythonQt()
-#else
-void init@TARGET_CONFIG@PythonQt()
-#endif
 {
-  #if PY_MAJOR_VERSION < 3
-  static const char modulename[] = "@TARGET_CONFIG@PythonQt";
-  #endif
-
   PyObject *m;
-  #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
-  #else
-    m = Py_InitModule((char*)modulename, Py@TARGET_CONFIG@PythonQt_ClassMethods);
-  #endif
   extern void PythonQt_init_@WRAPPING_NAMESPACE_UNDERSCORE@_@TARGET_CONFIG@(PyObject*);
   PythonQt_init_@WRAPPING_NAMESPACE_UNDERSCORE@_@TARGET_CONFIG@(m);
 
@@ -99,14 +81,8 @@ void init@TARGET_CONFIG@PythonQt()
   if(currentModule.isNull())
     {
     PyErr_SetString(PyExc_ImportError, (char*)"Failed to import PythonQt.@TARGET_CONFIG@");
-#if PY_MAJOR_VERSION >= 3
     return NULL;
-#else
-    return;
-#endif
     }
   copyAttributes(currentModule, m);
-#if PY_MAJOR_VERSION >= 3
   return m;
-#endif
 }

--- a/CMake/ctkMacroWrapPythonQtModuleInit.cpp.in
+++ b/CMake/ctkMacroWrapPythonQtModuleInit.cpp.in
@@ -66,7 +66,7 @@ static struct PyModuleDef moduledef = {
 PyObject* PyInit_@TARGET_CONFIG@PythonQt()
 {
   PyObject *m;
-    m = PyModule_Create(&moduledef);
+  m = PyModule_Create(&moduledef);
   extern void PythonQt_init_@WRAPPING_NAMESPACE_UNDERSCORE@_@TARGET_CONFIG@(PyObject*);
   PythonQt_init_@WRAPPING_NAMESPACE_UNDERSCORE@_@TARGET_CONFIG@(m);
 

--- a/CMake/ctk_compile_python_scripts.cmake.in
+++ b/CMake/ctk_compile_python_scripts.cmake.in
@@ -15,17 +15,12 @@ from __future__ import print_function
 #   https://github.com/jonashaag/cpython/blob/ce5e5df0c9d8098da05dee26e12ffe2aa331889e/Lib/compileall.py#L61-111
 #
 
+import importlib
 import os
 import sys
 import py_compile
 import struct
-magic = None
-if sys.version_info.major>= 3:
-    import importlib
-    magic = importlib.util.MAGIC_NUMBER
-else:
-    import imp
-    magic = imp.get_magic()
+
 
 def ctk_compile_file(fullname, ddir=None, force=0, rx=None, quiet=0):
     \"\"\"Byte-compile one file.
@@ -54,7 +49,7 @@ def ctk_compile_file(fullname, ddir=None, force=0, rx=None, quiet=0):
             if not force:
                 try:
                     mtime = int(os.stat(fullname).st_mtime)
-                    expect = struct.pack('<4sl', magic, mtime)
+                    expect = struct.pack('<4sl', importlib.util.MAGIC_NUMBER, mtime)
                     cfile = fullname + (__debug__ and 'c' or 'o')
                     with open(cfile, 'rb') as chandle:
                         actual = chandle.read(8)

--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -73,12 +73,10 @@ if(NOT DEFINED VTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     if(NOT "${VTK_PYTHON_VERSION}" STREQUAL "${PYTHON_VERSION_MAJOR}")
       message(FATAL_ERROR "error: VTK_PYTHON_VERSION [${VTK_PYTHON_VERSION}] is expected to match PYTHON_VERSION_MAJOR [${PYTHON_VERSION_MAJOR}]")
     endif()
-    if(VTK_PYTHON_VERSION VERSION_GREATER "2.7")
       set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
       set(Python3_INCLUDE_DIR ${PYTHON_INCLUDE_DIR})
       set(Python3_LIBRARY ${PYTHON_LIBRARY})
       find_package(Python3 COMPONENTS Interpreter Development)
-    endif()
 
     ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
     list(APPEND additional_vtk_cmakevars
@@ -89,7 +87,6 @@ if(NOT DEFINED VTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       -DPYTHON_LIBRARY:FILEPATH=${PYTHON_LIBRARY}
       -DPYTHON_DEBUG_LIBRARIES:FILEPATH=${PYTHON_DEBUG_LIBRARIES}
       )
-    if(VTK_PYTHON_VERSION VERSION_GREATER "2.7")
       # VTK9
       list(APPEND additional_vtk9_cmakevars
         # FindPython3
@@ -97,7 +94,6 @@ if(NOT DEFINED VTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
         -DPython3_LIBRARY:FILEPATH=${Python3_LIBRARY}
         -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE}
         )
-    endif()
   endif()
 
   if(CTK_QT_VERSION VERSION_EQUAL "5")
@@ -200,7 +196,6 @@ mark_as_superbuild(
   LABELS "FIND_PACKAGE"
   )
 
-if(VTK_PYTHON_VERSION VERSION_GREATER "2.7")
   # Propagate variables expected when VTK searches for python
   mark_as_superbuild(
     VARS
@@ -211,4 +206,3 @@ if(VTK_PYTHON_VERSION VERSION_GREATER "2.7")
       Python3_LIBRARY_RELEASE:FILEPATH
       Python3_EXECUTABLE:FILEPATH
     )
-endif()

--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -73,10 +73,10 @@ if(NOT DEFINED VTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     if(NOT "${VTK_PYTHON_VERSION}" STREQUAL "${PYTHON_VERSION_MAJOR}")
       message(FATAL_ERROR "error: VTK_PYTHON_VERSION [${VTK_PYTHON_VERSION}] is expected to match PYTHON_VERSION_MAJOR [${PYTHON_VERSION_MAJOR}]")
     endif()
-      set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
-      set(Python3_INCLUDE_DIR ${PYTHON_INCLUDE_DIR})
-      set(Python3_LIBRARY ${PYTHON_LIBRARY})
-      find_package(Python3 COMPONENTS Interpreter Development)
+    set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
+    set(Python3_INCLUDE_DIR ${PYTHON_INCLUDE_DIR})
+    set(Python3_LIBRARY ${PYTHON_LIBRARY})
+    find_package(Python3 COMPONENTS Interpreter Development)
 
     ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
     list(APPEND additional_vtk_cmakevars
@@ -87,13 +87,13 @@ if(NOT DEFINED VTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       -DPYTHON_LIBRARY:FILEPATH=${PYTHON_LIBRARY}
       -DPYTHON_DEBUG_LIBRARIES:FILEPATH=${PYTHON_DEBUG_LIBRARIES}
       )
-      # VTK9
-      list(APPEND additional_vtk9_cmakevars
-        # FindPython3
-        -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR}
-        -DPython3_LIBRARY:FILEPATH=${Python3_LIBRARY}
-        -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE}
-        )
+    # VTK9
+    list(APPEND additional_vtk9_cmakevars
+      # FindPython3
+      -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR}
+      -DPython3_LIBRARY:FILEPATH=${Python3_LIBRARY}
+      -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE}
+      )
   endif()
 
   if(CTK_QT_VERSION VERSION_EQUAL "5")
@@ -196,13 +196,13 @@ mark_as_superbuild(
   LABELS "FIND_PACKAGE"
   )
 
-  # Propagate variables expected when VTK searches for python
-  mark_as_superbuild(
-    VARS
-      Python3_INCLUDE_DIR:PATH
-      Python3_ROOT_DIR:PATH
-      Python3_LIBRARY:FILEPATH
-      Python3_LIBRARY_DEBUG:FILEPATH
-      Python3_LIBRARY_RELEASE:FILEPATH
-      Python3_EXECUTABLE:FILEPATH
-    )
+# Propagate variables expected when VTK searches for python
+mark_as_superbuild(
+  VARS
+    Python3_INCLUDE_DIR:PATH
+    Python3_ROOT_DIR:PATH
+    Python3_LIBRARY:FILEPATH
+    Python3_LIBRARY_DEBUG:FILEPATH
+    Python3_LIBRARY_RELEASE:FILEPATH
+    Python3_EXECUTABLE:FILEPATH
+  )

--- a/Libs/Scripting/Python/Core/Testing/Cpp/ctkAbstractPythonManagerTest.cpp
+++ b/Libs/Scripting/Python/Core/Testing/Cpp/ctkAbstractPythonManagerTest.cpp
@@ -442,11 +442,7 @@ void ctkAbstractPythonManagerTester::testPythonModule_data()
 
   QTest::newRow("1") << ""
                      << "__main__.__builtins__"
-#if PY_MAJOR_VERSION < 3
-                     << "__builtin__";
-#else
                      << "builtins";
-#endif
 
   QTest::newRow("2") << "class foo: pass"
                      << "__main__.foo"

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
@@ -328,27 +328,12 @@ void ctkAbstractPythonManager::executeFile(const QString& filename)
   if (main)
     {
     QString path = QFileInfo(filename).absolutePath();
-    // See http://nedbatchelder.com/blog/200711/rethrowing_exceptions_in_python.html
-    // Re-throwing is only needed in Python 2.7
     QStringList code = QStringList()
         << "import sys"
         << QString("sys.path.insert(0, %1)").arg(ctkAbstractPythonManager::toPythonStringLiteral(path))
         << "_updated_globals = globals()"
         << QString("_updated_globals['__file__'] = %1").arg(ctkAbstractPythonManager::toPythonStringLiteral(filename))
-#if PY_MAJOR_VERSION >= 3
         << QString("exec(open(%1).read(), _updated_globals)").arg(ctkAbstractPythonManager::toPythonStringLiteral(filename));
-#else
-        << "_ctk_executeFile_exc_info = None"
-        << "try:"
-        << QString("    execfile(%1, _updated_globals)").arg(ctkAbstractPythonManager::toPythonStringLiteral(filename))
-        << "except Exception as e:"
-        << "    _ctk_executeFile_exc_info = sys.exc_info()"
-        << "finally:"
-        << "    del _updated_globals"
-        << QString("    if sys.path[0] == %1: sys.path.pop(0)").arg(ctkAbstractPythonManager::toPythonStringLiteral(path))
-        << "    if _ctk_executeFile_exc_info:"
-        << "        raise _ctk_executeFile_exc_info[1], None, _ctk_executeFile_exc_info[2]";
-#endif
     this->executeString(code.join("\n"));
     //PythonQt::self()->handleError(); // Clear errorOccured flag
     }

--- a/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
+++ b/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
@@ -241,11 +241,7 @@ int ctkPythonConsoleCompleterPrivate::parameterCountUserDefinedFunction(const QS
   PyObject* pFunction = this->PythonManager.pythonModule(pythonFunctionName);
   if (PyCallable_Check(pFunction))
     {
-#if PY_MAJOR_VERSION >= 3
     PyObject* fc = PyObject_GetAttrString(pFunction, "__code__");
-#else
-    PyObject* fc = PyObject_GetAttrString(pFunction, "func_code");
-#endif
     if (fc)
        {
       PyObject* ac = PyObject_GetAttrString(fc, "co_argcount");
@@ -267,11 +263,7 @@ int ctkPythonConsoleCompleterPrivate::parameterCountUserDefinedClassFunction(con
   PyObject* pFunction = this->PythonManager.pythonObject(pythonFunctionName);
   if (PyCallable_Check(pFunction))
     {
-#if PY_MAJOR_VERSION >= 3
     PyObject* fc = PyObject_GetAttrString(pFunction, "__code__");
-#else
-    PyObject* fc = PyObject_GetAttrString(pFunction, "func_code");
-#endif
     if (fc)
       {
       PyObject* ac = PyObject_GetAttrString(fc, "co_argcount");
@@ -584,11 +576,7 @@ bool ctkPythonConsolePrivate::push(const QString& code)
   PyObject *res = PyObject_CallMethod(this->InteractiveConsole,
                                       const_cast<char*>("push"),
                                       const_cast<char*>("z"),
-#if PY_MAJOR_VERSION >= 3
                                       buffer.toUtf8().data());
-#else
-                                      buffer.toLatin1().data());
-#endif
   if (res)
     {
     int status = 0;


### PR DESCRIPTION
Following 777b5ea (`DOC: Mention Qt 4/C++98/Python 2.7/VTK 8/ITK v4.13.3 are unsupported`), support for Python 2.7 is obsolete.