### PR TITLE
Support building against DCMTK >= 3.6.7

### DIFF
--- a/Libs/DICOM/Core/CMakeLists.txt
+++ b/Libs/DICOM/Core/CMakeLists.txt
@@ -172,6 +172,17 @@ set(KIT_resources
 # The following macro will read the target libraries from the file 'target_libraries.cmake'
 ctkFunctionGetTargetLibraries(KIT_target_libraries)
 
+# Support namespaced DCMTK targets
+set(_target_libraries)
+foreach(target_library IN LISTS KIT_target_libraries)
+  if(TARGET DCMTK::${target_library})
+    list(APPEND _target_libraries DCMTK::${target_library})
+  else()
+    list(APPEND _target_libraries ${target_library})
+  endif()
+endforeach()
+set(KIT_target_libraries ${_target_libraries})
+
 list(APPEND KIT_target_libraries Qt${CTK_QT_VERSION}::Sql Qt${CTK_QT_VERSION}::Svg)
 
 # create a dcm query/retrieve service config file that points to the build dir

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -2433,7 +2433,7 @@ bool ctkDICOMDatabase::storeThumbnailFile(const QString &originalFilePath,
   }
   else
   {
-    DicomImage dcmImage(QDir::toNativeSeparators(originalFilePath).toUtf8());
+    DicomImage dcmImage(QDir::toNativeSeparators(originalFilePath).toUtf8().data());
     return d->ThumbnailGenerator->generateThumbnail(&dcmImage, thumbnailPath, backgroundColor);
   }
 }

--- a/Libs/DICOM/Core/ctkDICOMThumbnailGenerator.cpp
+++ b/Libs/DICOM/Core/ctkDICOMThumbnailGenerator.cpp
@@ -176,7 +176,7 @@ bool ctkDICOMThumbnailGenerator::generateThumbnail(DicomImage *dcmImage, QImage&
   /* create output buffer for DicomImage class */
   QByteArray buffer;
   /* copy header to output buffer and resize it for pixel data */
-  buffer.append(header.toUtf8());
+  buffer.append(header.toUtf8().data());
   buffer.resize(length);
 
   /* render pixel data to buffer */
@@ -211,14 +211,14 @@ bool ctkDICOMThumbnailGenerator::generateThumbnail(DicomImage *dcmImage, const Q
 //------------------------------------------------------------------------------
 bool ctkDICOMThumbnailGenerator::generateThumbnail(const QString& dcmImagePath, QImage& image)
 {
-  DicomImage dcmImage(QDir::toNativeSeparators(dcmImagePath).toUtf8());
+  DicomImage dcmImage(QDir::toNativeSeparators(dcmImagePath).toUtf8().data());
   return this->generateThumbnail(&dcmImage, image);
 }
 
 //------------------------------------------------------------------------------
 bool ctkDICOMThumbnailGenerator::generateThumbnail(const QString& dcmImagePath, const QString& thumbnailPath)
 {
-  DicomImage dcmImage(QDir::toNativeSeparators(dcmImagePath).toUtf8());
+  DicomImage dcmImage(QDir::toNativeSeparators(dcmImagePath).toUtf8().data());
   return this->generateThumbnail(&dcmImage, thumbnailPath);
 }
 

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMImageTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMImageTest1.cpp
@@ -54,7 +54,7 @@ int ctkDICOMImageTest1( int argc, char * argv [] )
 
   QString dicomFilePath(arguments.at(0));
 
-  DicomImage dcmtkImage(QDir::toNativeSeparators(dicomFilePath).toUtf8());
+  DicomImage dcmtkImage(QDir::toNativeSeparators(dicomFilePath).toUtf8().data());
   ctkDICOMImage ctkImage(&dcmtkImage);
 
   QLabel qtImage;

--- a/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMItemViewTest1.cpp
+++ b/Libs/DICOM/Widgets/Testing/Cpp/ctkDICOMItemViewTest1.cpp
@@ -55,7 +55,7 @@ int ctkDICOMItemViewTest1( int argc, char * argv [] )
 
   QString dicomFilePath(arguments.at(0));
 
-  DicomImage img(QDir::toNativeSeparators(dicomFilePath).toUtf8());
+  DicomImage img(QDir::toNativeSeparators(dicomFilePath).toUtf8().data());
   QImage image;
   QImage image2(200, 200, QImage::Format_RGB32);
 


### PR DESCRIPTION
Introduces two compatibility updates for DCMTK integration:

1. **Explicit `QByteArray` Conversion for DCMTK Compatibility**: Adds an explicit conversion from `QByteArray` to `const char *`, preparing for changes in DCMTK's handling of the `filename` parameter (commit DCMTK/dcmtk@1ebac2d0f).

2. **Support for Namespaced DCMTK CMake Targets**: Adapts the build system to support namespaced CMake targets introduced in DCMTK commit DCMTK/dcmtk@c684bb3. The update correctly sets the `KIT_target_libraries` variable to accommodate the "DCMTK::" prefix in target names.

Related pull requests:
* https://github.com/Slicer/Slicer/pull/6709
* https://github.com/InsightSoftwareConsortium/ITK/pull/4910
* https://github.com/commontk/CTK/pull/1053