### PR TITLE
visual dicom browser enhs and bugs fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 # Exclude QtCreator files ...
 CMakeLists.txt.user*
+CMakeCache.txt
+CMakeFiles/cmake.check_cache
 
 # ignore ctags file
 tags

--- a/Libs/Core/ctkAbstractJob.cpp
+++ b/Libs/Core/ctkAbstractJob.cpp
@@ -86,6 +86,23 @@ void ctkAbstractJob::setStatus(JobStatus status)
   {
     this->CompletionDateTime = QDateTime::currentDateTime();
   }
+
+  if (this->Status == JobStatus::Running)
+  {
+    emit this->started();
+  }
+  else if (this->Status == JobStatus::Stopped)
+  {
+    emit this->canceled();
+  }
+  else if (this->Status == JobStatus::Failed)
+  {
+    emit this->failed();
+  }
+  else if (this->Status == JobStatus::Finished)
+  {
+    emit this->finished();
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/Core/ctkAbstractJob.h
+++ b/Libs/Core/ctkAbstractJob.h
@@ -26,6 +26,7 @@
 
 // Qt includes
 #include <QDateTime>
+#include <QMetaEnum>
 #include <QObject>
 #include <QThread>
 #include <QVariant>
@@ -69,11 +70,18 @@ public:
 
   ///@{
   /// Status
+  /// Initialized: the object has been created and inserted in the JobsQueue map in the ctkJobScheduler
+  /// Queued: a worker is associated to the job and the worker has been inserted in the queue list of the QThreadPool (object owned by the ctkJobScheduler) with a priority
+  /// Running: the job is running in another thread by the associated worker.
+  /// Stopped: the job has been stopped externally (a cancel request from the worker)
+  /// Failed: the job failed internally (logic returns false).
+  /// Finished: the job has been run successfully (logic returns true).
   enum JobStatus {
     Initialized = 0,
     Queued,
     Running,
     Stopped,
+    Failed,
     Finished,
   };
   JobStatus status() const;
@@ -153,9 +161,9 @@ public:
 
 Q_SIGNALS:
   void started();
-  void finished();
   void canceled();
   void failed();
+  void finished();
 
 protected:
   QString JobUID;

--- a/Libs/Core/ctkAbstractWorker.cpp
+++ b/Libs/Core/ctkAbstractWorker.cpp
@@ -109,32 +109,29 @@ void ctkAbstractWorker::startNextJob()
 }
 
 //----------------------------------------------------------------------------
-void ctkAbstractWorker::onJobCanceled()
+void ctkAbstractWorker::onJobCanceled(const bool& wasCanceled)
 {
   if (!this->Job)
   {
     return;
   }
 
-  if (this->Job->retryCounter() < this->Job->maximumNumberOfRetry() &&
-      this->Job->status() != ctkAbstractJob::JobStatus::Stopped)
+  if (!wasCanceled)
   {
-    QTimer timer;
-    timer.setSingleShot(true);
-    QEventLoop loop;
-    connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
-    timer.start(this->Job->retryDelay());
+    if (this->Job->retryCounter() < this->Job->maximumNumberOfRetry())
+    {
+      QTimer timer;
+      timer.setSingleShot(true);
+      QEventLoop loop;
+      connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
+      timer.start(this->Job->retryDelay());
 
-    this->startNextJob();
-
-    emit this->Job->canceled();
-  }
-  else if (this->Job->status() != ctkAbstractJob::JobStatus::Stopped)
-  {
-    emit this->Job->failed();
+      this->startNextJob();
+    }
+    this->Job->setStatus(ctkAbstractJob::JobStatus::Failed);
   }
   else
   {
-    emit this->Job->canceled();
+    this->Job->setStatus(ctkAbstractJob::JobStatus::Stopped);
   }
 }

--- a/Libs/Core/ctkAbstractWorker.h
+++ b/Libs/Core/ctkAbstractWorker.h
@@ -25,6 +25,7 @@
 #define __ctkAbstractWorker_h
 
 // Qt includes
+#include <QMutex>
 #include <QRunnable>
 #include <QSharedPointer>
 
@@ -44,14 +45,15 @@ public:
   explicit ctkAbstractWorker();
   virtual ~ctkAbstractWorker();
 
-  /// Execute worker
+  /// Execute worker. This method is run by the QThreadPool and is thread safe
   virtual void run() = 0;
 
-  /// Cancel worker
-  virtual void cancel() = 0;
+  /// Cancel worker. This method is thread safe
+  virtual void requestCancel() = 0;
 
   ///@{
-  /// Job
+  /// Job.
+  /// These methods are not thread safe
   Q_INVOKABLE ctkAbstractJob* job() const;
   QSharedPointer<ctkAbstractJob> jobShared() const;
   Q_INVOKABLE void setJob(ctkAbstractJob& job);
@@ -60,6 +62,7 @@ public:
 
   ///@{
   /// Scheduler
+  /// These methods are not thread safe
   Q_INVOKABLE ctkJobScheduler* scheduler() const;
   QSharedPointer<ctkJobScheduler> schedulerShared() const;
   Q_INVOKABLE void setScheduler(ctkJobScheduler& scheduler);
@@ -67,8 +70,9 @@ public:
   ///@}
 
 public slots:
+  /// These slots are thread safe
   virtual void startNextJob();
-  virtual void onJobCanceled();
+  virtual void onJobCanceled(const bool& wasCanceled);
 
 protected:
   QSharedPointer<ctkAbstractJob> Job;

--- a/Libs/Core/ctkJobScheduler.h
+++ b/Libs/Core/ctkJobScheduler.h
@@ -79,7 +79,7 @@ public:
 
   ///@{
   /// Maximum number of concurrent QThreads spawned by the threadPool in the Job pool
-  /// default: 10
+  /// default: 20
   int maximumThreadCount() const;
   void setMaximumThreadCount(int maximumThreadCount);
   ///@}

