### PR TITLE
BUG: Fix Qt designer crash at startup

### DIFF
--- a/Libs/Core/ctkJobScheduler.cpp
+++ b/Libs/Core/ctkJobScheduler.cpp
@@ -267,8 +267,6 @@ void ctkJobScheduler::waitForFinish(bool waitForPersistentJobs)
 void ctkJobScheduler::waitForDone(int msec)
 {
   Q_D(ctkJobScheduler);
-
-  QCoreApplication::processEvents();
   d->ThreadPool->waitForDone(msec);
 }
 

--- a/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
@@ -930,6 +930,7 @@ void ctkDICOMVisualBrowserWidgetPrivate::retrieveSeries()
   bool wait = true;
   while (wait)
     {
+    QCoreApplication::processEvents();
     this->Scheduler->waitForDone(300);
     wait = false;
     foreach (ctkDICOMSeriesItemWidget* seriesItemWidget, selectedSeriesWidgetsList)


### PR DESCRIPTION
One of the DICOM widgets crashed the Qt designer because ctkDICOMScheduler::~ctkDICOMScheduler() called ctkJobScheduler::waitForDone, and that method called processEvents(). After returning form processEvents() the application crashed because the "this" pointer has become invalid (probably the ctkDICOMScheduler object got deleted).

Solved the issue by removing processEvents() from ctkJobScheduler::waitForDone, and instead calling processEvents() before calling ctkJobScheduler::waitForDone.

@Punzo please have a look and feel free to suggest a better design.