### PR TITLE
COMP: Fix build error with VTK 9.5

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
@@ -226,7 +226,7 @@ void ctkVTKChartView::setTitle(const QString& newTitle)
 QString ctkVTKChartView::title()const
 {
   Q_D(const ctkVTKChartView);
-  return QString(d->Chart->GetTitle());
+  return QString::fromStdString(d->Chart->GetTitle());
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes the following observed build error when building with VTK 9.5.0.rc1.

```
'<function-style-cast>': cannot convert from 'vtkStdString' to 'QString'
```