--- a/Libs/Core/ctkJobScheduler.h
+++ b/Libs/Core/ctkJobScheduler.h
@@ -40,6 +40,11 @@ class ctkJobSchedulerPrivate;
 class CTK_CORE_EXPORT ctkJobScheduler : public QObject
 {
   Q_OBJECT
+  Q_PROPERTY(int freezeJobsScheduling READ freezeJobsScheduling WRITE setFreezeJobsScheduling);
+  Q_PROPERTY(int maximumThreadCount READ maximumThreadCount WRITE setMaximumThreadCount);
+  Q_PROPERTY(int maximumNumberOfRetry READ maximumNumberOfRetry WRITE setMaximumNumberOfRetry);
+  Q_PROPERTY(int retryDelay READ retryDelay WRITE setRetryDelay);
+
 public:
   typedef QObject Superclass;
   explicit ctkJobScheduler(QObject* parent = 0);
@@ -59,14 +64,22 @@ public:
   Q_INVOKABLE ctkAbstractJob* getJobByUID(const QString& jobUID);
 
   Q_INVOKABLE void waitForFinish(bool waitForPersistentJobs = false);
-  Q_INVOKABLE void waitForDone(int msec);
+  Q_INVOKABLE void waitForDone(int msec = -1);
 
   Q_INVOKABLE void stopAllJobs(bool stopPersistentJobs = false);
+  Q_INVOKABLE void stopJobsByJobUIDs(const QStringList& jobUIDs);
+  ///@}
+
+  ///@{
+  /// if set to true, new jobs will not be queued
+  /// default: false
+  bool freezeJobsScheduling() const;
+  void setFreezeJobsScheduling(bool freezeJobsScheduling);
   ///@}
 
   ///@{
   /// Maximum number of concurrent QThreads spawned by the threadPool in the Job pool
-  /// default: 20
+  /// default: 10
   int maximumThreadCount() const;
   void setMaximumThreadCount(int maximumThreadCount);
   ///@}
@@ -93,12 +106,12 @@ public:
   QSharedPointer<QThreadPool> threadPoolShared() const;
 
 Q_SIGNALS:
+  void jobInitialized(QVariant data);
   void jobQueued(QVariant data);
   void jobStarted(QVariant data);
   void jobFinished(QVariant data);
   void jobCanceled(QVariant data);
   void jobFailed(QVariant data);
-  void queueJobs();
   void progressJobDetail(QVariant data);
 
 public Q_SLOTS:
@@ -106,7 +119,6 @@ public Q_SLOTS:
   virtual void onJobFinished();
   virtual void onJobCanceled();
   virtual void onJobFailed();
-  virtual void onQueueJobsInThreadPool();
 
 protected:
   QScopedPointer<ctkJobSchedulerPrivate> d_ptr;

--- a/Libs/Core/ctkJobScheduler_p.h
+++ b/Libs/Core/ctkJobScheduler_p.h
@@ -43,6 +43,12 @@ class CTK_CORE_EXPORT ctkJobSchedulerPrivate : public QObject
 protected:
   ctkJobScheduler* const q_ptr;
 
+Q_SIGNALS:
+  void queueJobs();
+
+public Q_SLOTS:
+  virtual void onQueueJobsInThreadPool();
+
 public:
   ctkJobSchedulerPrivate(ctkJobScheduler& object);
   virtual ~ctkJobSchedulerPrivate();
@@ -50,15 +56,17 @@ public:
   /// Convenient setup methods
   virtual void init();
 
-  virtual void insertJob(QSharedPointer<ctkAbstractJob> job);
-  virtual void removeJob(const QString& jobUID);
+  virtual bool insertJob(QSharedPointer<ctkAbstractJob> job);
+  virtual bool removeJob(const QString& jobUID);
+  virtual void removeJobs(const QStringList& jobUIDs);
   int getSameTypeJobsInThreadPoolQueueOrRunning(QSharedPointer<ctkAbstractJob> job);
   QString generateUniqueJobUID();
 
-  QMutex mMutex;
+  QMutex QueueMutex;
 
   int RetryDelay{100};
   int MaximumNumberOfRetry{3};
+  bool FreezeJobsScheduling{false};
 
   QSharedPointer<QThreadPool> ThreadPool;
   QMap<QString, QSharedPointer<ctkAbstractJob>> JobsQueue;

--- a/Libs/DICOM/Core/ctkDICOMCorePythonQtDecorators.h
+++ b/Libs/DICOM/Core/ctkDICOMCorePythonQtDecorators.h
@@ -27,6 +27,7 @@
 // CTK includes
 #include <ctkDICOMDisplayedFieldGeneratorRuleFactory.h>
 #include <ctkDICOMUtil.h>
+#include <ctkDICOMJob.h>
 #include <ctkDICOMJobResponseSet.h>
 
 // NOTE:
@@ -55,17 +56,53 @@ public slots:
   // ctkDICOMJobDetail
   //----------------------------------------------------------------------------
   ctkDICOMJobDetail* new_ctkDICOMJobDetail()
-{
+  {
     return new ctkDICOMJobDetail();
-}
-
-  void setJobType(ctkDICOMJobDetail* td, ctkDICOMJobResponseSet::JobType jobType)
-  {
-    td->JobType = jobType;
   }
-  ctkDICOMJobResponseSet::JobType jobType(ctkDICOMJobDetail* td)
+
+  void setJobClass(ctkDICOMJobDetail* td, QString jobClass)
   {
-    return td->JobType;
+    td->JobClass = jobClass;
+  }
+  QString jobClass(ctkDICOMJobDetail* td)
+  {
+    return td->JobClass;
+  }
+
+  void setJobUID(ctkDICOMJobDetail* td, QString jobUID)
+  {
+    td->JobUID = jobUID;
+  }
+  QString jobUID(ctkDICOMJobDetail* td)
+  {
+    return td->JobUID;
+  }
+
+  void setCreationDateTime(ctkDICOMJobDetail* td, QString creationDateTime)
+  {
+    td->CreationDateTime = creationDateTime;
+  }
+  QString creationDateTime(ctkDICOMJobDetail* td)
+  {
+    return td->CreationDateTime;
+  }
+
+  void setStartDateTime(ctkDICOMJobDetail* td, QString startDateTime)
+  {
+    td->StartDateTime = startDateTime;
+  }
+  QString startDateTime(ctkDICOMJobDetail* td)
+  {
+    return td->StartDateTime;
+  }
+
+  void setCompletionDateTime(ctkDICOMJobDetail* td, QString completionDateTime)
+  {
+    td->CompletionDateTime = completionDateTime;
+  }
+  QString completionDateTime(ctkDICOMJobDetail* td)
+  {
+    return td->CompletionDateTime;
   }
 
   void setPatientID(ctkDICOMJobDetail* td, const QString& patientID)
@@ -104,6 +141,15 @@ public slots:
     return td->SOPInstanceUID;
   }
 
+  void setReferenceInserterJobUID(ctkDICOMJobDetail* td, const QString& referenceInserterJobUID)
+  {
+    td->ReferenceInserterJobUID = referenceInserterJobUID;
+  }
+  QString referenceInserterJobUID(ctkDICOMJobDetail* td)
+  {
+    return td->ReferenceInserterJobUID;
+  }
+
   void setConnectionName(ctkDICOMJobDetail* td, const QString& connectionName)
   {
     td->ConnectionName = connectionName;
@@ -111,6 +157,24 @@ public slots:
   QString connectionName(ctkDICOMJobDetail* td)
   {
     return td->ConnectionName;
+  }
+
+  void setDICOMLevel(ctkDICOMJobDetail* td, ctkDICOMJob::DICOMLevels level)
+  {
+    td->DICOMLevel = level;
+  }
+  ctkDICOMJob::DICOMLevels DICOMLevel(ctkDICOMJobDetail* td)
+  {
+    return td->DICOMLevel;
+  }
+
+  void setJobType(ctkDICOMJobDetail* td, ctkDICOMJobResponseSet::JobType jobType)
+  {
+    td->JobType = jobType;
+  }
+  ctkDICOMJobResponseSet::JobType jobType(ctkDICOMJobDetail* td)
+  {
+    return td->JobType;
   }
 
   void setNumberOfDataSets(ctkDICOMJobDetail* td, int numberOfDataSets)

--- a/Libs/DICOM/Core/ctkDICOMEcho.cpp
+++ b/Libs/DICOM/Core/ctkDICOMEcho.cpp
@@ -48,7 +48,7 @@ public:
   QString CalledAETitle;
   QString Host;
   int Port;
-  DcmSCU SCU;
+  DcmSCU *SCU;
 };
 
 //------------------------------------------------------------------------------
@@ -63,8 +63,9 @@ ctkDICOMEchoPrivate::ctkDICOMEchoPrivate()
   this->Host = "";
   this->Port = 80;
 
-  this->SCU.setACSETimeout(3);
-  this->SCU.setConnectionTimeout(3);
+  this->SCU = new DcmSCU();
+  this->SCU->setACSETimeout(3);
+  this->SCU->setConnectionTimeout(3);
 }
 
 //------------------------------------------------------------------------------
