### PR TITLE
ENH: Always compile python scripts as legacy .pyc files

### DIFF
--- a/CMake/ctk_compile_python_scripts.cmake.in
+++ b/CMake/ctk_compile_python_scripts.cmake.in
@@ -60,7 +60,8 @@ def ctk_compile_file(fullname, ddir=None, force=0, rx=None, quiet=0):
             if not quiet:
                 print('Compiling', fullname, '...')
             try:
-                ok = py_compile.compile(fullname, None, dfile, True)
+                cfile = fullname + (__debug__ and 'c' or 'o')
+                ok = py_compile.compile(fullname, cfile, dfile, True)
             except py_compile.PyCompileError as err:
                 if quiet:
                     print('Compiling', fullname, '...')


### PR DESCRIPTION
Refine the script introduced in commit db3f4d99 ("Re-create python compile script only if needed and fix dependency. See #449", 2014-04-16) by explicitly specifying the `cfile` parameter. Disable the default behavior (introduced in Python 3.2) of generating .pyc files in the `__pycache__` directory, as outlined in PEP-3147.

This improvement is needed for Slicer-based applications, enabling them to locate scripted modules and plugins as either .py or .pyc files in a specific directory.

References:
* PEP-3147: https://peps.python.org/pep-3147/
* Slicer Forum Discussion: https://discourse.slicer.org/t/how-to-hide-the-code-of-the-script-module/26135/14
* Python Documentation: https://docs.python.org/3/library/py_compile.html#py_compile.compile