### PR TITLE
Simplify DICOM testing removing needs for installing CTK

### DIFF
--- a/Applications/ctkDICOMHost/Testing/Cpp/CMakeLists.txt
+++ b/Applications/ctkDICOMHost/Testing/Cpp/CMakeLists.txt
@@ -17,4 +17,4 @@ TARGET_LINK_LIBRARIES(${KIT}CppTests ${KIT_target_libraries} ${QT_LIBRARIES})
 #
 # Add Tests
 #
-SIMPLE_TEST(ctkDICOMHostTest1)
+SIMPLE_TEST( ctkDICOMHostTest1 $<TARGET_FILE:ctkDICOMHost> )

--- a/Applications/ctkDICOMHost/Testing/Cpp/CMakeLists.txt
+++ b/Applications/ctkDICOMHost/Testing/Cpp/CMakeLists.txt
@@ -14,16 +14,6 @@ ctkFunctionGetTargetLibraries(KIT_target_libraries)
 ctk_add_executable_utf8(${KIT}CppTests ${Tests})
 TARGET_LINK_LIBRARIES(${KIT}CppTests ${KIT_target_libraries} ${QT_LIBRARIES})
 
-SET( KIT_TESTS ${CPP_TEST_PATH}/${KIT}CppTests)
-IF(WIN32)
-  SET(KIT_TESTS ${CPP_TEST_PATH}/${CMAKE_BUILD_TYPE}/${KIT}CppTests)
-ENDIF(WIN32)
-
-MACRO( SIMPLE_TEST  TESTNAME )
-  ADD_TEST( ${TESTNAME} ${KIT_TESTS} ${TESTNAME} )
-  SET_PROPERTY(TEST ${TESTNAME} PROPERTY LABELS ${PROJECT_NAME})
-ENDMACRO( SIMPLE_TEST  )
-
 #
 # Add Tests
 #

--- a/Applications/ctkDICOMHost/Testing/Cpp/ctkDICOMHostTest1.cpp
+++ b/Applications/ctkDICOMHost/Testing/Cpp/ctkDICOMHostTest1.cpp
@@ -21,15 +21,26 @@
 // Qt includes
 #include <QCoreApplication>
 #include <QProcess>
+#include <QStringList>
 
 // STD includes
 #include <cstdlib>
 #include <iostream>
 
