### PR TITLE
BUG: Fix error log filtering in ctkErrorLogWidget

### DIFF
--- a/Libs/Core/ctkErrorLogAbstractModel.cpp
+++ b/Libs/Core/ctkErrorLogAbstractModel.cpp
@@ -371,7 +371,7 @@ void ctkErrorLogAbstractModel::clear()
 
 //------------------------------------------------------------------------------
 void ctkErrorLogAbstractModel::filterEntry(const ctkErrorLogLevel::LogLevels& logLevel,
-                                   bool disableFilter)
+                                           bool disableFilter)
 {
   Q_D(ctkErrorLogAbstractModel);
 
@@ -381,11 +381,6 @@ void ctkErrorLogAbstractModel::filterEntry(const ctkErrorLogLevel::LogLevels& lo
     patterns << this->filterRegExp().pattern().split("|");
   }
   patterns.removeAll(d->ErrorLogLevel(ctkErrorLogLevel::None));
-
-//  foreach(QString s, patterns)
-//    {
-//    std::cout << "pattern:" << qPrintable(s) << std::endl;
-//    }
 
   QMetaEnum logLevelEnum = d->ErrorLogLevel.metaObject()->enumerator(0);
   Q_ASSERT(QString("LogLevel").compare(logLevelEnum.name()) == 0);

--- a/Libs/Core/ctkErrorLogLevel.h
+++ b/Libs/Core/ctkErrorLogLevel.h
@@ -39,16 +39,16 @@ public:
 
   enum LogLevel
   {
-    Unknown = 0,
-    Status,
-    Trace,
-    Debug,
-    Info,
-    Warning,
-    Error,
-    Critical,
-    Fatal,
-    None,
+    Unknown  = 0x1,
+    Status   = 0x2,
+    Trace    = 0x4,
+    Debug    = 0x8,
+    Info     = 0x10,
+    Warning  = 0x20,
+    Error    = 0x40,
+    Critical = 0x80,
+    Fatal    = 0x100,
+    None     = 0x200,
   };
   Q_DECLARE_FLAGS(LogLevels, LogLevel)
 


### PR DESCRIPTION
Fix regression introduced in https://github.com/commontk/CTK/commit/e9ef4c397b49bd594bf75f3be80a516252cc410b

which made the error filtering buttons bugged.