### PR TITLE
BUG: Update PythonQt and fix warnings and regression

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -82,7 +82,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
 
   ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
   if(CTK_QT_VERSION VERSION_EQUAL "5")
-    set(revision_tag db525aff0d8c053bddf13902107b34c93c1e3a44) # patched-9
+    set(revision_tag 7f7105ba9ec59d719ded80090e049fa85ad76e79) # patched-9
   else()
     message(FATAL_ERROR "Support for Qt${CTK_QT_VERSION} is not implemented")
   endif()


### PR DESCRIPTION
This commit continues the effort started in 9058c638 ("ENH: Update PythonQt backporting recent changes from MeVisLab/pythonqt", 2024-01-28) by integrating additional upstream changes. These updates further reduce divergence from the MeVisLab/pythonqt project.

Fixes:

* **Build warnings** when using Qt 5.15 (e.g., `QSet::unite`, `qrand()` deprecation).
* **Regression** in `setRedirectStdInCallbackEnabled` logic, introduced while backporting commontk/PythonQt@90220d92 ("Replace NULL with nullptr", 2023-01-01). This is resolved through the integration of commontk/PythonQt@2401816c ("BUG: Fix regression introduced in setRedirectStdInCallbackEnabled", 2025-07-02).

List of PythonQt changes:

```
$ git shortlog db525aff0..7f7105ba9 --no-merges
Fabio Loli (1):
      [Backport] Fix build with Python 3.13 (#246)

HE (1):
      [Backport] [gui] [ScriptingConsole] Fix so that history position is correct after call to setHistory so that pressing up-arrow works and shows last history item.

Iakov 'Jake' Kirilenko (3):
      [Backport] Better reference management pattern
      [Backport] Fix build with PYTHONQT_DEBUG enabled
      [Backport] PythonQtTests: Fix tests

Jean-Christophe Fillion-Robin (6):
      Fix warning related to QSet::unite when building against Qt 5.15
      Fix warning related to use of qrand() when building against Qt 5.15
      Re-introduce support for QMatrix when building against Qt < 6.0
      COMP: Replace NULL with nullptr
      COMP: Remove break statement inadvertently added
      BUG: Fix regression introduced in setRedirectStdInCallbackEnabled

MinyazevR (3):
      [Backport] Fix memory leak and add memory tests
      [Backport] Fix memory leak with PyDict_Copy
      [Backport] PythonQtTests: Change PY_VERSION_HEX for use PyConfig

Uwe Kindler (1):
      [Backport] Added MinGW build documentation for MinGW

Uwe Siems (17):
      [Backport] Handle QStringView et al as argument/return value
      [Backport generator] Filter out methods that do the same (at least in Python)
      [Backport generator] Add missing classes
      [Backport] Add "enum class" values to the enum type in Python
      [Backport] Escape reserved names by adding "_"
      [Backport] Support QByteArrayView arguments + return values
      [Backport generator] Suppress some methods of QByteArray and others...
      [Backport generator] Fix misspelled attribute name
      [Backport generator] More typesystem entries (added classes and rejections)
      [Backport generator] Remove work-around for package spelling
      [Backport] Create a global namespace wrapper for each package if required
      [Backport] Add enum values to the enum type object itself in any case...
      [Backport] Small documentation updates
      [Backport] Fix conversion of large integers to quint64
      [Backport] Fix nullptr crash in error message
      [Backport] Support for unary + in PythonQt itself
      [Backport] Fix that registered classes are not added to the designated package

githubuser0xFFFF (1):
      [Backport] Fix setting environment vars in readme (#63)

mrbean-bremen (9):
      [Backport generator] Add QtOpenGLWidgets to masterinclude
      [Partial Backport] Minor documentation fixes
      [Backport] Minor documentation updates
      [Backport generator] Move implementation from main.h into main.cpp
      [Backport generator] Replace INCLUDE by PYTHONQT_INCLUDE env var
      [Backport] Fix potential crash for unknown inner type
      [Backport] Register container classes with bool
      [Backport] Make sure the ubuntu artifacts do not overwrite each other
      [Backport] Use Py_REFCNT instead of ob_refcnt in generated code
```