### PR TITLE
 Improve robustness of Python completion model

### DIFF
--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
@@ -669,7 +669,7 @@ PyObject* ctkAbstractPythonManager::pythonModule(const QString& module)
     if (PyObject_HasAttrString(object, "__dict__"))
     {
       dict = PyObject_GetAttrString(object, "__dict__");
-    }\
+    }
     prevObject = object;
   }
   return object;

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
@@ -367,6 +367,7 @@ QStringList ctkAbstractPythonManager::dir_object(PyObject* object,
       value = PyObject_GetAttr(object, key);
       if (!value)
       {
+        PyErr_Clear();
         continue;
       }
       QString key_str(PyString_AsString(key));
@@ -465,6 +466,7 @@ QStringList ctkAbstractPythonManager::pythonAttributes(const QString& pythonVari
   }
   if (!object)
   {
+    PyErr_Clear();
     return QStringList();
   }
 
@@ -514,7 +516,16 @@ QStringList ctkAbstractPythonManager::pythonAttributes(const QString& pythonVari
           line_code.append('.'); // add the point again in case we need to continue to fill line_code
           object = PyObject_GetAttrString(main_object,instantiated_class_name.toLatin1().data());
 
-          results = ctkAbstractPythonManager::dir_object(object,appendParenthesis);
+          if (object)
+          {
+            results = ctkAbstractPythonManager::dir_object(object,appendParenthesis);
+          }
+          else
+          {
+            // failed to invoke callable, no completions are available
+            PyErr_Clear();
+            results.clear();
+          }
         }
       }
       else
@@ -537,6 +548,7 @@ QStringList ctkAbstractPythonManager::pythonAttributes(const QString& pythonVari
         }
         else
         {
+          PyErr_Clear();
           // not a valid attribute, no completions are available
           results.clear();
         }

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
@@ -500,12 +500,19 @@ QStringList ctkAbstractPythonManager::pythonAttributes(const QString& pythonVari
         // Attempt to instantiate the associated python class
         PyObject* classToInstantiate;
         if (PyDict_Check(object))
+        {
           classToInstantiate = PyDict_GetItemString(object, tmpName.data());
+          Py_XINCREF(classToInstantiate);
+        }
         else
+        {
           classToInstantiate = PyObject_GetAttrString(object, tmpName.data());
+        }
 
         if (classToInstantiate)
         {
+          Py_DECREF(classToInstantiate);
+
           QString code = " = ";
           code.prepend(instantiated_class_name);
           line_code.remove(line_code.size()-1,1); // remove the last char which is a dot

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
@@ -468,12 +468,6 @@ QStringList ctkAbstractPythonManager::pythonAttributes(const QString& pythonVari
     return QStringList();
   }
 
-//  PyObject* object = PyDict_GetItemString(dict, module.toLatin1().data());
-//  if (!object)
-//    {
-//    return QStringList();
-//    }
-//  Py_INCREF(object);
 
   PyObject* main_object = object; // save the module object (usually __main__ or __main__.__builtins__)
   QString instantiated_class_name = "_ctkAbstractPythonManager_autocomplete_tmp";
@@ -503,8 +497,8 @@ QStringList ctkAbstractPythonManager::pythonAttributes(const QString& pythonVari
 
         // Attempt to instantiate the associated python class
         PyObject* classToInstantiate;
-        if (PyDict_Check(dict))
-          classToInstantiate = PyDict_GetItemString(dict, tmpName.data());
+        if (PyDict_Check(object))
+          classToInstantiate = PyDict_GetItemString(object, tmpName.data());
         else
           classToInstantiate = PyObject_GetAttrString(object, tmpName.data());
 
@@ -520,7 +514,6 @@ QStringList ctkAbstractPythonManager::pythonAttributes(const QString& pythonVari
           line_code.append('.'); // add the point again in case we need to continue to fill line_code
           object = PyObject_GetAttrString(main_object,instantiated_class_name.toLatin1().data());
 
-          dict = object;
           results = ctkAbstractPythonManager::dir_object(object,appendParenthesis);
         }
       }
@@ -535,7 +528,6 @@ QStringList ctkAbstractPythonManager::pythonAttributes(const QString& pythonVari
         else
         {
           object = PyObject_GetAttrString(object, tmpName.data());
-          dict = object;
         }
         Py_DECREF(prevObj);
 

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
@@ -129,6 +129,7 @@ public:
   /// By default the attributes are looked up from \c __main__.
   /// If the argument \c appendParenthesis is set to True, "()" will be appended to attributes
   /// being Python callable.
+  Q_INVOKABLE
   QStringList pythonAttributes(const QString& pythonVariableName,
                                const QString& module = QLatin1String("__main__"),
                                bool appendParenthesis = false) const;


### PR DESCRIPTION
This pull request includes a series of improvements and bug fixes to the `ctkAbstractPythonManager::pythonAttributes` and related methods improving the autocompletion model. The changes focus on simplifying the code, improving memory management, and ensuring more accurate and error-resilient behavior when inspecting Python objects.

- <s>Exclude property-like accessors from autocompletion</s>
- Fix reference management for `classToInstantiate`
- Improve error handling during attribute lookup
- Simplify logic by removing unused `dict` variable

Related pull request:
* https://github.com/Slicer/Slicer/pull/8238