### PR TITLE
Fix DICOM tests and update `ctkFileDialog` to consider  `AA_DontUseNativeDialogs` attribute

### DIFF
--- a/Applications/ctkDICOMDemoSCU/Testing/Cpp/ctkDICOMDemoSCUTest1.cpp
+++ b/Applications/ctkDICOMDemoSCU/Testing/Cpp/ctkDICOMDemoSCUTest1.cpp
@@ -30,7 +30,7 @@ int ctkDICOMDemoSCUTest1(int argc, char * argv [])
 {
   QCoreApplication app(argc, argv);
   QString peer("www.dicomserver.co.uk");
-  QString port("11112");
+  QString port("104");
   QString aeTitle("MOVESCP");
   QStringList parameters;
   parameters << peer << port << aeTitle;

--- a/Applications/ctkDICOMQuery/ctkDICOMQueryMain.cpp
+++ b/Applications/ctkDICOMQuery/ctkDICOMQueryMain.cpp
@@ -26,7 +26,7 @@
  *
  * ../CTK-build/bin/ctkDICOMQuery test.db FINDSCU MI2B2 mi2b2.slicer.org 11112
  * or this one:
- * ../CTK-build/bin/ctkDICOMQuery test.db FINDSCU DICOMSERVER dicomserver.co.uk 11112
+ * ../CTK-build/bin/ctkDICOMQuery test.db FINDSCU DICOMSERVER dicomserver.co.uk 104
  *
  * you can get a similar
  * functionality with this command line:

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest2.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest2.cpp
@@ -100,7 +100,7 @@ int ctkDICOMDatabaseTest2( int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-  if ( database.groupElementToTag(group, element) != tag )
+  if ( database.groupElementToTag(group, element) != tag.toUpper() )
     {
     std::cerr << "ctkDICOMDatabase: could not convert a uints to tag string" << std::endl;
     return EXIT_FAILURE;

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMAppWidgetTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMAppWidgetTest1.cpp
@@ -20,6 +20,7 @@
 
 // Qt includes
 #include <QApplication>
+#include <QCommandLineParser>
 #include <QDebug>
 #include <QDir>
 #include <QTimer>
@@ -43,7 +44,16 @@
 int ctkDICOMAppWidgetTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
-  
+
+  QCommandLineParser parser;
+  parser.addOption({"I", "Run in interactive mode"});
+  parser.addPositionalArgument("directory", "Directory to import");
+  parser.process(app);
+
+  QString directoryToImport = parser.positionalArguments().at(0);
+
+  qDebug() << "Importing directory " << directoryToImport;
+
   ctkDICOMAppWidget appWidget;
 
   QFileInfo tempFileInfo(QDir::tempPath() + QString("/ctkDICOMAppWidgetTest1-db"));
@@ -66,9 +76,9 @@ int ctkDICOMAppWidgetTest1( int argc, char * argv [] )
   appWidget.openQueryDialog();
 
   appWidget.openQueryDialog();
-  
+
   appWidget.setDisplayImportSummary(false);
-  appWidget.onImportDirectory(argv[argc -1]);
+  appWidget.onImportDirectory(directoryToImport);
   if ( appWidget.patientsAddedDuringImport() != 1
     || appWidget.studiesAddedDuringImport() != 1
     || appWidget.seriesAddedDuringImport() != 1
@@ -78,7 +88,7 @@ int ctkDICOMAppWidgetTest1( int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-  if (argc <= 2 || QString(argv[1]) != "-I")
+  if (!parser.isSet("I"))
     {
     QTimer::singleShot(200, &app, SLOT(quit()));
     }

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMBrowserTest.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMBrowserTest.cpp
@@ -149,13 +149,21 @@ void ctkDICOMBrowserTester::testImportDirectoryMode()
   browser.setImportDirectoryMode(ctkDICOMBrowser::ImportDirectoryAddLink);
   QCOMPARE(browser.importDirectoryMode(), ctkDICOMBrowser::ImportDirectoryAddLink);
 
-  QComboBox* comboBox = browser.importDialog()->bottomWidget()->findChild<QComboBox*>();
+  bool usingNativeDialog = !browser.importDialog()->testOption(QFileDialog::DontUseNativeDialog);
+  if (!usingNativeDialog)
+    {
+    QComboBox* comboBox = browser.importDialog()->bottomWidget()->findChild<QComboBox*>();
 
-  comboBox->setCurrentIndex(comboBox->findData(static_cast<int>(ctkDICOMBrowser::ImportDirectoryCopy)));
-  QCOMPARE(browser.importDirectoryMode(), ctkDICOMBrowser::ImportDirectoryCopy);
+    comboBox->setCurrentIndex(comboBox->findData(static_cast<int>(ctkDICOMBrowser::ImportDirectoryCopy)));
+    QCOMPARE(browser.importDirectoryMode(), ctkDICOMBrowser::ImportDirectoryCopy);
 
-  comboBox->setCurrentIndex(comboBox->findData(static_cast<int>(ctkDICOMBrowser::ImportDirectoryAddLink)));
-  QCOMPARE(browser.importDirectoryMode(), ctkDICOMBrowser::ImportDirectoryAddLink);
+    comboBox->setCurrentIndex(comboBox->findData(static_cast<int>(ctkDICOMBrowser::ImportDirectoryAddLink)));
+    QCOMPARE(browser.importDirectoryMode(), ctkDICOMBrowser::ImportDirectoryAddLink);
+    }
+  else
+    {
+    QCOMPARE(browser.importDialog()->bottomWidget(), nullptr);
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/Libs/DICOM/Widgets/ctkDICOMServerNodeWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMServerNodeWidget.cpp
@@ -210,7 +210,7 @@ void ctkDICOMServerNodeWidget::readSettings()
     defaultServerNode["CheckState"] = static_cast<int>(Qt::Unchecked);
     defaultServerNode["AETitle"] = QString("ANYAE");
     defaultServerNode["Address"] = QString("dicomserver.co.uk");
-    defaultServerNode["Port"] = QString("11112");
+    defaultServerNode["Port"] = QString("104");
     defaultServerNode["CGET"] = static_cast<int>(Qt::Checked);
     this->addServerNode(defaultServerNode);
 

--- a/Libs/Widgets/ctkFileDialog.cpp
+++ b/Libs/Widgets/ctkFileDialog.cpp
@@ -19,6 +19,7 @@
 =========================================================================*/
 
 // QT includes
+#include <QGuiApplication>
 #include <QChildEvent>
 #include <QDebug>
 #include <QDialogButtonBox>
@@ -143,6 +144,11 @@ ctkFileDialog::ctkFileDialog(QWidget *parentWidget,
   , d_ptr(new ctkFileDialogPrivate(*this))
 {
   Q_D(ctkFileDialog);
+
+  if (QGuiApplication::testAttribute(Qt::AA_DontUseNativeDialogs))
+    {
+    this->setOptions(QFileDialog::DontUseNativeDialog);
+    }
 
   d->init();
 }


### PR DESCRIPTION
Ensure the following tests can be executed after installing CTK into `<CTK-top-level-build>/CMakeExternals/Install/`:
* `ctkDICOMAppWidgetTest1`
* `ctkDICOMDatabaseTest2`
* `ctkDICOMBrowserTester`

It also updates `ctkFileDialog` to ensure it considers application attribute `AA_DontUseNativeDialogs`.