@@ -77,7 +78,7 @@ ctkDICOMEcho::ctkDICOMEcho(QObject* parentObject)
 {
   Q_D(ctkDICOMEcho);
 
-  d->SCU.setVerbosePCMode(false);
+  d->SCU->setVerbosePCMode(false);
 }
 
 //------------------------------------------------------------------------------
@@ -157,15 +158,15 @@ int ctkDICOMEcho::port() const
 void ctkDICOMEcho::setConnectionTimeout(int timeout)
 {
   Q_D(ctkDICOMEcho);
-  d->SCU.setACSETimeout(timeout);
-  d->SCU.setConnectionTimeout(timeout);
+  d->SCU->setACSETimeout(timeout);
+  d->SCU->setConnectionTimeout(timeout);
 }
 
 //-----------------------------------------------------------------------------
 int ctkDICOMEcho::connectionTimeout() const
 {
   Q_D(const ctkDICOMEcho);
-  return d->SCU.getConnectionTimeout();
+  return d->SCU->getConnectionTimeout();
 }
 
 //------------------------------------------------------------------------------
@@ -173,9 +174,9 @@ bool ctkDICOMEcho::echo()
 {
   Q_D(ctkDICOMEcho);
 
-  d->SCU.setPeerAETitle(OFString(this->calledAETitle().toStdString().c_str()));
-  d->SCU.setPeerHostName(OFString(this->host().toStdString().c_str()));
-  d->SCU.setPeerPort(this->port());
+  d->SCU->setPeerAETitle(OFString(this->calledAETitle().toStdString().c_str()));
+  d->SCU->setPeerHostName(OFString(this->host().toStdString().c_str()));
+  d->SCU->setPeerPort(this->port());
 
   logger.debug("Setting Transfer Syntaxes");
 
@@ -184,15 +185,15 @@ bool ctkDICOMEcho::echo()
   transferSyntaxes.push_back(UID_BigEndianExplicitTransferSyntax);
   transferSyntaxes.push_back(UID_LittleEndianImplicitTransferSyntax);
 
-  d->SCU.addPresentationContext(UID_VerificationSOPClass, transferSyntaxes);
-  if (!d->SCU.initNetwork().good())
+  d->SCU->addPresentationContext(UID_VerificationSOPClass, transferSyntaxes);
+  if (!d->SCU->initNetwork().good())
   {
     logger.error("Error initializing the network");
     return false;
   }
   logger.debug("Negotiating Association");
 
-  OFCondition result = d->SCU.negotiateAssociation();
+  OFCondition result = d->SCU->negotiateAssociation();
   if (result.bad())
   {
     logger.error("Error negotiating the association: " + QString(result.text()));
@@ -201,26 +202,15 @@ bool ctkDICOMEcho::echo()
 
   logger.info("Seding Echo");
   // Issue ECHO request and let scu find presentation context itself (0)
-  OFCondition status = d->SCU.sendECHORequest(0);
+  OFCondition status = d->SCU->sendECHORequest(0);
   if (!status.good())
   {
     logger.error("Echo failed");
-    d->SCU.releaseAssociation();
+    d->SCU->releaseAssociation();
     return false;
   }
 
-  d->SCU.releaseAssociation();
+  d->SCU->releaseAssociation();
 
   return true;
-}
-
-//------------------------------------------------------------------------------
-void ctkDICOMEcho::cancel()
-{
-  Q_D(ctkDICOMEcho);
-
-  if (d->SCU.isConnected())
-  {
-    d->SCU.releaseAssociation();
-  }
 }

--- a/Libs/DICOM/Core/ctkDICOMEcho.h
+++ b/Libs/DICOM/Core/ctkDICOMEcho.h
@@ -89,9 +89,6 @@ public:
   /// Echo connection.
   Q_INVOKABLE bool echo();
 
-  /// Cancel the current operation
-  Q_INVOKABLE void cancel();
-
 protected:
   QScopedPointer<ctkDICOMEchoPrivate> d_ptr;
 

--- a/Libs/DICOM/Core/ctkDICOMInserterJob.cpp
+++ b/Libs/DICOM/Core/ctkDICOMInserterJob.cpp
@@ -116,3 +116,9 @@ ctkAbstractWorker* ctkDICOMInserterJob::createWorker()
   worker->setJob(*this);
   return worker;
 }
+
+//------------------------------------------------------------------------------
+ctkDICOMJobResponseSet::JobType ctkDICOMInserterJob::getJobType() const
+{
+  return ctkDICOMJobResponseSet::JobType::Inserter;
+}

--- a/Libs/DICOM/Core/ctkDICOMInserterJob.h
+++ b/Libs/DICOM/Core/ctkDICOMInserterJob.h
@@ -76,6 +76,9 @@ public:
   /// Generate worker for job
   Q_INVOKABLE ctkAbstractWorker* createWorker() override;
 
+  /// Return job type.
+  Q_INVOKABLE virtual ctkDICOMJobResponseSet::JobType getJobType() const override;
+
 protected:
   QString DatabaseFilename;
   QStringList TagsToPrecache;

