### PR TITLE
ENH: Increase minimum required CMake version to 3.16.3

### DIFF
--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -22,7 +22,7 @@
 macro(ctkMacroSetupQt)
 
   if(CTK_QT_VERSION VERSION_EQUAL "5")
-    cmake_minimum_required(VERSION 2.8.12)
+    cmake_minimum_required(VERSION 3.16.3)
     find_package(Qt5 COMPONENTS Core)
 
     set(CTK_QT5_COMPONENTS Core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,9 @@
 #
 ###########################################################################
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16.3)
 
 foreach(p
-  CMP0054 # CMake 3.1
   )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)

--- a/Utilities/DGraph/CMakeLists.txt
+++ b/Utilities/DGraph/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 ###########################################################################
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16.3)
 
 project(DGraph)
 


### PR DESCRIPTION
Avoids configure errors with the latest ITK and CMake 3.29.3:

```log
6>CMake Warning (dev) at M:/a/Srd/ITK-build/ITKConfig.cmake:90 (if):
6>  Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
6>  --help-policy CMP0057" for policy details.  Use the cmake_policy command to
6>  set the policy and suppress this warning.
6>
6>  IN_LIST will be interpreted as an operator when the policy is set to NEW.
6>  Since the policy is not set the OLD behavior will be used.
6>Call Stack (most recent call first):
6>  Libs/ImageProcessing/ITK/Core/CMakeLists.txt:16 (find_package)
6>This warning is for project developers.  Use -Wno-dev to suppress it.
6>
6>CMake Error at M:/a/Srd/ITK-build/ITKConfig.cmake:90 (if):
6>  if given arguments:
6>
6>    "ITK_FIND_REQUIRED_ITKCommon" "OR" "M" "IN_LIST" "ITK_MODULES_ENABLED"
6>
6>  Unknown arguments specified
6>Call Stack (most recent call first):
6>  Libs/ImageProcessing/ITK/Core/CMakeLists.txt:16 (find_package)
6>
6>
6>-- Configuring incomplete, errors occurred!
```