### PR TITLE
ENH: Add GitHub Actions workflow for running "pre-commit"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: CI (Lint)
+
+on:
+  # Triggers the workflow on push or pull request events
+  push:
+    branches: [ master ]
+  pull_request:
+    branches:
+      - "*"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+      with:
+        python-version: '3.9'
+
+    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: "v4.4.0"
+  hooks:
+  - id: check-added-large-files
+    args: ['--maxkb=1024']
+  - id: check-case-conflict
+  - id: check-merge-conflict
+  - id: check-symlinks


### PR DESCRIPTION
This pull-request adds workflow leveraging pre-commit, a framework for managing and maintaining pre-commit hooks.

> [!IMPORTANT]
> For now, this will only report info to developers after the PR is submitted. There are no changes in the hook setup locally yet.

See https://pre-commit.com/ and https://github.com/pre-commit/action

Running the pre-commit locally can be done using the following
command:

```
pre-commit run --all-files
```

The hooks enabled in the "pre-commit-config.yaml" configuration
file are:

* `check-added-large-files`
  Prevent giant files from being committed.

  Set the size to 1024 to match the value hard-coded in
  https://github.com/Slicer/Slicer/blob/hooks/pre-commit#L125

* `check-case-conflict`
  Check for files with names that would conflict on a case-insensitive
  filesystem like MacOS HFS+ or Windows FAT.

* `check-merge-conflict`
  Check for files that contain merge conflict strings.

* `check-symlinks`
  Checks for symlinks which do not point to anything.

----

To allow a gradual improvement of the code base while carefully reviewing
each changes, exceptions for all issues reported by locally running the
following command are listed in `.flake8` configuration files:

```
  pre-commit run --all-files
```

----

It is based from similar updates integrated in Slicer through https://github.com/Slicer/Slicer/pull/6262 themselves adapted from prior work done by @henryiii in https://github.com/scikit-build/scikit-build and https://scikit-hep.org/developer/style