### PR TITLE
Fix parallel execution of DICOM tests

### DIFF
--- a/Applications/Testing/Cpp/CMakeLists.txt
+++ b/Applications/Testing/Cpp/CMakeLists.txt
@@ -66,4 +66,7 @@ if(CTK_APP_ctkDICOMQuery AND CTK_APP_ctkDICOMRetrieve)
                )
 
   set_property(TEST ${testname} PROPERTY ENVIRONMENT_MODIFICATION "${CTK_TEST_LAUNCH_BUILD_ENVIRONMENT_MODIFICATION}")
+
+  set_property(TEST ${testname} PROPERTY RESOURCE_LOCK "dcmqrscp")
+
 endif()

--- a/Applications/Testing/Cpp/ctkDICOMApplicationTest1.cpp
+++ b/Applications/Testing/Cpp/ctkDICOMApplicationTest1.cpp
@@ -206,10 +206,19 @@ int main(int argc, char * argv []) {
   QCoreApplication app(argc, argv);
   QTextStream out(stdout);
 
-  if ( argc < 10 )
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 9)
   {
-    out << "ERROR: invalid arguments.  Should be:\n";
-    out << " ctkDICOMApplicationTest1 <dcmqrscp> <configfile> <dicomData1> <dcmData2> <storescu> <ctkDICOMQuery> <ctkDICOMRetrieve> <retrieveDirectory>\n";
+    std::cerr << "ERROR: invalid or missing arguments.\n\n"
+              << "Usage: " << qPrintable(testName)
+              << " <dcmqrscp> <configfile>"
+                 " <dicomData1>"
+                 " <dicomData2>"
+                 " <storescu>"
+                 " <ctkDICOMQuery> <databaseFile>"
+                 " <ctkDICOMRetrieve> <retrieveDirectory>\n";
     return EXIT_FAILURE;
   }
 

--- a/Applications/ctkDICOM/Testing/Cpp/ctkDICOMTest1.cpp
+++ b/Applications/ctkDICOM/Testing/Cpp/ctkDICOMTest1.cpp
@@ -29,14 +29,22 @@
 int ctkDICOMTest1(int argc, char * argv [])
 {
   QCoreApplication app(argc, argv);
-  if (app.arguments().count() != 2)
+
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 1)
     {
-    std::cerr << "Line " << __LINE__ << " - Failed to run " << argv[0] << "\n"
-              << "Usage:\n"
-              << "  " << argv[0] << " /path/to/ctkDICOM";
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-ctkDICOM-executable>" << std::endl;
     return EXIT_FAILURE;
     }
-  QString command = app.arguments().at(1);
+
+  QString command = arguments.at(0);
+
+  std::cout << "Testing:\n"
+            << qPrintable(command) << std::endl;
+
   QProcess process;
   process.start(command, /* arguments= */ QStringList());
   bool res = process.waitForStarted();

--- a/Applications/ctkDICOM2/Testing/Cpp/ctkDICOM2Test1.cpp
+++ b/Applications/ctkDICOM2/Testing/Cpp/ctkDICOM2Test1.cpp
@@ -29,14 +29,22 @@
 int ctkDICOM2Test1(int argc, char * argv [])
 {
   QCoreApplication app(argc, argv);
-  if (app.arguments().count() != 2)
+
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 1)
     {
-    std::cerr << "Line " << __LINE__ << " - Failed to run " << argv[0] << "\n"
-              << "Usage:\n"
-              << "  " << argv[0] << " /path/to/ctkDICOM";
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-ctkDICOM-executable>" << std::endl;
     return EXIT_FAILURE;
     }
-  QString command = app.arguments().at(1);
+
+  QString command = arguments.at(0);
+
+  std::cout << "Testing:\n"
+            << qPrintable(command) << std::endl;
+
   QProcess process;
   process.start(command, /* arguments= */ QStringList());
   bool res = process.waitForStarted();

--- a/Applications/ctkDICOMDemoSCU/Testing/Cpp/ctkDICOMDemoSCUTest1.cpp
+++ b/Applications/ctkDICOMDemoSCU/Testing/Cpp/ctkDICOMDemoSCUTest1.cpp
@@ -29,19 +29,28 @@
 int ctkDICOMDemoSCUTest1(int argc, char * argv [])
 {
   QCoreApplication app(argc, argv);
+
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 1)
+    {
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-ctkDICOMDemoSCU-executable>" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  QString command = arguments.at(0);
+
   QString peer("www.dicomserver.co.uk");
   QString port("104");
   QString aeTitle("MOVESCP");
   QStringList parameters;
   parameters << peer << port << aeTitle;
 
-  if (argc < 2)
-    {
-    std::cerr << "Must specify path to ctkDICOMDemoSCU on command line\n";
-    return EXIT_FAILURE;
-    }
-  std::cout << "Testing ctkDICOMDemoSCU: " << argv[1] << "\n";
-  QString command = QString(argv[1]);
+  std::cout << "Testing:\n"
+            << qPrintable(command) << " "
+            << qPrintable(parameters.join(" ")) << std::endl;
 
   int res = QProcess::execute(command, parameters);
   if (res != EXIT_SUCCESS)

--- a/Applications/ctkDICOMHost/Testing/Cpp/ctkDICOMHostTest1.cpp
+++ b/Applications/ctkDICOMHost/Testing/Cpp/ctkDICOMHostTest1.cpp
@@ -33,14 +33,20 @@ int ctkDICOMHostTest1(int argc, char * argv [])
   QCoreApplication app(argc, argv);
 
   QStringList arguments = app.arguments();
-  arguments.pop_front(); // remove "program" name
-  if (!arguments.count())
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 1)
     {
-    std::cerr << "Usage: ctkDICOMHostTest1 /path/to/ctkDICOMHost" << std::endl;
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-ctkDICOMHost-executable>" << std::endl;
     return EXIT_FAILURE;
     }
 
   QString command = arguments.at(0);
