### PR TITLE
BUG: Fix ctkSettingsPanelTest reading settings file as text

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkSettingsPanelTest.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSettingsPanelTest.cpp
@@ -105,7 +105,7 @@ void ctkSettingsPanelTester::testChangeProperty()
     if (QFile::exists(settings.fileName()))
       {
       QFile file(settings.fileName());
-      QVERIFY(file.open(QIODevice::ReadOnly));
+      QVERIFY(file.open(QIODevice::ReadOnly | QIODevice::Text));
       currentSettingContent = file.readAll();
       file.close();
       }
@@ -117,7 +117,7 @@ void ctkSettingsPanelTester::testChangeProperty()
     if (QFile::exists(specificSettings.fileName()))
       {
       QFile file(specificSettings.fileName());
-      QVERIFY(file.open(QIODevice::ReadOnly));
+      QVERIFY(file.open(QIODevice::ReadOnly | QIODevice::Text));
       currentSpecificSettingsContent = file.readAll();
       file.close();
       }


### PR DESCRIPTION
This ensures newlines are always read as `/n` independently of the platform.

It fixes errors like the following:

```
126: FAIL!  : ctkSettingsPanelTester::testChangeProperty(null none changed obj) Compared values are not the same
126:    Actual   (currentSettingContent)             : "[General]\r\nproperty=2\r\n"
```