### PR TITLE
COMP: Support build using CMake 4+ by consistently requiring CMake 3.16.3

### DIFF
--- a/CMake/ctkLinkerAsNeededFlagCheck/CMakeLists.txt
+++ b/CMake/ctkLinkerAsNeededFlagCheck/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 project(ctkLinkerAsNeededFlagCheck)
 add_library(A SHARED A.cpp)
 add_library(B SHARED B.cpp)


### PR DESCRIPTION
Ensure consistent use of the updated CMake minimum version across all configuration checks to support future compatibility with CMake 4.
    
This follows up on commit e081be7d ("ENH: Increase minimum required CMake version to 3.16.3", 2024-05-30) by updating the `cmake_minimum_required()` call in `ctkLinkerAsNeededFlagCheck` to match the project-wide baseline.

<details><summary>Previous description</summary>
<p>
ENH: Support compilation with CMake 4+ 

Set the cmake_minimum_required version to the same value as the reset of the CTK package to allow building this small package for testing.

</p>
</details> 