+
+  std::cout << "Testing:\n"
+            << qPrintable(command) << std::endl;
+
   QProcess process;
   process.start(command, /* arguments= */ QStringList());
   bool res = process.waitForStarted();

--- a/Applications/ctkDICOMIndexer/Testing/Cpp/ctkDICOMIndexerAppTest1.cpp
+++ b/Applications/ctkDICOMIndexer/Testing/Cpp/ctkDICOMIndexerAppTest1.cpp
@@ -29,18 +29,28 @@
 int ctkDICOMIndexerAppTest1(int argc, char * argv [])
 {
   QCoreApplication app(argc, argv);
+
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
   QString database("test.db");
 
-  if (argc < 2)
+  if (arguments.count() != 1)
     {
-    std::cerr << "Must specify path to ctkDICOMIndexer on command line\n";
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-ctkDICOMIndexer-executable>" << std::endl;
     return EXIT_FAILURE;
     }
-  std::cout << "Testing ctkDICOMIndexer: " << argv[1] << "\n";
-  QString command = QString(argv[1]);
+
+  QString command = arguments.at(0);
 
   QStringList parameters;
   parameters << "--init" << database;
+
+  std::cout << "Testing:\n"
+            << qPrintable(command) << " "
+            << qPrintable(parameters.join(" ")) << std::endl;
+
   int res = QProcess::execute(command, parameters);
   if (res != EXIT_SUCCESS)
     {

--- a/Libs/DICOM/Core/Testing/Cpp/CMakeLists.txt
+++ b/Libs/DICOM/Core/Testing/Cpp/CMakeLists.txt
@@ -59,6 +59,7 @@ SIMPLE_TEST( ctkDICOMQueryTest2
   ${CTKData_DIR}/Data/DICOM/MRHEAD/000055.IMA
   ${CTKData_DIR}/Data/DICOM/MRHEAD/000056.IMA
   )
+set_property(TEST "ctkDICOMQueryTest2" PROPERTY RESOURCE_LOCK "dcmqrscp")
 
 # ctkDICOMRetrieve
 SIMPLE_TEST( ctkDICOMRetrieveTest1)
@@ -66,6 +67,7 @@ SIMPLE_TEST( ctkDICOMRetrieveTest2
   ${CTKData_DIR}/Data/DICOM/MRHEAD/000055.IMA
   ${CTKData_DIR}/Data/DICOM/MRHEAD/000056.IMA
   )
+set_property(TEST "ctkDICOMRetrieveTest2" PROPERTY RESOURCE_LOCK "dcmqrscp")
 
 # ctkDICOMCore
 SIMPLE_TEST( ctkDICOMCoreTest1
@@ -75,7 +77,9 @@ SIMPLE_TEST( ctkDICOMCoreTest1
 
 # ctkDICOMTester
 SIMPLE_TEST( ctkDICOMTesterTest1 )
+set_property(TEST "ctkDICOMTesterTest1" PROPERTY RESOURCE_LOCK "dcmqrscp")
 SIMPLE_TEST( ctkDICOMTesterTest2
   ${CTKData_DIR}/Data/DICOM/MRHEAD/000055.IMA
   ${CTKData_DIR}/Data/DICOM/MRHEAD/000056.IMA
   )
+set_property(TEST "ctkDICOMTesterTest2" PROPERTY RESOURCE_LOCK "dcmqrscp")

--- a/Libs/DICOM/Core/Testing/Cpp/CMakeLists.txt
+++ b/Libs/DICOM/Core/Testing/Cpp/CMakeLists.txt
@@ -48,7 +48,7 @@ SIMPLE_TEST(ctkDICOMIndexerTest1 )
 
 # ctkDICOMModel
 SIMPLE_TEST(ctkDICOMModelTest1
-  ${CMAKE_CURRENT_BINARY_DIR}/dicom.db
+  ${CMAKE_CURRENT_BINARY_DIR}/Testing/Temporary/ctkDICOMModelTest1-dicom.db
   ${CMAKE_CURRENT_SOURCE_DIR}/../../Resources/dicom-sample.sql
   )
 SIMPLE_TEST(ctkDICOMPersonNameTest1)
@@ -71,7 +71,7 @@ set_property(TEST "ctkDICOMRetrieveTest2" PROPERTY RESOURCE_LOCK "dcmqrscp")
 
 # ctkDICOMCore
 SIMPLE_TEST( ctkDICOMCoreTest1
-  ${CMAKE_CURRENT_BINARY_DIR}/dicom.db
+  ${CMAKE_CURRENT_BINARY_DIR}/Testing/Temporary/ctkDICOMCoreTest1-dicom.db
   ${CMAKE_CURRENT_SOURCE_DIR}/../../Resources/dicom-sample.sql
   )
 

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMCoreTest1.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMCoreTest1.cpp
@@ -23,6 +23,9 @@
 #include <QCoreApplication>
 #include <QTextStream>
 
+// ctkCore includes
+#include <ctkCoreTestingMacros.h>
+
 // ctkDICOMCore includes
 #include "ctkDICOMDatabase.h"
 
@@ -33,28 +36,37 @@
 int ctkDICOMCoreTest1(int argc, char * argv []) {
 
   QCoreApplication app(argc, argv);
-  QTextStream out(stdout);
-  try
+
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 2)
   {
-    ctkDICOMDatabase myCTK( argv[1] );
-    out << "open db success\n";
-    /// make sure it is empty and properly initialized
-    if (! myCTK.initializeDatabase() ) {
-       out << "ERROR: basic DB init failed";
-       return EXIT_FAILURE;
-    };
-    /// insert some sample data
-    if (! myCTK.initializeDatabase(argv[2]) ) {
-       out << "ERROR: sample DB init failed";
-       return EXIT_FAILURE;
-    };
-    myCTK.closeDatabase();
-    }
-  catch (const std::exception& e)
-  {
-    out << "ERROR: " << e.what();
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <dumpfile1.sql> <dumpfile2.sql>" << std::endl;
     return EXIT_FAILURE;
   }
+
+  QString sqlFileName1(arguments.at(0));
+  QString sqlFileName2(arguments.at(1));
+
+  try
+  {
+    ctkDICOMDatabase myCTK(sqlFileName1);
+    CHECK_BOOL(myCTK.initializeDatabase(), true);
+
+    /// insert some sample data
+    CHECK_BOOL(myCTK.initializeDatabase(sqlFileName2.toUtf8()), true);
+
+    myCTK.closeDatabase();
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << "Error when opening the data base file: " << argv[1]
+              << " error: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+
   return EXIT_SUCCESS;
 }
 

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest2.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest2.cpp
@@ -39,14 +39,17 @@ int ctkDICOMDatabaseTest2( int argc, char * argv [] )
 {
   QCoreApplication app(argc, argv);
 
-  if (argc < 2)
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 1)
     {
-    std::cerr << "ctkDICOMDatabaseTest2: missing dicom filePath argument";
-    std::cerr << std::endl;
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-dicom-file>" << std::endl;
     return EXIT_FAILURE;
     }
 
-  QString dicomFilePath(argv[1]);
+  QString dicomFilePath(arguments.at(0));
 
   QTemporaryDir tempDirectory;
   CHECK_BOOL(tempDirectory.isValid(), true);

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest2.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest2.cpp
@@ -91,28 +91,25 @@ int ctkDICOMDatabaseTest2( int argc, char * argv [] )
   //
   // Test that the tag interface works to parse ascii
   //
-  QString tag("0008,103e");
-  unsigned short group, element;
-  if ( !database.tagToGroupElement(tag, group, element) )
-    {
-    std::cerr << "ctkDICOMDatabase: could not parse tag" << std::endl;
-    return EXIT_FAILURE;
-    }
+  {
+    unsigned short group, element;
+    QString tag("0008,103E"); // upper case
+    CHECK_BOOL(database.tagToGroupElement(tag, group, element), true);
+    CHECK_INT(group, 0x8);
+    CHECK_INT(element, 0x103E);
+  }
+  {
+    unsigned short group, element;
+    QString tag("0008,103e"); // lower case
+    CHECK_BOOL(database.tagToGroupElement(tag, group, element), true);
+    CHECK_INT(group, 0x8);
+    CHECK_INT(element, 0x103E);
+  }
 
-  if ( group != 0x8 || element != 0x103e )
-    {
-    std::cerr << "ctkDICOMDatabase: expected: " << "0008,103e" << std::endl;
-    std::cerr << "ctkDICOMDatabase: got: " << group << " " << element << std::endl;
-    std::cerr << "ctkDICOMDatabase: parsed tag does not match group/element" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  if ( database.groupElementToTag(group, element) != tag.toUpper() )
-    {
-    std::cerr << "ctkDICOMDatabase: could not convert a uints to tag string" << std::endl;
-    return EXIT_FAILURE;
-    }
-
+  //
+  // Test that conversion from uints to tag string works
+  //
+  CHECK_QSTRING(database.groupElementToTag(0x8, 0x103E), "0008,103E");
 
   //
   // Basic test:
@@ -161,7 +158,7 @@ int ctkDICOMDatabaseTest2( int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-
+  QString tag("0008,103E");
   if (database.cachedTag(instanceUID, tag) != QString(""))
     {
     std::cerr << "ctkDICOMDatabase: tag cache should return empty string for unknown instance tag" << std::endl;

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest3.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest3.cpp
@@ -38,12 +38,18 @@ int ctkDICOMDatabaseTest3( int argc, char * argv [] )
 {
   QCoreApplication app(argc, argv);
 
-  if (argc <= 1)
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 1)
     {
     std::cerr << "Warning, no sql file given. Test stops" << std::endl;
-    std::cerr << "Usage: ctkDICOMDatabaseTest3 <olddumpfile.sql>" << std::endl;
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <dumpfile.sql>" << std::endl;
     return EXIT_FAILURE;
     }
+
+  QString sqlFileName(arguments.at(0));
 
   QTemporaryDir tempDirectory;
   CHECK_BOOL(tempDirectory.isValid(), true);
@@ -59,9 +65,9 @@ int ctkDICOMDatabaseTest3( int argc, char * argv [] )
   {
     ctkDICOMDatabase myCTK( databaseFileName );
 
-    if (!myCTK.initializeDatabase(argv[1]))
+    if (!myCTK.initializeDatabase(sqlFileName.toUtf8()))
     {
-      std::cerr << "Error when initializing the data base with: " << argv[1]
+      std::cerr << "Error when initializing the data base with: " << qPrintable(sqlFileName)
           << " error: " << myCTK.lastError().toStdString();
       return EXIT_FAILURE;
     }

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest4.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest4.cpp
@@ -38,14 +38,17 @@ int ctkDICOMDatabaseTest4( int argc, char * argv [] )
 {
   QCoreApplication app(argc, argv);
 
-  if (argc < 2)
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 1)
     {
-    std::cerr << "ctkDICOMDatabaseTest2: missing dicom filePath argument";
-    std::cerr << std::endl;
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-dicom-file>" << std::endl;
     return EXIT_FAILURE;
     }
 
-  QString dicomFilePath(argv[1]);
+  QString dicomFilePath(arguments.at(0));
 
   QTemporaryDir tempDirectory;
   CHECK_BOOL(tempDirectory.isValid(), true);

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest5.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest5.cpp
@@ -38,14 +38,17 @@ int ctkDICOMDatabaseTest5( int argc, char * argv [] )
 {
   QCoreApplication app(argc, argv);
 
-  if (argc < 2)
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 1)
     {
-    std::cerr << "ctkDICOMDatabaseTest2: missing dicom filePath argument";
-    std::cerr << std::endl;
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-dicom-file>" << std::endl;
     return EXIT_FAILURE;
     }
 
-  QString dicomFilePath(argv[1]);
+  QString dicomFilePath(arguments.at(0));
 
   QTemporaryDir tempDirectory;
   CHECK_BOOL(tempDirectory.isValid(), true);

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest6.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMDatabaseTest6.cpp
@@ -38,14 +38,17 @@ int ctkDICOMDatabaseTest6( int argc, char * argv [] )
 {
   QCoreApplication app(argc, argv);
 
-  if (argc < 2)
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 1)
     {
-    std::cerr << "ctkDICOMDatabaseTest6: missing dicom filePath argument";
-    std::cerr << std::endl;
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-dicom-file>" << std::endl;
     return EXIT_FAILURE;
     }
 
-  QString dicomFilePath(argv[1]);
+  QString dicomFilePath(arguments.at(0));
 
   QTemporaryDir tempDirectory;
   CHECK_BOOL(tempDirectory.isValid(), true);

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMModelTest1.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMModelTest1.cpp
@@ -41,21 +41,28 @@ int ctkDICOMModelTest1( int argc, char * argv [] )
 {
   QCoreApplication app(argc, argv);
 
-  if (argc <= 2)
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (arguments.count() != 2)
     {
-    std::cerr << "Warning, no sql file given. Test stops" << std::endl;
-    std::cerr << "Usage: qctkDICOMModelTest1 <scratch.db> <dumpfile.sql>" << std::endl;
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <scratch.db> <dumpfile.sql>" << std::endl;
     return EXIT_FAILURE;
     }
 
+  QString databaseFile(arguments.at(0));
+  QString sqlFileName(arguments.at(1));
+
   try
   {
-    ctkDICOMDatabase myCTK( argv[1] );
+    ctkDICOMDatabase myCTK( databaseFile );
 
-    if (!myCTK.initializeDatabase(argv[2]))
+    if (!myCTK.initializeDatabase(sqlFileName.toUtf8()))
     {
-      std::cerr << "Error when initializing the data base: " << argv[2]
-          << " error: " << myCTK.lastError().toStdString();
+      std::cerr << "Error when initializing the data base: " << qPrintable(sqlFileName)
+                << " error: " << qPrintable(myCTK.lastError()) << std::endl;
+      return EXIT_FAILURE;
     }
     /*
   QSqlQuery toto("SELECT PatientsName as 'Name tt' FROM Patients ORDER BY \"Name tt\" ASC", myCTK.database());
@@ -92,8 +99,8 @@ int ctkDICOMModelTest1( int argc, char * argv [] )
   }
   catch (const std::exception& e)
   {
-    std::cerr << "Error when opening the data base file: " << argv[1]
-        << " error: " << e.what();
+    std::cerr << "Error when opening the data base file: " << qPrintable(databaseFile)
+              << " error: " << e.what() << std::endl;
     return EXIT_FAILURE;
   }
 }

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMQueryTest2.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMQueryTest2.cpp
@@ -32,27 +32,24 @@
 // STD includes
 #include <iostream>
 
-void ctkDICOMQueryTest2PrintUsage()
-{
-  std::cout << " ctkDICOMQueryTest2 images" << std::endl;
-}
 
 // Test on a real local database
 int ctkDICOMQueryTest2( int argc, char * argv [] )
 {
   QCoreApplication app(argc, argv);
 
-  ctkDICOMTester tester;
-  tester.startDCMQRSCP();
-
   QStringList arguments = app.arguments();
-  arguments.pop_front(); // remove application name
-  arguments.pop_front(); // remove test name
+  QString testName = arguments.takeFirst();
+
   if (!arguments.count())
     {
-    ctkDICOMQueryTest2PrintUsage();
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-image> [...]" << std::endl;
     return EXIT_FAILURE;
     }
+
+  ctkDICOMTester tester;
+  tester.startDCMQRSCP();
   tester.storeData(arguments);
 
   ctkDICOMDatabase database;

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMRetrieveTest2.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMRetrieveTest2.cpp
@@ -35,28 +35,26 @@
 // STD includes
 #include <iostream>
 
-void ctkDICOMRetrieveTest2PrintUsage()
-{
-  std::cout << " ctkDICOMRetrieveTest2 images" << std::endl;
-}
 
 // Test on a real local database
 int ctkDICOMRetrieveTest2( int argc, char * argv [] )
 {
   QCoreApplication app(argc, argv);
 
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  if (!arguments.count())
+    {
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-image> [...]" << std::endl;
+    return EXIT_FAILURE;
+    }
+
   ctkDICOMTester tester;
   std::cerr << "ctkDICOMRetrieveTest2: Starting dcmqrscp\n";
   tester.startDCMQRSCP();
 
-  QStringList arguments = app.arguments();
-  arguments.pop_front(); // remove application name
-  arguments.pop_front(); // remove test name
-  if (!arguments.count())
-    {
-    ctkDICOMRetrieveTest2PrintUsage();
-    return EXIT_FAILURE;
-    }
   std::cerr << "ctkDICOMRetrieveTest2: Storing data to dcmqrscp\n";
   tester.storeData(arguments);
 

--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMTesterTest2.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMTesterTest2.cpp
@@ -29,20 +29,18 @@
 #include <iostream>
 #include <cstdlib>
 
-void ctkDICOMTesterTest2PrintUsage()
-{
-  std::cout << " ctkDICOMTesterTest2 images" << std::endl;
-}
 
 int ctkDICOMTesterTest2(int argc, char * argv [])
 {
   QCoreApplication app(argc, argv);
 
   QStringList arguments = app.arguments();
-  arguments.pop_front();
+  QString testName = arguments.takeFirst();
+
   if (!arguments.count())
     {
-    ctkDICOMTesterTest2PrintUsage();
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <path-to-image> [...]" << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Libs/DICOM/Core/ctkDICOMTester.cpp
+++ b/Libs/DICOM/Core/ctkDICOMTester.cpp
@@ -91,8 +91,10 @@ ctkDICOMTesterPrivate::ctkDICOMTesterPrivate(ctkDICOMTester& o): q_ptr(&o)
 //------------------------------------------------------------------------------
 ctkDICOMTesterPrivate::~ctkDICOMTesterPrivate()
 {
-  this->STORESCPProcess->terminate();
-  if (!this->STORESCPProcess->waitForFinished())
+  // Do not wait for the process to finish.
+  // See https://doc.qt.io/qt-5/qprocess.html#terminate
+  // this->STORESCPProcess->terminate();
+  // if (!this->STORESCPProcess->waitForFinished())
     {
     this->STORESCPProcess->kill();
     }

--- a/Libs/DICOM/Widgets/Testing/Cpp/CMakeLists.txt
+++ b/Libs/DICOM/Widgets/Testing/Cpp/CMakeLists.txt
@@ -51,13 +51,13 @@ SIMPLE_TEST(ctkDICOMDirectoryListWidgetTest1)
 SIMPLE_TEST(ctkDICOMImportWidgetTest1)
 SIMPLE_TEST(ctkDICOMListenerWidgetTest1)
 SIMPLE_TEST(ctkDICOMModelTest2
-  ${CMAKE_CURRENT_BINARY_DIR}/dicom.db
+  ${CMAKE_CURRENT_BINARY_DIR}/Testing/Temporary/ctkDICOMModelTest2-dicom.db
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../Core/Resources/dicom-sample.sql
   )
 SIMPLE_TEST(ctkDICOMQueryRetrieveWidgetTest1)
 SIMPLE_TEST(ctkDICOMQueryResultsTabWidgetTest1)
 SIMPLE_TEST(ctkDICOMThumbnailListWidgetTest1
-  ${CMAKE_CURRENT_BINARY_DIR}/dicom.db
+  ${CMAKE_CURRENT_BINARY_DIR}/Testing/Temporary/ctkDICOMThumbnailListWidgetTest1-dicom.db
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../Core/Resources/dicom-sample.sql
   )
 

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMAppWidgetTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMAppWidgetTest1.cpp
@@ -48,7 +48,13 @@ int ctkDICOMAppWidgetTest1( int argc, char * argv [] )
   QCommandLineParser parser;
   parser.addOption({"I", "Run in interactive mode"});
   parser.addPositionalArgument("directory", "Directory to import");
-  parser.process(app);
+  parser.process(app); // Automatically exit if there is a parsing error
+
+  if (parser.positionalArguments().count() != 1)
+    {
+    std::cerr << qPrintable(parser.helpText()) << std::endl;
+    return EXIT_FAILURE;
+    }
 
   QString directoryToImport = parser.positionalArguments().at(0);
 

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMBrowserTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMBrowserTest1.cpp
@@ -40,11 +40,19 @@ int ctkDICOMBrowserTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
 
-  qDebug() << "argc = " << argc;
-  for (int i = 0; i < argc; ++i)
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  bool interactive = arguments.removeOne("-I");
+
+  if (arguments.count() != 1)
     {
-    qDebug() << "\t" << argv[i];
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " [-I] <path-to-dicom-directory>" << std::endl;
+    return EXIT_FAILURE;
     }
+
+  QString dicomDirectory(arguments.at(0));
 
   QFileInfo tempFileInfo(QDir::tempPath() + QString("/ctkDICOMBrowserTest1-db"));
   QString dbDir = tempFileInfo.absoluteFilePath();
@@ -64,7 +72,7 @@ int ctkDICOMBrowserTest1( int argc, char * argv [] )
   browser.show();
 
   browser.setDisplayImportSummary(false);
-  qDebug() << "Importing directory " << argv[1];
+  qDebug() << "Importing directory " << dicomDirectory;
 
   // [Deprecated]
   // make sure copy/link dialog doesn't pop up, always copy on import
@@ -77,7 +85,7 @@ int ctkDICOMBrowserTest1( int argc, char * argv [] )
   // [/Deprecated]
 
   // Test import of a few specific files
-  QDirIterator it(argv[1], QStringList() << "*.IMA", QDir::Files, QDirIterator::Subdirectories);
+  QDirIterator it(dicomDirectory, QStringList() << "*.IMA", QDir::Files, QDirIterator::Subdirectories);
   // Skip a few files
   it.next();
   it.next();
@@ -99,7 +107,7 @@ int ctkDICOMBrowserTest1( int argc, char * argv [] )
   CHECK_INT(browser.seriesAddedDuringImport(), 1);
   CHECK_INT(browser.instancesAddedDuringImport(), 3);
 
-  browser.importDirectories(QStringList() << argv[1]);
+  browser.importDirectories(QStringList() << dicomDirectory);
   browser.waitForImportFinished();
 
   qDebug() << "\n\nAdded to database directory: " << files;
@@ -116,7 +124,7 @@ int ctkDICOMBrowserTest1( int argc, char * argv [] )
 
   qDebug() << "\n\nAdded to database directory: " << dbDir;
 
-  if (argc <= 2 || QString(argv[argc - 1]) != "-I")
+  if (!interactive)
     {
     QTimer::singleShot(200, &app, SLOT(quit()));
     }

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMDirectoryListWidgetTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMDirectoryListWidgetTest1.cpp
@@ -33,6 +33,12 @@ int ctkDICOMDirectoryListWidgetTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
 
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+  Q_UNUSED(testName);
+
+  bool interactive = arguments.removeOne("-I");
+
   ctkDICOMDatabase database;
   ctkDICOMDirectoryListWidget listWidget;
   listWidget.setDICOMDatabase(0);
@@ -42,7 +48,7 @@ int ctkDICOMDirectoryListWidgetTest1( int argc, char * argv [] )
 
   listWidget.show();
 
-  if (argc <= 1 || QString(argv[1]) != "-I")
+  if (!interactive)
     {
     QTimer::singleShot(200, &app, SLOT(quit()));
     }

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMImageTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMImageTest1.cpp
@@ -21,6 +21,7 @@
 
 // Qt includes
 #include <QApplication>
+#include <QDir>
 #include <QLabel>
 
 
@@ -38,14 +39,22 @@ int ctkDICOMImageTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
 
-  if (argc <= 1)
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  bool interactive = arguments.removeOne("-I");
+
+  if (arguments.count() != 1)
     {
     std::cerr << "Warning, no dicom file given. Test stops" << std::endl;
-    std::cerr << "Usage: qctkDICOMImageTest1 <dicom file>" << std::endl;
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " [-I] <path-to-dicom-file>" << std::endl;
     return EXIT_FAILURE;
   }
 
-  DicomImage dcmtkImage(argv[1]);
+  QString dicomFilePath(arguments.at(0));
+
+  DicomImage dcmtkImage(QDir::toNativeSeparators(dicomFilePath).toUtf8());
   ctkDICOMImage ctkImage(&dcmtkImage);
 
   QLabel qtImage;
@@ -58,7 +67,7 @@ int ctkDICOMImageTest1( int argc, char * argv [] )
   qtImage.setPixmap(pixmap);
   qtImage.show();
 
-  if (argc > 2 && QString(argv[2]) == "-I")
+  if (interactive)
     {
     return app.exec();
     }

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMImportWidgetTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMImportWidgetTest1.cpp
@@ -36,13 +36,19 @@ int ctkDICOMImportWidgetTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
 
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+  Q_UNUSED(testName);
+
+  bool interactive = arguments.removeOne("-I");
+
   ctkDICOMDatabase* database = new ctkDICOMDatabase;
   ctkDICOMImportWidget importWidget;
   importWidget.setDICOMDatabase(QSharedPointer<ctkDICOMDatabase>(database));
   importWidget.setTopDirectory(QDir::tempPath());
   importWidget.show();
 
-  if (argc <= 1 || QString(argv[1]) != "-I")
+  if (!interactive)
     {
     QTimer::singleShot(200, &app, SLOT(quit()));
     }

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMItemViewTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMItemViewTest1.cpp
@@ -40,13 +40,22 @@
 int ctkDICOMItemViewTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
-  if (argc < 2)
+
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  bool interactive = arguments.removeOne("-I");
+
+  if (arguments.count() != 1)
     {
-    std::cerr << "Usage: ctkDICOMItemViewTest1 dcmimage [-I]" << std::endl;
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " [-I] <path-to-dicom-file>" << std::endl;
     return EXIT_FAILURE;
     }
 
-  DicomImage    img(argv[1]);
+  QString dicomFilePath(arguments.at(0));
+
+  DicomImage img(QDir::toNativeSeparators(dicomFilePath).toUtf8());
   QImage image;
   QImage image2(200, 200, QImage::Format_RGB32);
 
@@ -60,7 +69,7 @@ int ctkDICOMItemViewTest1( int argc, char * argv [] )
   datasetView.update( true, true);
   datasetView.show();
 
-  if (argc <= 2 || QString(argv[2]) != "-I")
+  if (!interactive)
     {
     QTimer::singleShot(200, &app, SLOT(quit()));
     }

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMListenerWidgetTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMListenerWidgetTest1.cpp
@@ -32,10 +32,16 @@ int ctkDICOMListenerWidgetTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
 
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+  Q_UNUSED(testName);
+
+  bool interactive = arguments.removeOne("-I");
+
   ctkDICOMListenerWidget listenerWidget;
   listenerWidget.show();
 
-  if (argc <= 1 || QString(argv[1]) != "-I")
+  if (!interactive)
     {
     QTimer::singleShot(200, &app, SLOT(quit()));
     }

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMObjectModelTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMObjectModelTest1.cpp
@@ -37,10 +37,33 @@
 int ctkDICOMObjectModelTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
+
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+  Q_UNUSED(testName);
+
+  bool interactive = arguments.removeOne("-I");
+
   QString fileName;
-  //TODO: Add the option for reading the test file from argv
-  fileName = QFileDialog::getOpenFileName( 0,
-    "Choose a DCM File", ".","DCM (*)" );
+
+  if (!interactive && arguments.count() != 1)
+    {
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " [-I] <path-to-dicom-file>" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  if (arguments.count() == 1)
+    {
+    fileName = arguments.at(0);
+    }
+
+  if (interactive && arguments.count() == 0)
+    {
+    fileName = QFileDialog::getOpenFileName(
+                 0, "Choose a DCM File", ".","DCM (*)" );
+    }
+
   ctkDICOMObjectModel dcmObjModel;
   dcmObjModel.setFile(fileName);
 
@@ -55,6 +78,11 @@ int ctkDICOMObjectModelTest1( int argc, char * argv [] )
   //viewer->header()->setResizeMode( QHeaderView::Stretch);
   viewer->show();
   viewer->raise();
+
+  if (!interactive)
+    {
+    QTimer::singleShot(200, &app, SLOT(quit()));
+    }
 
   return app.exec();
 }

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMQueryResultsTabWidgetTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMQueryResultsTabWidgetTest1.cpp
@@ -32,11 +32,17 @@ int ctkDICOMQueryResultsTabWidgetTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
 
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+  Q_UNUSED(testName);
+
+  bool interactive = arguments.removeOne("-I");
+
   ctkDICOMQueryResultsTabWidget widget;
   widget.disableCloseOnTab(0);
   widget.show();
 
-  if (argc <= 1 || QString(argv[1]) != "-I")
+  if (!interactive)
     {
     QTimer::singleShot(200, &app, SLOT(quit()));
     }

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMQueryRetrieveWidgetTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMQueryRetrieveWidgetTest1.cpp
@@ -33,6 +33,12 @@ int ctkDICOMQueryRetrieveWidgetTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
 
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+  Q_UNUSED(testName);
+
+  bool interactive = arguments.removeOne("-I");
+
   QSharedPointer<ctkDICOMDatabase> dicomDatabase;
   ctkDICOMQueryRetrieveWidget widget;
   widget.setRetrieveDatabase(dicomDatabase);
@@ -40,13 +46,14 @@ int ctkDICOMQueryRetrieveWidgetTest1( int argc, char * argv [] )
     {
     std::cerr << "ctkDICOMQueryRetrieveDatabase::setRetrieveDatabase failed."
               << std::endl;
+    return EXIT_FAILURE;
     }
 
   widget.query();
   widget.retrieve();
   widget.show();
 
-  if (argc <= 1 || QString(argv[1]) != "-I")
+  if (!interactive)
     {
     QTimer::singleShot(200, &app, SLOT(quit()));
     }

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMServerNodeWidgetTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMServerNodeWidgetTest1.cpp
@@ -33,6 +33,12 @@ int ctkDICOMServerNodeWidgetTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
 
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+  Q_UNUSED(testName);
+
+  bool interactive = arguments.removeOne("-I");
+
   ctkDICOMServerNodeWidget widget;
   if (widget.callingAETitle() != "FINDSCU")
     {
@@ -140,7 +146,7 @@ int ctkDICOMServerNodeWidgetTest1( int argc, char * argv [] )
   widget.readSettings();
   widget.show();
 
-  if (argc <= 1 || QString(argv[1]) != "-I")
+  if (!interactive)
     {
     QTimer::singleShot(200, &app, SLOT(quit()));
     }

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMThumbnailListWidgetTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMThumbnailListWidgetTest1.cpp
@@ -35,23 +35,33 @@ int ctkDICOMThumbnailListWidgetTest1( int argc, char * argv [] )
 {
   QApplication app(argc, argv);
 
-  if (argc <= 2)
+  QStringList arguments = app.arguments();
+  QString testName = arguments.takeFirst();
+
+  bool interactive = arguments.removeOne("-I");
+
+  if (arguments.count() != 2)
     {
     std::cerr << "Warning, no sql file given. Test stops" << std::endl;
-    std::cerr << "Usage: qctkDICOMModelTest1 <scratch.db> <dumpfile.sql>" << std::endl;
+    std::cerr << "Usage: " << qPrintable(testName)
+              << " <scratch.db> <dumpfile.sql>" << std::endl;
     return EXIT_FAILURE;
     }
+
+  QString databaseFile(arguments.at(0));
+  QString sqlFileName(arguments.at(1));
 
   try
     {
     QFileInfo databasePath;
-    databasePath.setFile(argv[1]);
+    databasePath.setFile(databaseFile);
     ctkDICOMDatabase myCTK( databasePath.absoluteFilePath() );
 
-    if (!myCTK.initializeDatabase(argv[2]))
+    if (!myCTK.initializeDatabase(sqlFileName.toUtf8()))
       {
-      std::cerr << "Error when initializing the data base: " << argv[2]
-                << " error: " << myCTK.lastError().toStdString();
+      std::cerr << "Error when initializing the data base: " << qPrintable(sqlFileName)
+                << " error: " << qPrintable(myCTK.lastError()) << std::endl;
+      return EXIT_FAILURE;
       }
 
     ctkDICOMModel model;
@@ -62,7 +72,7 @@ int ctkDICOMThumbnailListWidgetTest1( int argc, char * argv [] )
     widget.addThumbnails(model.index(0,0));
     widget.show();
 
-    if (argc <= 3 || QString(argv[3]) != "-I")
+    if (!interactive)
       {
       QTimer::singleShot(200, &app, SLOT(quit()));
       }

--- a/Libs/Widgets/Testing/Cpp/ctkFileDialogTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkFileDialogTest1.cpp
@@ -87,10 +87,7 @@ int ctkFileDialogTest1(int argc, char * argv [] )
           {"I", "Run in interactive mode"},
           {"do-not-use-native-dialogs", "Do not use native dialogs"},
         });
-  parser.process(app);
-
-  QStringList arguments = app.arguments();
-  arguments.pop_front(); // remove application name
+  parser.process(app); // Automatically exit if there is a parsing error
 
   bool skipNativeDialogs = parser.isSet("do-not-use-native-dialogs");
   QApplication::setAttribute(Qt::AA_DontUseNativeDialogs, skipNativeDialogs);


### PR DESCRIPTION
* Update `ctkDICOMDatabaseTest2` to test use of lower and upper case tags
* Fix argument processing and usage message in ctkDICOM tests
* Support running tests using `dcmqrscp` in parallel
* Ensure DICOM tests all read/write from different sqlite database
* Update ctkDICOMTester to always kill "storescp" process on destruction