### PR TITLE
BUG: Fix ctkCoreSettingsTest testMultiplePaths on Windows

### DIFF
--- a/Libs/Core/Testing/Cpp/ctkCoreSettingsTest.cpp
+++ b/Libs/Core/Testing/Cpp/ctkCoreSettingsTest.cpp
@@ -139,7 +139,7 @@ void ctkCoreSettingsTester::testMultiplePaths_data()
     << (QStringList() << "<APPLICATION_HOME_DIR>/internal/dir");
 
   QTest::newRow("windows-style absolute paths") << "c:/windows/path"
-    << (QStringList() << "d:/windows/path/internal/dir" << "c:/windows/external/subdir/file.txt")
+    << (QStringList() << "c:/windows/path/internal/dir" << "c:/windows/external/subdir/file.txt")
     << (QStringList() << "<APPLICATION_HOME_DIR>/internal/dir" << "c:/windows/external/subdir/file.txt");
 #endif
 


### PR DESCRIPTION
Follow-up on commit f0bb5d782 (ENH: Allow saving relative paths to settings) where the test case was incorrectly specified.

It fixes the following error:

```
10: FAIL!  : ctkCoreSettingsTester::testMultiplePaths(windows-style absolute paths) Compared lists differ at index 0.
10:    Actual   (settings.value(key).toStringList()): "d:/windows/path/internal/dir"
10:    Expected (expectedStoredValues): "<APPLICATION_HOME_DIR>/internal/dir"
10: C:\path\to\CTK\Libs\Core\Testing\Cpp\ctkCoreSettingsTest.cpp(115) : failure location
```