--- a/Libs/DICOM/Core/ctkDICOMInserterWorker.cpp
+++ b/Libs/DICOM/Core/ctkDICOMInserterWorker.cpp
@@ -83,7 +83,7 @@ ctkDICOMInserterWorker::ctkDICOMInserterWorker(ctkDICOMInserterWorkerPrivate* pi
 ctkDICOMInserterWorker::~ctkDICOMInserterWorker() = default;
 
 //----------------------------------------------------------------------------
-void ctkDICOMInserterWorker::cancel()
+void ctkDICOMInserterWorker::requestCancel()
 {
   Q_D(const ctkDICOMInserterWorker);
   d->Inserter->cancel();
@@ -100,14 +100,13 @@ void ctkDICOMInserterWorker::run()
     return;
   }
 
-  if (inserterJob->status() == ctkAbstractJob::JobStatus::Stopped)
+  if (d->Inserter->wasCanceled())
   {
-    this->onJobCanceled();
+    this->onJobCanceled(d->Inserter->wasCanceled());
     return;
   }
 
   inserterJob->setStatus(ctkAbstractJob::JobStatus::Running);
-  emit inserterJob->started();
 
   logger.debug(QString("ctkDICOMInserterWorker : running job %1 in thread %2.\n")
                        .arg(inserterJob->jobUID())
@@ -116,9 +115,9 @@ void ctkDICOMInserterWorker::run()
   QList<QSharedPointer<ctkDICOMJobResponseSet>> jobResponseSets = inserterJob->jobResponseSetsShared();
   d->Inserter->addJobResponseSets(jobResponseSets);
 
-  if (inserterJob->status() == ctkAbstractJob::JobStatus::Stopped)
+  if (d->Inserter->wasCanceled())
   {
-    this->onJobCanceled();
+    this->onJobCanceled(d->Inserter->wasCanceled());
     return;
   }
 
@@ -128,7 +127,6 @@ void ctkDICOMInserterWorker::run()
   }
 
   inserterJob->setStatus(ctkAbstractJob::JobStatus::Finished);
-  emit inserterJob->finished();
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/DICOM/Core/ctkDICOMInserterWorker.h
+++ b/Libs/DICOM/Core/ctkDICOMInserterWorker.h
@@ -44,18 +44,20 @@ public:
   explicit ctkDICOMInserterWorker();
   virtual ~ctkDICOMInserterWorker();
 
-  /// Execute worker
+  /// Execute worker. This method is run by the QThreadPool and is thread safe
   void run() override;
 
-  /// Cancel worker
-  void cancel() override;
+  /// Cancel worker. This method is thread safe
+  void requestCancel() override;
 
-  /// Job
+  /// Job.
+  /// These methods are not thread safe
   void setJob(QSharedPointer<ctkAbstractJob> job) override;
   using ctkAbstractWorker::setJob;
 
   ///@{
-  /// Inserter
+  /// Inserter.
+  /// These methods are not thread safe
   QSharedPointer<ctkDICOMInserter> inserterShared() const;
   Q_INVOKABLE ctkDICOMInserter* inserter() const;
   ///@}

--- a/Libs/DICOM/Core/ctkDICOMJob.cpp
+++ b/Libs/DICOM/Core/ctkDICOMJob.cpp
@@ -41,6 +41,7 @@ ctkDICOMJob::ctkDICOMJob()
   this->StudyInstanceUID = "";
   this->SeriesInstanceUID = "";
   this->SOPInstanceUID = "";
+  this->ReferenceInserterJobUID = "";
 }
 
 //------------------------------------------------------------------------------
@@ -107,6 +108,18 @@ QString ctkDICOMJob::sopInstanceUID() const
 }
 
 //----------------------------------------------------------------------------
+void ctkDICOMJob::setReferenceInserterJobUID(const QString &referenceInserterJobUID)
+{
+  this->ReferenceInserterJobUID = referenceInserterJobUID;
+}
+
+//----------------------------------------------------------------------------
+QString ctkDICOMJob::referenceInserterJobUID() const
+{
+  return this->ReferenceInserterJobUID;
+}
+
+//----------------------------------------------------------------------------
 static void skipDelete(QObject* obj)
 {
   Q_UNUSED(obj);
@@ -158,6 +171,12 @@ void ctkDICOMJob::copyJobResponseSets(const QList<QSharedPointer<ctkDICOMJobResp
       QSharedPointer<ctkDICOMJobResponseSet>(jobResponseSet->clone());
     this->JobResponseSets.append(jobResponseSetCopy);
   }
+}
+
+//------------------------------------------------------------------------------
+ctkDICOMJobResponseSet::JobType ctkDICOMJob::getJobType() const
+{
+  return ctkDICOMJobResponseSet::JobType::None;
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Core/ctkDICOMJobResponseSet.cpp
+++ b/Libs/DICOM/Core/ctkDICOMJobResponseSet.cpp
@@ -26,6 +26,7 @@
 
 // ctkDICOMCore includes
 #include "ctkDICOMItem.h"
+#include "ctkDICOMJob.h"
 #include "ctkDICOMJobResponseSet.h"
 
 // DCMTK includes

--- a/Libs/DICOM/Core/ctkDICOMJobResponseSet.h
+++ b/Libs/DICOM/Core/ctkDICOMJobResponseSet.h
@@ -31,7 +31,6 @@
 
 // ctkDICOMCore includes
 #include "ctkDICOMCoreExport.h"
-#include "ctkDICOMJob.h"
 #include "ctkDICOMItem.h"
 
 class ctkDICOMJobResponseSetPrivate;
@@ -88,7 +87,8 @@ public:
     RetrieveStudy,
     RetrieveSeries,
     RetrieveSOPInstance,
-    StoreSOPInstance
+    StoreSOPInstance,
+    Inserter
   };
   void setJobType(JobType jobType);
   JobType jobType() const;
@@ -156,55 +156,5 @@ private:
   Q_DECLARE_PRIVATE(ctkDICOMJobResponseSet);
   Q_DISABLE_COPY(ctkDICOMJobResponseSet);
 };
-
-//------------------------------------------------------------------------------
-struct CTK_DICOM_CORE_EXPORT ctkDICOMJobDetail : ctkJobDetail
-{
-  explicit ctkDICOMJobDetail() = default;
-
-  explicit ctkDICOMJobDetail(const ctkDICOMJob& job) : ctkJobDetail(job)
-  {
-    this->DICOMLevel = job.dicomLevel();
-    this->PatientID = job.patientID();
-    this->StudyInstanceUID = job.studyInstanceUID();
-    this->SeriesInstanceUID = job.seriesInstanceUID();
-    this->SOPInstanceUID = job.sopInstanceUID();
-  }
-
-  explicit ctkDICOMJobDetail(const ctkDICOMJob& job, const QString& connectionName)
-    : ctkDICOMJobDetail(job)
-  {
-    this->ConnectionName = connectionName;
-  }
-
-  explicit ctkDICOMJobDetail(const ctkDICOMJobResponseSet& responseSet)
-  {
-    this->JobUID = responseSet.jobUID();
-    this->JobType = responseSet.jobType();
-    this->PatientID = responseSet.patientID();
-    this->StudyInstanceUID = responseSet.studyInstanceUID();
-    this->SeriesInstanceUID = responseSet.seriesInstanceUID();
-    this->SOPInstanceUID = responseSet.sopInstanceUID();
-    this->ConnectionName = responseSet.connectionName();
-    this->NumberOfDataSets = responseSet.datasets().count();
-  }
-  virtual ~ctkDICOMJobDetail() = default;
-
-  QString PatientID;
-  QString StudyInstanceUID;
-  QString SeriesInstanceUID;
-  QString SOPInstanceUID;
-
-  // Common to DICOM Query and Retrieve jobs, and DICOM JobResponseSet
-  QString ConnectionName;
-
-  // Specific to DICOM Query and Retrieve jobs
-  ctkDICOMJob::DICOMLevels DICOMLevel{ctkDICOMJob::DICOMLevels::Patients};
-
-  // Specific to DICOM JobResponseSet
-  ctkDICOMJobResponseSet::JobType JobType{ctkDICOMJobResponseSet::JobType::None};
-  int NumberOfDataSets{0};
-};
-Q_DECLARE_METATYPE(ctkDICOMJobDetail);
 
 #endif

