### PR TITLE
ENH: Add method to check if double-spinbox value is being edited

### DIFF
--- a/Libs/Widgets/ctkDoubleSpinBox.cpp
+++ b/Libs/Widgets/ctkDoubleSpinBox.cpp
@@ -37,6 +37,9 @@
 #include <QStyleOptionSpinBox>
 #include <QVariant>
 
+//------------------------------------------------------------------------------
+CTK_GET_CPP(ctkDoubleSpinBox, bool, isSettingValue, IsSettingValue)
+
 //-----------------------------------------------------------------------------
 // ctkQDoubleSpinBox
 //----------------------------------------------------------------------------
@@ -187,6 +190,7 @@ ctkDoubleSpinBoxPrivate::ctkDoubleSpinBoxPrivate(ctkDoubleSpinBox& object)
   this->InputRange[0] = 0.;
   this->InputRange[1] = 99.99;
   this->ForceInputValueUpdate = false;
+  this->IsSettingValue = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -285,6 +289,8 @@ int ctkDoubleSpinBoxPrivate::decimalsForValue(double value) const
 void ctkDoubleSpinBoxPrivate::setValue(double value, int dec)
 {
   Q_Q(ctkDoubleSpinBox);
+  bool wasSettingValue = this->IsSettingValue;
+  this->IsSettingValue = true;
   dec = this->boundDecimals(dec);
   const bool changeDecimals = dec != q->decimals();
   if (changeDecimals)
@@ -316,6 +322,7 @@ void ctkDoubleSpinBoxPrivate::setValue(double value, int dec)
     this->CachedMinimumSizeHint = QSize();
     q->updateGeometry();
   }
+  this->IsSettingValue = wasSettingValue;
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Widgets/ctkDoubleSpinBox.h
+++ b/Libs/Widgets/ctkDoubleSpinBox.h
@@ -89,6 +89,9 @@ class CTK_WIDGETS_EXPORT ctkDoubleSpinBox : public QWidget
   /// SizeHintByMinMax by default
   /// SizeHintPolicy, sizeHintPolicy(), setSizeHintPolicy()
   Q_PROPERTY(SizeHintPolicy sizeHintPolicy READ sizeHintPolicy WRITE setSizeHintPolicy)
+  /// This property is true while the spinbox is setting a value.
+  /// \sa isSettingValue()
+  Q_PROPERTY(bool isSettingValue READ isSettingValue)
 
 public:
 
@@ -318,6 +321,14 @@ public Q_SLOTS:
   /// spinbox is not displayed.
   /// \sa isReadOnly
   void setReadOnly(bool readOnly);
+
+  /// Return true if the spinbox is in the progress of setting a value.
+  ///
+  /// Setting of value is performed in two steps: first the value is set in the spinbox
+  /// and then the valueChanged and decimalsChanged signals are emitted.
+  /// During this entire time, isSettingValue() returns true, because in some cases
+  /// it is important to know which of the sibling widgets initiated an update.
+  bool isSettingValue()const;
 
 Q_SIGNALS:
   /// Emitted every time the spinbox value is modified

--- a/Libs/Widgets/ctkDoubleSpinBox_p.h
+++ b/Libs/Widgets/ctkDoubleSpinBox_p.h
@@ -101,6 +101,8 @@ public:
   mutable QSize CachedMinimumSizeHint;
   bool ForceInputValueUpdate;
 
+  bool IsSettingValue;
+
   QPointer<ctkValueProxy> Proxy;
 
   void init();

--- a/Libs/Widgets/ctkSliderWidget.cpp
+++ b/Libs/Widgets/ctkSliderWidget.cpp
@@ -738,3 +738,10 @@ void ctkSliderWidget::onValueProxyModified()
   d->SpinBox->setValue(d->Slider->value());
   Q_ASSERT(d->equal(d->SpinBox->value(),d->Slider->value()));
 }
+
+// --------------------------------------------------------------------------
+bool ctkSliderWidget::isSettingValueFromSpinBox()const
+{
+  Q_D(const ctkSliderWidget);
+  return d->SpinBox->isSettingValue();
+}

--- a/Libs/Widgets/ctkSliderWidget.h
+++ b/Libs/Widgets/ctkSliderWidget.h
@@ -265,6 +265,9 @@ public:
   virtual void setValueProxy(ctkValueProxy* proxy);
   virtual ctkValueProxy* valueProxy() const;
 
+  /// Return true if a value is currently being set in the spinbox.
+  bool isSettingValueFromSpinBox()const;
+
 public Q_SLOTS:
   ///
   /// Reset the slider and spinbox to zero (value and position)


### PR DESCRIPTION
New method is added to ctkDoubleSpinBox and ctkSliderWidget to check if a value is currently being set using the spinbox. This is useful because when there are many sibling widgets then many signals may be emitted and it may be difficult to determine which widget was the source of all changes.

This feature was needed for fixing https://github.com/Slicer/Slicer/issues/7574