+//-----------------------------------------------------------------------------
 int ctkDICOMHostTest1(int argc, char * argv [])
 {
   QCoreApplication app(argc, argv);
-  QString command = QString("ctkDICOMHost");
+
+  QStringList arguments = app.arguments();
+  arguments.pop_front(); // remove "program" name
+  if (!arguments.count())
+    {
+    std::cerr << "Usage: ctkDICOMHostTest1 /path/to/ctkDICOMHost" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  QString command = arguments.at(0);
   QProcess process;
   process.start(command, /* arguments= */ QStringList());
   bool res = process.waitForStarted();

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest1.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest1.cpp
@@ -21,7 +21,11 @@
 // Qt includes
 #include <QCoreApplication>
 #include <QDir>
+#include <QTemporaryDir>
 #include <QTimer>
+
+// ctkCore includes
+#include <ctkCoreTestingMacros.h>
 
 // ctkDICOMCore includes
 #include "ctkDICOMDatabase.h"
@@ -35,8 +39,11 @@ int ctkDICOMDatabaseTest1( int argc, char * argv [] )
 {
   QCoreApplication app(argc, argv);
 
+  QTemporaryDir tempDirectory;
+  CHECK_BOOL(tempDirectory.isValid(), true);
+
   ctkDICOMDatabase database;
-  QDir databaseDirectory = QDir::temp();
+  QDir databaseDirectory(tempDirectory.path());
   QFileInfo databaseFile(databaseDirectory, QString("database.test"));
   database.openDatabase(databaseFile.absoluteFilePath());
 

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest2.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest2.cpp
@@ -21,7 +21,11 @@
 // Qt includes
 #include <QCoreApplication>
 #include <QDir>
+#include <QTemporaryDir>
 #include <QTimer>
+
+// ctkCore includes
+#include <ctkCoreTestingMacros.h>
 
 // ctkDICOMCore includes
 #include "ctkDICOMDatabase.h"
@@ -44,8 +48,11 @@ int ctkDICOMDatabaseTest2( int argc, char * argv [] )
 
   QString dicomFilePath(argv[1]);
 
+  QTemporaryDir tempDirectory;
+  CHECK_BOOL(tempDirectory.isValid(), true);
+
   ctkDICOMDatabase database;
-  QDir databaseDirectory = QDir::temp();
+  QDir databaseDirectory(tempDirectory.path());
   databaseDirectory.remove("ctkDICOMDatabase.sql");
   databaseDirectory.remove("ctkDICOMTagCache.sql");
 

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest3.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest3.cpp
@@ -21,6 +21,10 @@
 // Qt includes
 #include <QCoreApplication>
 #include <QDir>
+#include <QTemporaryDir>
+
+// ctkCore includes
+#include <ctkCoreTestingMacros.h>
 
 // ctkDICOMCore includes
 #include "ctkDICOMDatabase.h"
@@ -41,9 +45,10 @@ int ctkDICOMDatabaseTest3( int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-  QDir databaseDirectory = QDir::temp();
-  databaseDirectory.remove("ctkDICOMDatabase.sql");
+  QTemporaryDir tempDirectory;
+  CHECK_BOOL(tempDirectory.isValid(), true);
 
+  QDir databaseDirectory(tempDirectory.path());
   QFileInfo databaseFile(databaseDirectory, QString("database.test"));
   QString databaseFileName(databaseFile.absoluteFilePath());
   

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest4.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest4.cpp
@@ -21,6 +21,10 @@
 // Qt includes
 #include <QCoreApplication>
 #include <QDir>
+#include <QTemporaryDir>
+
+// ctkCore includes
+#include <ctkCoreTestingMacros.h>
 
 // ctkDICOMCore includes
 #include "ctkDICOMDatabase.h"
@@ -43,8 +47,11 @@ int ctkDICOMDatabaseTest4( int argc, char * argv [] )
 
   QString dicomFilePath(argv[1]);
 
+  QTemporaryDir tempDirectory;
+  CHECK_BOOL(tempDirectory.isValid(), true);
+
   ctkDICOMDatabase database;
-  QDir databaseDirectory = QDir::temp();
+  QDir databaseDirectory(tempDirectory.path());
   databaseDirectory.remove("ctkDICOMDatabase.sql");
   databaseDirectory.remove("ctkDICOMTagCache.sql");
 

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest5.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest5.cpp
@@ -21,6 +21,10 @@
 // Qt includes
 #include <QCoreApplication>
 #include <QDir>
+#include <QTemporaryDir>
+
+// ctkCore includes
+#include <ctkCoreTestingMacros.h>
 
 // ctkDICOMCore includes
 #include "ctkDICOMDatabase.h"
@@ -43,8 +47,11 @@ int ctkDICOMDatabaseTest5( int argc, char * argv [] )
 
   QString dicomFilePath(argv[1]);
 
+  QTemporaryDir tempDirectory;
+  CHECK_BOOL(tempDirectory.isValid(), true);
+
   ctkDICOMDatabase database;
-  QDir databaseDirectory = QDir::temp();
+  QDir databaseDirectory(tempDirectory.path());
   databaseDirectory.remove("ctkDICOMDatabase.sql");
   databaseDirectory.remove("ctkDICOMTagCache.sql");
 

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest6.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest6.cpp
@@ -21,6 +21,10 @@
 // Qt includes
 #include <QCoreApplication>
 #include <QDir>
+#include <QTemporaryDir>
+
+// ctkCore includes
+#include <ctkCoreTestingMacros.h>
 
 // ctkDICOMCore includes
 #include "ctkDICOMDatabase.h"
@@ -43,8 +47,11 @@ int ctkDICOMDatabaseTest6( int argc, char * argv [] )
 
   QString dicomFilePath(argv[1]);
 
+  QTemporaryDir tempDirectory;
+  CHECK_BOOL(tempDirectory.isValid(), true);
+
   ctkDICOMDatabase database;
-  QDir databaseDirectory = QDir::temp();
+  QDir databaseDirectory(tempDirectory.path());
   databaseDirectory.remove("ctkDICOMDatabase.sql");
   databaseDirectory.remove("ctkDICOMTagCache.sql");
 

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest7.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest7.cpp
@@ -21,6 +21,10 @@
 // Qt includes
 #include <QCoreApplication>
 #include <QDir>
+#include <QTemporaryDir>
+
+// ctkCore includes
+#include <ctkCoreTestingMacros.h>
 
 // ctkDICOMCore includes
 #include "ctkDICOMDatabase.h"
@@ -34,8 +38,11 @@ int ctkDICOMDatabaseTest7( int argc, char * argv [] )
 {
   QCoreApplication app(argc, argv);
 
+  QTemporaryDir tempDirectory;
+  CHECK_BOOL(tempDirectory.isValid(), true);
+
   ctkDICOMDatabase database;
-  QDir databaseDirectory = QDir::temp();
+  QDir databaseDirectory(tempDirectory.path());
   databaseDirectory.remove("ctkDICOMDatabase.sql");
   databaseDirectory.remove("ctkDICOMTagCache.sql");
 

--- a/Libs/DICOM/Core/ctkDICOMTester.cpp
+++ b/Libs/DICOM/Core/ctkDICOMTester.cpp
@@ -134,7 +134,7 @@ QString ctkDICOMTesterPrivate::findFile(const QStringList& nameFilters, const QS
 //------------------------------------------------------------------------------
 QString ctkDICOMTesterPrivate::findDCMQRSCPExecutable()const
 {
-  return this->findFile(QStringList("dcmqrscp*"), "CMakeExternals/Install/bin");  
+  return this->findFile(QStringList("dcmqrscp*"), "../DCMTK-build/bin");
 }
 
 //------------------------------------------------------------------------------
@@ -146,13 +146,13 @@ QString ctkDICOMTesterPrivate::findDCMQRSCPConfigFile()const
 //------------------------------------------------------------------------------
 QString ctkDICOMTesterPrivate::findStoreSCUExecutable()const
 {
-  return this->findFile(QStringList("storescu*"), "CMakeExternals/Install/bin");  
+  return this->findFile(QStringList("storescu*"), "../DCMTK-build/bin");
 }
 
 //------------------------------------------------------------------------------
 QString ctkDICOMTesterPrivate::findStoreSCPExecutable()const
 {
-  return this->findFile(QStringList("storescp*"), "CMakeExternals/Install/bin");  
+  return this->findFile(QStringList("storescp*"), "../DCMTK-build/bin");
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
* Update `ctkDICOMTester` to lookup DCMTK executables in build tree. This removes the requirement to install CTK into the `CMakeExternals/Install` directory. 
* Support running `ctkDICOMHostTest1` without having to install CTK 
* Support running `ctkDICOMDatabase` tests in parallel using `QTemporaryDir` introduced in Qt5