### PR TITLE
ENH: Update PythonQt backporting recent changes from `MeVisLab/pythonqt`

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -82,7 +82,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
 
   ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
   if(CTK_QT_VERSION VERSION_EQUAL "5")
-    set(revision_tag c4a5a155b2942d4b003862c3317105b4a1ea6755) # patched-9
+    set(revision_tag db525aff0d8c053bddf13902107b34c93c1e3a44) # patched-9
   else()
     message(FATAL_ERROR "Support for Qt${CTK_QT_VERSION} is not implemented")
   endif()


### PR DESCRIPTION
Meticulous backport of all recent changes introduced in https://github.com/MeVisLab/pythonqt/

Commit impacting only the PythonQt library are prefix with `[Backport]` the one impacting only the generator are prefixed with `[Backport generator]`.

List of PythonQt changes:

```
$ git shortlog c4a5a155b..db525aff0 --no-merges
Christophe Giboudeaux (1):
      [Backport] Fix build with Python 3.8

David Brooks (2):
      [Backport] Use `quote` characters around includes of our headers.
      [Backport] Support Qt 5.12

Felix Petriconi (4):
      [Backport generator] Also generate python function for operator!=()
      [Backport generator] Default initialize all members
      [Backport] Replace foreach macro with range based for loop
      [Backport generator] Remove __* and _Uppercase from symbols because they must not been used

Gregor Anich (2):
      [Backport] More potential leak fixes and build fix
      [Backport] Allow setting PYTHON_VERSION and PYTHON_DIR when including python.prf, add rpath

Iakov Kirilenko (2):
      [Backport] Use XSETREF for safety
      [Backport] CI for CONFIG+=debug + UbSan for tests

James Butler (1):
      Prevent crashes during and after cleanup

Jean-Christophe Fillion-Robin (1):
      [Backport] Remove unused variable from PythonQtPrivate::callMethodInPython

John Bowler (19):
      [Backport] Qt6: initial changes to make compilation work (#114)
      [Backport generator] Replace deprecated QAtomicPointer<T>::load() (#115)
      [Backport generator] Qt6: QList<T>operator== requires const T::operator== (#116)
      [Backport generator] Qt6: qSort and qStableSort removed (#117)
      [Backport generator] Qt6: qSort, toList and fromList removal (#118)
      [Backport generator] Qt6: QString::SkipEmptyParts moved to Qt (#119)
      [Backport generator] Qt6: QTextStream compatibility (#120)
      [Backport generator] Eliminate warnings about #warning (#122)
      [Backport generator] Qt6: generator/typesystem.cpp: XML workround (#123)
      [Backport generator] Add constexpr and decltype parsing (#125)
      [Backport generator] Handle constexpr, auto (#126)
      [Backport] Qt6: fixes for removal of Qt5 types (#127)
      [Backport generator] Fix problems in Qt5.11 generator (#128)
      [Backport generator] Use spaces instead of tabs (#129)
      [Backport generator] generator: remove anonymous structs (#121)
      [Backport generator] generator: call Reporthandler::setContext more (#131)
      [Backport generator] generator: AbstractMetaClassList: correct sorting (#132)
      [Backport generator] generator: fix iterator issues with Qt5.14 headers (#142)
      [Backport generator] Fix: AbstractMetaBuilder::classesTopologicalSorted (#148)

Richard Goedeken (1):
      [Backport] Qt6 compatibility fixes for core PythonQt library

Uwe Kindler (2):
      [Backport] Fixed mingw build issues
      [Backport] Fixed mingw64-build

Uwe Siems (90):
      [Backport] Loop did never finish if the first entry didn't match, fixes support for kwargs in slots.
      [Backport generator] Add default and copy constructor for QFontInfo and QFontMetrics
      [Backport generator] Avoid spaces at end of generated lines.
      [Backport] Make __enter__ and __exit__ slots work with "with" statements
      [Backport generator] Create correct __enter__ and __exit__ methods for QMutexLocker, QReadLocker, and QWriteLocker
      [Backport] Add a hint about QByteArray/bytes conversion, use fake footnote references.
      [Backport] Avoid crash for certain types that have no wrapper because they can't be instantiated
      [Backport] Fix a possible invalid memory access
      [Backport generator] QUrl::FormattingOptions flag arguments didn't work for Qt 5
      [Backport] Make this a proper C++ struct
      [Backport] Get rid of typedef struct completely, this is C++ code
      [Backport] Update __spec__ too (if existing) when setting the import path
      [Backport] Ignore some file types and directories
      [Backport] Generate modern C++ code with nullptr and override
      [Backport generator] Also consider interfaces of super classes (issue #75)
      [Backport generator] Add missing space in message
      [Backport generator] initialize members with list-initializers
      [Backport] Fix crash when converting Python list with None value to QVariant
      [Backport] Fix crash when using QObject::disconnect method (when multi-threading is enabled)
      [Backport] Limit string representation of argument list in length
      [Backport generator] add option to print parser errors when they occur
      [Backport generator] Keep track of current source code in Debug mode,
      [Backport] always ignore .vs folder
      [Backport generator] Don't interpret "= default" or "= delete" to mean this is an abstract method
      [Backport generator] Deleted methods need to marked as "invalid" to be handled correctly
      [Backport generator] Cover cases where noexcept comes with an expression
      [Backport generator] Implement and use Parser::skipFunctionBody
      [Backport generator] Simplify skipFunctionBody by only looking at curly braces
      [Backport generator] Avoid currently unsupported use of "noexcept(...)"
      [Backport generator] Ignore some more macros that lead to parser errors
      [Backport generator] Support basic new-style initializers
      [Backport generator] Add missing enum used as default value for a method
      [Backport generator] Automatically mark methods with r-value references (&&) as invalid
      [Backport generator] Don't create wrappers for cbegin and cend
      [Backport generator] Hopefully make generator immune against iterator order changes for typeMap
      [Backport generator] Don't generate wrappers for templated methods in non-template classes
      [Backport generator] Handle ellipsis in type parser
      [Backport generator] Improve debugging code for rewind, also show identifiers
      [Backport] Add qsizetype and qptrdiff as primitive types
      [Backport generator] Avoid crash if supposed property setter has no arguments
      [Backport generator] Avoid crash in lexer by increasing size of token_stream early
      [Backport generator] Make number of classes per generated file configurable
      [Backport generator] Add version qualifiers to typesystem XML files
      [Backport generator] Don't assume some Qt version if it could not be found/parsed
      [Backport] Correct initialization of return value pointer failed
      [Backport] Some types are aliases in Qt6 now
      [Backport] Comparison rules of QVariant have changed in Qt6
      [Backport generator] Better handling of "auto" and trailing return types "-> decltype()"
      [Backport generator] Better handling of variadic templates
      [Backport generator] Skip attribute specifiers like [[maybe_unused]]
      [Backport generator] Fix types being rejected because they contain "constexpr"
      [Backport generator] Handle "friend" functions with implementation body...
      [Backport generator] Treat constexpr as a function modifier, not as a type modifier
      [Backport generator] Treat noexcept inside of expressions
      [Backport generator] Fix expansion of variadic macros in preprocessor
      [Backport generator] Fix handling of elif in preprocessor...
      [Backport generator] Support for new-style initializers in expressions
      [Backport generator] Improve handling of new-style initializers
      [Backport generator] Improve type name handling
      [Backport generator] Make parsing more robust against shuffling of qualifiers/specifiers
      [Backport generator] Fix missing includes for namespace items from different files
      [Backport generator] Implement methods with lvalue/rvalue references, ...
      [Backport generator] Handle (templated) functions with packed parameters
      [Backport generator] Parse inline namespaces,
      [Backport generator] Parse string literal operator definition,
      [Backport generator] Some necessary defines for Qt6
      [Backport generator] Add some entries to typesystem files missing for Qt6
      [Backport generator] Add new multimedia classes
      [Backport generator] Automatically add enums marked with Q_ENUM to TypeDatabase
      [Backport generator] Fix uninitialized member
      [Backport generator] Some more defines we don't need to parse
      [Backport generator] Q_PROPERTY might contain "REVISION(1, 1)"
      [Backport generator] Improve parsing of Q_PROPERTY types starting with "const"
      [Backport generator] Rename "after-version" attribute to "since-version"
      [Backport generator] More missing or updated type entries
      [Backport generator] Handle enum classes
      [Backport generator] Complete/fix scope for enum class values
      [Backport generator] Remove figureOutEnumValues and company
      [Backport generator] Do not add copy constructor if it was deleted or private
      [Backport generator] QMutexLocker is a template now, don't know how to handle this
      [Backport generator] Fix handling of protected operators
      [Backport generator] Fix compiler warning (possibly unintended copy)
      [Backport generator] Fix QList::swap missing the template argument in the argument type
      [Backport generator] I believe it is not necessary to create a shell for QPagedPaintDevice
      [Backport] Try to fix library names and linking problems
      [Backport] Make PythonQtTests compile with Qt6
      [Backport generator] Do not prepend enum class name for items of enum classes,
      [Backport generator] Avoid emitting QStringList* arguments as QStringList<QString>*
      [Backport generator] Avoid some compiler warnings
      [Backport generator] Skip alignas specifier

Yuri Victorovich (1):
      [Backport] Fix install paths by adding INSTALL_PREFIX

YuriUfimtsev (4):
      [Backport generator] Add support for parsing enum class declarations
      [Backport generator] Add parsed enums and some more enums from warning messages to typesystem
      [Backport generator] Add a token consistency check between enum and array
      [Backport generator] Reduce memory leaks by implementing the AbstractMetaBuilder destructor

githubuser0xFFFF (1):
      [Backport] Provide missing implementation of PythonQtSlotInfo::getGlobalShouldAllowThreads() (#65)

iakov (5):
      [Backport] Fix memory leak
      [Backport] Add missing break in switch to fix P3K conversion
      [Backport] Several fixes and patches (#89)
      [Backport] Add support for Python 3.11 (#91)
      [Backport] Tiny improvements for build system

mrbean-bremen (21):
      [Backport] Add -std=c++11 flag to check for problems
      [Backport] Replace NULL with nullptr
      [Backport] Add override and noexcept modifiers
      [Backport] Fix type conversion warnings, use const
      [Backport] Avoid redefinition warnings, fix export macros
      [Backport] Add facility to set task done callback
      [Backport] Make sure queued connection of Signals with Python types are safe
      [Backport] Add missing GIL scope to single shot timer destructor
      [Backport] Add initial support for coroutines
      [Backport] Use ubuntu instead of gcc based images
      [Backport] Revert undefining some defines (#103)
      [Backport] Add back undefining _POSIX_C_SOURCE and _XOPEN_SOURCE (#106)
      [Backport generator] Make the generator compile with C++17
      [Backport generator] Add parsing of noexcept exception specifier
      [Backport generator] Add support for parsing using declarations
      [Backport generator] Fix parse error for function declaration
      [Backport] Bring back more Qt5 compatibility
      [Backport] More Qt5 compatibility changes
      [Backport] Bring back QRegExp and QMatrix for Qt5
      [Backport generator] Fix handling of right-shift as template bracket
      [Backport generator] Ignore variadic template parameters
```