### PR TITLE
BUG: Update DCMTK to backport fixes for CVE-2022-2119 and CVE-2022-2120

### DIFF
--- a/CMakeExternals/DCMTK.cmake
+++ b/CMakeExternals/DCMTK.cmake
@@ -28,7 +28,7 @@ if(DEFINED DCMTK_DIR AND NOT EXISTS ${DCMTK_DIR})
 endif()
 
 if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
-  set(revision_tag "0f9bf4d9e9a778c11fdddafca691b451c2b621bc") # patched-DCMTK-3.6.6_20210115
+  set(revision_tag "11972eaa4ecdbf3aab0f46eff78f33d7e2b16bfe") # patched-DCMTK-3.6.6_20210115
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()


### PR DESCRIPTION
Backport security fixes from the following post https://forum.dcmtk.org/viewtopic.php?t=5192 because of the following CVE:
* [CVE-2022-2119](https://www.cvedetails.com/cve/CVE-2022-2119/)
* [CVE-2022-2120](https://www.cvedetails.com/cve/CVE-2022-2120/)


List of DCMTK changes:

```
$ git shortlog 0f9bf4d9e..11972eaa4 --no-merges
Marco Eichelberg (2):
      [Backport] Fixed possible NULL pointer dereference.
      [Backport] Fixed path traversal vulnerability.
```

Related pull requests & issues:
* https://github.com/commontk/DCMTK/pull/14