--- a/Libs/DICOM/Core/ctkDICOMQueryJob.h
+++ b/Libs/DICOM/Core/ctkDICOMQueryJob.h
@@ -81,9 +81,7 @@ public:
   ///@{
   /// Server
   Q_INVOKABLE ctkDICOMServer* server() const;
-  QSharedPointer<ctkDICOMServer> serverShared() const;
-  Q_INVOKABLE void setServer(ctkDICOMServer& server);
-  void setServer(QSharedPointer<ctkDICOMServer> server);
+  Q_INVOKABLE void setServer(const ctkDICOMServer& server);
   ///@}
 
   /// Logger report string formatting for specific task
@@ -101,6 +99,9 @@ public:
   /// information between threads using Qt signals.
   /// \sa ctkDICOMJobDetail
   Q_INVOKABLE virtual QVariant toVariant() override;
+
+  /// Return job type.
+  Q_INVOKABLE virtual ctkDICOMJobResponseSet::JobType getJobType() const override;
 
 protected:
   QScopedPointer<ctkDICOMQueryJobPrivate> d_ptr;

--- a/Libs/DICOM/Core/ctkDICOMQueryJob_p.h
+++ b/Libs/DICOM/Core/ctkDICOMQueryJob_p.h
@@ -45,7 +45,7 @@ public:
   ctkDICOMQueryJobPrivate(ctkDICOMQueryJob* object);
   virtual ~ctkDICOMQueryJobPrivate();
 
-  QSharedPointer<ctkDICOMServer> Server;
+  ctkDICOMServer* Server;
   QMap<QString, QVariant> Filters;
   int MaximumPatientsQuery;
 };

--- a/Libs/DICOM/Core/ctkDICOMQueryWorker.h
+++ b/Libs/DICOM/Core/ctkDICOMQueryWorker.h
@@ -45,18 +45,20 @@ public:
   explicit ctkDICOMQueryWorker();
   virtual ~ctkDICOMQueryWorker();
 
-  /// Execute worker
+  /// Execute worker. This method is run by the QThreadPool and is thread safe
   void run() override;
 
-  /// Cancel worker
-  void cancel() override;
+  /// Cancel worker. This method is thread safe
+  void requestCancel() override;
 
-  /// Job
+  /// Job.
+  /// These methods are not thread safe
   void setJob(QSharedPointer<ctkAbstractJob> job) override;
   using ctkAbstractWorker::setJob;
 
   ///@{
-  /// Querier
+  /// Querier.
+  /// These methods are not thread safe
   QSharedPointer<ctkDICOMQuery> querierShared() const;
   Q_INVOKABLE ctkDICOMQuery* querier() const;
   ///@}

--- a/Libs/DICOM/Core/ctkDICOMRetrieveJob.h
+++ b/Libs/DICOM/Core/ctkDICOMRetrieveJob.h
@@ -50,9 +50,7 @@ public:
   ///@{
   /// Server
   Q_INVOKABLE ctkDICOMServer* server() const;
-  QSharedPointer<ctkDICOMServer> serverShared() const;
-  Q_INVOKABLE void setServer(ctkDICOMServer& server);
-  void setServer(QSharedPointer<ctkDICOMServer> server);
+  Q_INVOKABLE void setServer(const ctkDICOMServer& server);
   ///@}
 
   /// Logger report string formatting for specific task
@@ -70,6 +68,9 @@ public:
   /// information between threads using Qt signals.
   /// \sa ctkDICOMJobDetail
   Q_INVOKABLE virtual QVariant toVariant() override;
+
+  /// Return job type.
+  Q_INVOKABLE virtual ctkDICOMJobResponseSet::JobType getJobType() const override;
 
 protected:
   QScopedPointer<ctkDICOMRetrieveJobPrivate> d_ptr;

--- a/Libs/DICOM/Core/ctkDICOMRetrieveJob_p.h
+++ b/Libs/DICOM/Core/ctkDICOMRetrieveJob_p.h
@@ -45,7 +45,7 @@ public:
   ctkDICOMRetrieveJobPrivate(ctkDICOMRetrieveJob* object);
   virtual ~ctkDICOMRetrieveJobPrivate();
 
-  QSharedPointer<ctkDICOMServer> Server;
+  ctkDICOMServer* Server;
 };
 
 #endif

--- a/Libs/DICOM/Core/ctkDICOMRetrieveWorker.h
+++ b/Libs/DICOM/Core/ctkDICOMRetrieveWorker.h
@@ -44,18 +44,20 @@ public:
   explicit ctkDICOMRetrieveWorker();
   virtual ~ctkDICOMRetrieveWorker();
 
-  /// Execute worker
+  /// Execute worker. This method is run by the QThreadPool and is thread safe
   void run() override;
 
-  /// Cancel worker
-  void cancel() override;
+  /// Cancel worker. This method is thread safe
+  void requestCancel() override;
 
-  /// Job
+  /// Job.
+  /// These methods are not thread safe
   void setJob(QSharedPointer<ctkAbstractJob> job) override;
   using ctkAbstractWorker::setJob;
 
   ///@{
-  /// Retriever
+  /// Retriever.
+  /// These methods are not thread safe
   QSharedPointer<ctkDICOMRetrieve> retrieverShared() const;
   Q_INVOKABLE ctkDICOMRetrieve* retriever() const;
   ///@}

--- a/Libs/DICOM/Core/ctkDICOMScheduler.cpp
+++ b/Libs/DICOM/Core/ctkDICOMScheduler.cpp
@@ -561,7 +561,7 @@ void ctkDICOMScheduler::waitForFinishByDICOMUIDs(const QStringList& patientIDs,
     return;
   }
 
