### PR TITLE
BUG: Fix applySettings() to emit "settingChanged()" only if needed

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkSettingsPanelTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSettingsPanelTest1.cpp
@@ -354,7 +354,7 @@ int TestStringList(ctkSettingsPanelForTest& settingsPanel)
   CHECK_QSTRINGLIST(settingsPanel.myDefaultPropertyValue("key list").toStringList(), QStringList());
   CHECK_QSTRINGLIST(settingsPanel.myPropertyValue("key list").toStringList(), QStringList() << "first item");
   CHECK_QSTRINGLIST(settingsPanel.changedSettings(), QStringList());
-  CHECK_INT(spy.count(), 0);
+  CHECK_INT(spy.count(), 1);
 
   // Reset spy
   spy.clear();
@@ -386,7 +386,7 @@ int TestStringList(ctkSettingsPanelForTest& settingsPanel)
   CHECK_QSTRINGLIST(settingsPanel.myDefaultPropertyValue("key list").toStringList(), QStringList());
   CHECK_QSTRINGLIST(settingsPanel.myPropertyValue("key list").toStringList(), QStringList() << "first item" << "second item");
   CHECK_QSTRINGLIST(settingsPanel.changedSettings(), QStringList());
-  CHECK_INT(spy.count(), 0);
+  CHECK_INT(spy.count(), 1);
 
   // Reset spy
   spy.clear();
@@ -418,7 +418,7 @@ int TestStringList(ctkSettingsPanelForTest& settingsPanel)
   CHECK_QSTRINGLIST(settingsPanel.myDefaultPropertyValue("key list").toStringList(), QStringList());
   CHECK_QSTRINGLIST(settingsPanel.myPropertyValue("key list").toStringList(), QStringList());
   CHECK_QSTRINGLIST(settingsPanel.changedSettings(), QStringList());
-  CHECK_INT(spy.count(), 0);
+  CHECK_INT(spy.count(), 1);
 
   // Reset spy
   spy.clear();

--- a/Libs/Widgets/ctkSettingsPanel.cpp
+++ b/Libs/Widgets/ctkSettingsPanel.cpp
@@ -417,8 +417,11 @@ void ctkSettingsPanel::applySettings()
   foreach(const QString& key, d->Properties.keys())
     {
     PropertyType& prop = d->Properties[key];
-    prop.setPreviousValue(prop.value());
-    emit settingChanged(key, prop.value());
+    if (prop.previousValue() != prop.value())
+      {
+      prop.setPreviousValue(prop.value());
+      emit settingChanged(key, prop.value());
+      }
     }
 }
 


### PR DESCRIPTION
This issue was discovered while working on fixing `ctkSettingsPanelTest1` failure.

Further improve the fix integrated in c8ce0dec ("BUG: Fix incorrect changed settings indicator", 2018-07-04) and update ctkSettingsPanelTest1 accordingly.

cc: @jamesobutler 