### PR TITLE
ENH: Support using ctkAbstractPythonManager::ExecuteStringMode from Python

### DIFF
--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
@@ -96,6 +96,7 @@ public:
     FileInput,
     SingleInput
   };
+  Q_ENUMS(ExecuteStringMode);
 
   /// Execute a python of python code (can be multiple lines separated with newline)
   /// and return the result as a QVariant.


### PR DESCRIPTION
Follow-up of fc58c6a16 (ENH: Make executeString and executeFile invokable from Python)