-  d->QueueMutex.tryLock();
+  d->QueueMutex.lock();
   bool wait = true;
   while (wait)
   {
@@ -633,7 +633,7 @@ QList<QSharedPointer<ctkAbstractJob>> ctkDICOMScheduler::getJobsByDICOMUIDs(cons
     return jobs;
   }
 
-  d->QueueMutex.tryLock();
+  d->QueueMutex.lock();
   foreach (QSharedPointer<ctkAbstractJob> job, d->JobsQueue)
   {
     if (!job)
@@ -691,7 +691,7 @@ void ctkDICOMScheduler::stopJobsByDICOMUIDs(const QStringList& patientIDs,
   }
 
   QStringList jobsUIDs;
-  d->QueueMutex.tryLock();
+  d->QueueMutex.lock();
   // Stops jobs without a worker (in waiting, still in main thread)
   foreach (QSharedPointer<ctkAbstractJob> job, d->JobsQueue)
   {
@@ -790,7 +790,7 @@ void ctkDICOMScheduler::raiseJobsPriorityForSeries(const QStringList& selectedSe
     return;
   }
 
-  d->QueueMutex.tryLock();
+  d->QueueMutex.lock();
   foreach (QSharedPointer<ctkAbstractJob> job, d->JobsQueue)
   {
     if (job->isPersistent())
@@ -834,7 +834,7 @@ ctkDICOMStorageListenerJob* ctkDICOMScheduler::listenerJob()
 {
   Q_D(ctkDICOMScheduler);
   ctkDICOMStorageListenerJob* listenerJobRaw = nullptr;
-  d->QueueMutex.tryLock();
+  d->QueueMutex.lock();
   foreach (QSharedPointer<ctkAbstractJob> job, d->JobsQueue)
   {
     QSharedPointer<ctkDICOMStorageListenerJob> listenerJob =

--- a/Libs/DICOM/Core/ctkDICOMScheduler.h
+++ b/Libs/DICOM/Core/ctkDICOMScheduler.h
@@ -46,9 +46,6 @@ struct ctkDICOMJobDetail;
 class CTK_DICOM_CORE_EXPORT ctkDICOMScheduler : public ctkJobScheduler
 {
   Q_OBJECT
-  Q_PROPERTY(int maximumThreadCount READ maximumThreadCount WRITE setMaximumThreadCount);
-  Q_PROPERTY(int maximumNumberOfRetry READ maximumNumberOfRetry WRITE setMaximumNumberOfRetry);
-  Q_PROPERTY(int retryDelay READ retryDelay WRITE setRetryDelay);
   Q_PROPERTY(int maximumPatientsQuery READ maximumPatientsQuery WRITE setMaximumPatientsQuery);
 
 public:
@@ -106,10 +103,10 @@ public:
 
   ///@{
   /// Insert results from a job
-  void insertJobResponseSet(const QSharedPointer<ctkDICOMJobResponseSet>& jobResponseSet,
-                            QThread::Priority priority = QThread::HighPriority);
-  void insertJobResponseSets(const QList<QSharedPointer<ctkDICOMJobResponseSet>>& jobResponseSets,
-                             QThread::Priority priority = QThread::HighPriority);
+  QString insertJobResponseSet(const QSharedPointer<ctkDICOMJobResponseSet>& jobResponseSet,
+                               QThread::Priority priority = QThread::HighPriority);
+  QString insertJobResponseSets(const QList<QSharedPointer<ctkDICOMJobResponseSet>>& jobResponseSets,
+                                QThread::Priority priority = QThread::HighPriority);
   ///@}
 
   /// Return the Dicom Database.
@@ -163,7 +160,6 @@ public:
 
   ///@{
   /// Jobs managment
-  /// NOTE: methods ...ByDICOMUIDs accept only one list at the time
   Q_INVOKABLE void waitForFinishByDICOMUIDs(const QStringList& patientIDs = {},
                                             const QStringList& studyInstanceUIDs = {},
                                             const QStringList& seriesInstanceUIDs = {},
@@ -176,7 +172,7 @@ public:
                                                                        const QStringList& studyInstanceUIDs = {},
                                                                        const QStringList& seriesInstanceUIDs = {},
                                                                        const QStringList& sopInstanceUIDs = {});
-  Q_INVOKABLE void stopJobsByJobUIDs(const QStringList& jobUIDs);
+
   Q_INVOKABLE void runJobs(const QMap<QString, ctkDICOMJobDetail>& jobDetails);
   Q_INVOKABLE void raiseJobsPriorityForSeries(const QStringList& selectedSeriesInstanceUIDs,
                                               QThread::Priority priority = QThread::HighestPriority);

--- a/Libs/DICOM/Core/ctkDICOMServer.cpp
+++ b/Libs/DICOM/Core/ctkDICOMServer.cpp
@@ -43,7 +43,7 @@ protected:
 
 public:
   ctkDICOMServerPrivate(ctkDICOMServer& obj);
-  ~ctkDICOMServerPrivate() = default;
+  ~ctkDICOMServerPrivate();
 
   QString ConnectionName;
   bool QueryRetrieveEnabled;
@@ -56,7 +56,7 @@ public:
   bool KeepAssociationOpen;
   QString MoveDestinationAETitle;
   int ConnectionTimeout;
-  QSharedPointer<ctkDICOMServer> ProxyServer;
+  ctkDICOMServer* ProxyServer;
 };
 
 //------------------------------------------------------------------------------
@@ -78,6 +78,16 @@ ctkDICOMServerPrivate::ctkDICOMServerPrivate(ctkDICOMServer& obj)
   this->Port = 80;
   this->RetrieveProtocol = ctkDICOMServer::RetrieveProtocol::CGET;
   this->ProxyServer = nullptr;
+}
+
+//------------------------------------------------------------------------------
+ctkDICOMServerPrivate::~ctkDICOMServerPrivate()
+{
+  if (this->ProxyServer)
+    {
+    delete this->ProxyServer;
+    this->ProxyServer = nullptr;
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -265,65 +275,66 @@ QString ctkDICOMServer::moveDestinationAETitle() const
 }
 
 //------------------------------------------------------------------------------
-void ctkDICOMServer::setKeepAssociationOpen(bool keepOpen)
+void ctkDICOMServer::setKeepAssociationOpen(const bool& keepOpen)
 {
   Q_D(ctkDICOMServer);
   d->KeepAssociationOpen = keepOpen;
 }
 
 //------------------------------------------------------------------------------
-bool ctkDICOMServer::keepAssociationOpen()
+bool ctkDICOMServer::keepAssociationOpen() const
 {
   Q_D(const ctkDICOMServer);
   return d->KeepAssociationOpen;
 }
 
 //-----------------------------------------------------------------------------
-void ctkDICOMServer::setConnectionTimeout(int timeout)
+void ctkDICOMServer::setConnectionTimeout(const int& timeout)
 {
   Q_D(ctkDICOMServer);
   d->ConnectionTimeout = timeout;
 }
 
 //-----------------------------------------------------------------------------
-int ctkDICOMServer::connectionTimeout()
+int ctkDICOMServer::connectionTimeout() const
 {
   Q_D(const ctkDICOMServer);
   return d->ConnectionTimeout;
 }
 
 //----------------------------------------------------------------------------
-static void skipDelete(QObject* obj)
-{
-  Q_UNUSED(obj);
-  // this deleter does not delete the object from memory
-  // useful if the pointer is not owned by the smart pointer
-}
-
-//----------------------------------------------------------------------------
 ctkDICOMServer* ctkDICOMServer::proxyServer() const
-{
-  Q_D(const ctkDICOMServer);
-  return d->ProxyServer.data();
-}
-
-//----------------------------------------------------------------------------
-QSharedPointer<ctkDICOMServer> ctkDICOMServer::proxyServerShared() const
 {
   Q_D(const ctkDICOMServer);
   return d->ProxyServer;
 }
 
 //----------------------------------------------------------------------------
-void ctkDICOMServer::setProxyServer(ctkDICOMServer& proxyServer)
+void ctkDICOMServer::setProxyServer(const ctkDICOMServer& proxyServer)
 {
   Q_D(ctkDICOMServer);
-  d->ProxyServer = QSharedPointer<ctkDICOMServer>(&proxyServer, skipDelete);
+  d->ProxyServer = proxyServer.clone();
 }
 
 //----------------------------------------------------------------------------
-void ctkDICOMServer::setProxyServer(QSharedPointer<ctkDICOMServer> proxyServer)
+ctkDICOMServer *ctkDICOMServer::clone() const
 {
-  Q_D(ctkDICOMServer);
-  d->ProxyServer = proxyServer;
+  ctkDICOMServer* newServer = new ctkDICOMServer;
+  newServer->setConnectionName(this->connectionName());
+  newServer->setQueryRetrieveEnabled(this->queryRetrieveEnabled());
+  newServer->setStorageEnabled(this->storageEnabled());
+  newServer->setCallingAETitle(this->callingAETitle());
+  newServer->setCalledAETitle(this->calledAETitle());
+  newServer->setHost(this->host());
+  newServer->setPort(this->port());
+  newServer->setRetrieveProtocol(this->retrieveProtocol());
+  newServer->setMoveDestinationAETitle(this->moveDestinationAETitle());
+  newServer->setKeepAssociationOpen(this->keepAssociationOpen());
+  newServer->setConnectionTimeout(this->connectionTimeout());
+  if (this->proxyServer())
+    {
+    newServer->setProxyServer(*this->proxyServer());
+    }
+
+  return newServer;
 }

--- a/Libs/DICOM/Core/ctkDICOMServer.h
+++ b/Libs/DICOM/Core/ctkDICOMServer.h
@@ -125,23 +125,24 @@ public:
   ///@{
   /// prefer to keep using the existing association to peer host when doing
   /// multiple requests (default true)
-  void setKeepAssociationOpen(bool keepOpen);
-  bool keepAssociationOpen();
+  void setKeepAssociationOpen(const bool& keepOpen);
+  bool keepAssociationOpen() const;
   ///}@
 
   ///@{
   /// connection timeout in seconds, default 10 s.
-  void setConnectionTimeout(int timeout);
-  int connectionTimeout();
+  void setConnectionTimeout(const int& timeout);
+  int connectionTimeout() const;
   ///}@
 
   ///@{
   /// proxy server
   Q_INVOKABLE ctkDICOMServer* proxyServer() const;
-  QSharedPointer<ctkDICOMServer> proxyServerShared() const;
-  Q_INVOKABLE void setProxyServer(ctkDICOMServer& proxyServer);
-  void setProxyServer(QSharedPointer<ctkDICOMServer> proxyServer);
+  Q_INVOKABLE void setProxyServer(const ctkDICOMServer& proxyServer);
   ///}@
+
+  /// Create a copy of this Server.
+  Q_INVOKABLE ctkDICOMServer* clone() const;
 
 protected:
   QScopedPointer<ctkDICOMServerPrivate> d_ptr;

--- a/Libs/DICOM/Core/ctkDICOMStorageListenerJob.cpp
+++ b/Libs/DICOM/Core/ctkDICOMStorageListenerJob.cpp
@@ -139,3 +139,9 @@ ctkAbstractWorker* ctkDICOMStorageListenerJob::createWorker()
   worker->setJob(*this);
   return worker;
 }
+
+//------------------------------------------------------------------------------
+ctkDICOMJobResponseSet::JobType ctkDICOMStorageListenerJob::getJobType() const
+{
+  return ctkDICOMJobResponseSet::JobType::StoreSOPInstance;
+}

--- a/Libs/DICOM/Core/ctkDICOMStorageListenerJob.h
+++ b/Libs/DICOM/Core/ctkDICOMStorageListenerJob.h
@@ -77,6 +77,9 @@ public:
   /// Generate worker for job
   Q_INVOKABLE ctkAbstractWorker* createWorker() override;
 
+  /// Return job type.
+  Q_INVOKABLE virtual ctkDICOMJobResponseSet::JobType getJobType() const override;
+
 protected:
   QScopedPointer<ctkDICOMStorageListenerJobPrivate> d_ptr;
 

--- a/Libs/DICOM/Core/ctkDICOMStorageListenerWorker.h
+++ b/Libs/DICOM/Core/ctkDICOMStorageListenerWorker.h
@@ -45,18 +45,20 @@ public:
   explicit ctkDICOMStorageListenerWorker();
   virtual ~ctkDICOMStorageListenerWorker();
 
-  /// Execute worker
+  /// Execute worker. This method is run by the QThreadPool and is thread safe
   void run() override;
 
-  /// Cancel worker
-  void cancel() override;
+  /// Cancel worker. This method is thread safe
+  void requestCancel() override;
 
-  /// Job
+  /// Job.
+  /// These methods are not thread safe
   void setJob(QSharedPointer<ctkAbstractJob> job) override;
   using ctkAbstractWorker::setJob;
 
   ///@{
-  /// Retriever
+  /// Retriever.
+  /// These methods are not thread safe
   QSharedPointer<ctkDICOMStorageListener> storageListenerShared() const;
   Q_INVOKABLE ctkDICOMStorageListener* storageListener() const;
   ///@}

--- a/Libs/DICOM/Widgets/ctkDICOMJobListWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMJobListWidget.cpp
@@ -276,6 +276,7 @@ void QCenteredItemModel::updateJobStatus(const ctkDICOMJobDetail &td, const JobS
     QString statusText;
     if (status == Queued)
     {
+      statusIcon = QIcon(":/Icons/pending.svg");
       statusText = tr("queued");
     }
     else if (status == Running)

--- a/Libs/DICOM/Widgets/ctkDICOMJobListWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMJobListWidget.h
@@ -55,6 +55,7 @@ public:
   void setScheduler(QSharedPointer<ctkDICOMScheduler> scheduler);
 
 public Q_SLOTS:
+  void onJobInitialized(QVariant);
   void onJobQueued(QVariant);
   void onJobStarted(QVariant);
   void onJobCanceled(QVariant);

--- a/Libs/DICOM/Widgets/ctkDICOMSeriesItemWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMSeriesItemWidget.h
@@ -115,6 +115,10 @@ public:
   /// Series lives in the server
   bool isCloud() const;
 
+  /// Force retrieve for series. If the series was already fetched,
+  /// it will be retrieved again.
+  void forceRetrieve();
+
   ///@{
   /// in case the retrieve job failed
   void setRetrieveFailed(bool retrieveFailed);
@@ -133,9 +137,6 @@ public:
   void setThumbnailSizePixel(int thumbnailSizePixel);
   int thumbnailSizePixel() const;
   ///@}
-
-  /// Reset progress bar
-  Q_INVOKABLE void resetOperationProgressBar();
 
   /// Return the scheduler.
   Q_INVOKABLE ctkDICOMScheduler* scheduler() const;
@@ -163,6 +164,10 @@ public Q_SLOTS:
   void generateInstances();
   void updateGUIFromScheduler(const QVariant& data);
   void updateSeriesProgressBar(const QVariant& data);
+  void onJobStarted(const QVariant& data);
+  void onJobCanceled(const QVariant& data);
+  void onJobFailed(const QVariant& data);
+  void onJobFinished(const QVariant& data);
 
 protected:
   QScopedPointer<ctkDICOMSeriesItemWidgetPrivate> d_ptr;

--- a/Libs/DICOM/Widgets/ctkDICOMServerNodeWidget2.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMServerNodeWidget2.cpp
@@ -575,6 +575,11 @@ int ctkDICOMServerNodeWidget2Private::addServerNode(ctkDICOMServer* server)
     return -1;
   }
 
+  if (server->proxyServer())
+    {
+    this->addServerNode(server->proxyServer());
+    }
+
   int rowCount = this->NodeTable->rowCount();
   this->NodeTable->setRowCount(rowCount + 1);
 
@@ -666,12 +671,6 @@ int ctkDICOMServerNodeWidget2Private::addServerNode(ctkDICOMServer* server)
                    q, SLOT(onSettingsModified()));
   this->NodeTable->setCellWidget(rowCount, ctkDICOMServerNodeWidget2::ProxyColumn, proxyComboBox);
   this->NodeTable->setItem(rowCount, ctkDICOMServerNodeWidget2::ProxyColumn, newItem);
-
-  if (server->proxyServer())
-  {
-    this->addServerNode(server->proxyServer());
-    rowCount++;
-  }
 
   q->onSettingsModified();
 
@@ -934,8 +933,8 @@ void ctkDICOMServerNodeWidget2::saveSettings()
   int rowCount = d->NodeTable->rowCount();
 
   settings.remove("DICOM/ServerNodes");
-  this->removeAllServers();
   this->stopAllJobs();
+  this->removeAllServers();
 
   settings.setValue("DICOM/ServerNodeCount", rowCount);
 
@@ -989,7 +988,7 @@ void ctkDICOMServerNodeWidget2::saveSettings()
         ctkDICOMServer* server = this->getServer(tmpServerName.toStdString().c_str());
         if (server)
         {
-          server->setProxyServer(proxyServer);
+          server->setProxyServer(*proxyServer);
           server->setMoveDestinationAETitle(proxyServer->calledAETitle());
           break;
         }

--- a/Libs/DICOM/Widgets/ctkDICOMStudyItemWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMStudyItemWidget.cpp
@@ -32,8 +32,9 @@
 
 // ctkDICOMCore includes
 #include "ctkDICOMDatabase.h"
-#include "ctkDICOMScheduler.h"
+#include "ctkDICOMJob.h"
 #include "ctkDICOMJobResponseSet.h"
+#include "ctkDICOMScheduler.h"
 
 // ctkDICOMWidgets includes
 #include "ctkDICOMStudyItemWidget.h"
@@ -85,6 +86,8 @@ public:
   QString PatientID;
   QString StudyInstanceUID;
   QString StudyItem;
+
+  bool IsGUIUpdating;
 };
 
 //----------------------------------------------------------------------------
@@ -104,6 +107,8 @@ ctkDICOMStudyItemWidgetPrivate::ctkDICOMStudyItemWidgetPrivate(ctkDICOMStudyItem
   this->DicomDatabase = nullptr;
   this->Scheduler = nullptr;
   this->VisualDICOMBrowser = nullptr;
+
+  this->IsGUIUpdating = false;
 }
 
 //----------------------------------------------------------------------------
@@ -157,6 +162,10 @@ void ctkDICOMStudyItemWidgetPrivate::updateColumnsWidths()
 void ctkDICOMStudyItemWidgetPrivate::createSeries()
 {
   Q_Q(ctkDICOMStudyItemWidget);
+  if (this->IsGUIUpdating)
+    {
+    return;
+    }
 
   if (!this->DicomDatabase)
   {
@@ -169,6 +178,8 @@ void ctkDICOMStudyItemWidgetPrivate::createSeries()
   {
     return;
   }
+
+  this->IsGUIUpdating = true;
 
   // Sort by SeriesNumber
   QMap<int, QString> seriesMap;
@@ -240,6 +251,8 @@ void ctkDICOMStudyItemWidgetPrivate::createSeries()
     iHeight += 25;
     this->SeriesListTableWidget->setMinimumHeight(iHeight);
   }
+
+  this->IsGUIUpdating = false;
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.h
@@ -355,7 +355,6 @@ public Q_SLOTS:
   void onQueryPatients();
   void onShowPatients();
   void updateGUIFromScheduler(const QVariant&);
-  void onJobStarted(const QVariant&);
   void onJobFailed(const QVariant&);
   void onPatientItemChanged(int);
   void onClose();
@@ -390,6 +389,8 @@ protected:
   QStringList fileListForCurrentSelection(ctkDICOMModel::IndexType level, const QList<QWidget*>& selectedWidget);
   /// Show window that displays DICOM fields of all selected items
   void showMetadata(const QStringList& fileList);
+  /// Force redownload of selected series widgets
+  void forceSeriesRetrieve(const QList<QWidget*>& selectedWidgets = QList<QWidget*>());
   /// Remove items (both database and widget)
   void removeSelectedItems(ctkDICOMModel::IndexType level, const QList<QWidget*>& selectedWidgets = QList<QWidget*>());
   /// Export the items associated with the selected widget


### PR DESCRIPTION
@lassoan @jcfr

I am plannig to use this branch https://github.com/Punzo/CTK/tree/visualDICOMBrowserENH
for dev regarding to https://github.com/commontk/CTK/issues/1162

The current commit fix a couple of breaking bugs:

1. the proxy server option in the servers settings UI was cleared at startup
2. the sorting of the study widgets was broken when studies had the same date. This caused that some study widgets were not added to the layout.
3. fix and clean jobs handling (stopping, setting the status, etc...)

It would be nice to merge this PR and update Slicer as well.