### PR TITLE
COMP: Update PythonQt to branch based off upstream v3.6.1

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -82,7 +82,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
 
   ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
   if(CTK_QT_VERSION VERSION_EQUAL "5")
-    set(revision_tag 7f7105ba9ec59d719ded80090e049fa85ad76e79) # patched-9
+    set(revision_tag 37b0d31e5d313f5682f774bd8d5d41f5018a2ce9) # patched-v3.6.1-2025-06-13-a2687828e
   else()
     message(FATAL_ERROR "Support for Qt${CTK_QT_VERSION} is not implemented")
   endif()


### PR DESCRIPTION
This follows the plan mentioned in https://github.com/commontk/CTK/pull/1238#issuecomment-3029264024 where CTK would switch from the `patched-9` branch of PythonQt to the `patched-v3.6.1-2025-06-13-a2687828e` branch. It is based off https://github.com/MeVisLab/pythonqt/releases/tag/v3.6.1 with minimal additional commits added on top. The previous "patched-9" based branch was based on a very old version with a large collection of manual backports.

This is ultimately a continuation of https://github.com/commontk/CTK/pull/1159 and https://github.com/Slicer/Slicer/pull/7475 which also attempted to update to a newer PythonQt base. This branch includes Qt 5.15 wrappers unlike the older branch. Reviewing https://doc.qt.io/qt-5/newclasses515.html#new-enum-types, this now allows me to use https://doc.qt.io/qt-5/qtabbar.html#setTabVisible which was specifically introduced in Qt 5.15. This usage has currently been unavailable in latest Slicer.

I have tested this branch in the context of 3D Slicer and the build was successful ✔️. I could confirm that Qt 5.15 new methods were appropriately available through the python interface

![{36C6CB3B-A1C3-46A5-9BFB-391706B0680E}](https://github.com/user-attachments/assets/8bf648da-9995-48c7-9c2e-eaa268d52ad4)

---


<details><summary>List of PythonQt CTK-specific changes:</summary>
<p>

```
$ git shortlog v3.6.1..37b0d31e5d313f5682f774bd8d5d41f5018a2ce9 --no-merges
James Butler (2):
      [commontk] Prevent crashes during and after cleanup
      [commontk] Fix Qt 5.15 failing to use 5.15 wrappers

Jean-Christophe Fillion-Robin (11):
      [commontk] Re-introduce support for QMatrix when building against Qt < 6.0
      [commontk] Fix setRedirectStdInCallbackEnabled
      [commontk] Add support for enabling stdout/stderr redirection
      [commontk] Fix windows build error renaming stdout ivar
      [commontk] Fix warning related to use of qrand() when building against Qt 5.15
      [commontk] Replace NULL with nullptr
      [commontk] Fix "_invalid_parameter_noinfo_noreturn" link error
      [commontk] Fix warning related to QSet::unite when building against Qt 5.15
      [commontk] Revert part of r91 preventing QFlags from being wrapped
      [commontk] addDecorators: Check for null object
      [commontk] Re-enable CMake support importing historical improvements from commontk/PythonQt fork

John Stark (1):
      [commontk] Fix VS2010 compilation issue when PythonQt Debug build against python Release

Max Smolens (6):
      [commontk] Prevent crashes during and after cleanup
      [commontk] Fix tests link error on Windows
      [commontk] Add cleanup/finalization tests
      [commontk] Fix PythonQtSignalReceiver crash during cleanup
      [commontk] Prevent crash when an object is destroyed after calling PythonQt::cleanup()
      [commontk] Add missing refcount decrements when creating wrappers

Steve Pieper (1):
      [commontk] Fix mac build error with C standard lib macros

```

</p>
</details> 

<details><summary>List of PythonQt upstream changes:</summary>
<p>

```
$ git shortlog 7f7105ba9ec59d719ded80090e049fa85ad76e79..v3.6.1 --no-merges
Andras Lasso (1):
      Add isatty() method to PythonQtStdIn class

Christophe Giboudeaux (1):
      Fix build with Python 3.8

David Brooks (2):
      Support Qt 5.12
      Use `quote` characters around includes of our headers.

Fabio Loli (1):
      Fix build with Python 3.13 (#246)

Felix Petriconi (4):
      Also generate python function for operator!=()
      Default initialize all members
      Replace foreach macro with range based for loop
      Remove __* and _Uppercase from symbols because they must not been used

Gregor Anich (4):
      Fix reference/memory leaks
      More potential leak fixes and build fix
      Stylistic changes and refcount fixes in PythonQtImporter_load_module
      Allow setting PYTHON_VERSION and PYTHON_DIR when including python.prf, add rpath

Guilhem Saurel (4):
      fix format-security
      fix format-security on Q_OS_MAC
      clean more qWarnings()
      Update generator/main.cpp

HE (1):
      [gui] [ScriptingConsole] Fix so that history position is correct after call to setHistory so that pressing up-arrow works and shows last history item.

Iakov 'Jake' Kirilenko (6):
      Add Dependabot for GH actions
      Force C++11 for older Qt versions, safe/useless for 5.7+
      Better reference management pattern
      Add PYTHONDEVMODE to improve tests
      Fix tests    * `opengl` is not required    * `CHAR_MIN` is `0` for unsigned `char`. It is implementation specific, actually
      Fix build with PYTHONQT_DEBUG enabled

Iakov Kirilenko (2):
      Use XSETREF for safety
      CI for CONFIG+=debug + UbSan for tests

John Bowler (19):
      Qt6: initial changes to make compilation work (#114)
      Replace deprecated QAtomicPointer<T>::load() (#115)
      Qt6: QList<T>operator== requires const T::operator== (#116)
      Qt6: qSort and qStableSort removed (#117)
      Qt6: qSort, toList and fromList removal (#118)
      Qt6: QString::SkipEmptyParts moved to Qt (#119)
      Qt6: QTextStream compatibility (#120)
      Eliminate warnings about #warning (#122)
      Qt6: generator/typesystem.cpp: XML workround (#123)
      Add constexpr and decltype parsing (#125)
      Handle constexpr, auto (#126)
      Qt6: fixes for removal of Qt5 types (#127)
      Fix problems in Qt5.11 generator (#128)
      Use spaces instead of tabs (#129)
      generator: remove anonymous structs (#121)
      generator: call Reporthandler::setContext more (#131)
      generator: AbstractMetaClassList: correct sorting (#132)
      generator: fix iterator issues with Qt5.14 headers (#142)
      Fix: AbstractMetaBuilder::classesTopologicalSorted (#148)

Michael Aigner (1):
      Add detailed build instructions to Readme (#235)

MinyazevR (8):
      Change centos archive repository and add node16 support
      Fix memory leak and add memory tests
      Add memory tests with detect_leaks=1 to CI
      Fix issue with handling QT_VERSION in build.yml
      Change PY_VERSION_HEX for use PyConfig
      Fix big with LSan suppresion
      Add ccache to CI
      Fix memory leak with PyDict_Copy

Oliver (2):
      Update README.md
      Update README.md

Richard Goedeken (1):
      Qt6 compatibility fixes for core PythonQt library

Uwe Kindler (3):
      Fixed mingw build issues
      Added MinGW build documentation for MinGW
      Fixed mingw64-build

Uwe Siems (148):
      Loop did never finish if the first entry didn't match, fixes support for kwargs in slots.
      Add default and copy constructor for QFontInfo and QFontMetrics
      Avoid spaces at end of generated lines.
      Make __enter__ and __exit__ slots work with "with" statements
      Create correct __enter__ and __exit__ methods for QMutexLocker, QReadLocker, and QWriteLocker
      Add a hint about QByteArray/bytes conversion, use fake footnote references.
      Avoid crash for certain types that have no wrapper because they can't be instantiated
      Fix a possible invalid memory access
      Fix name clash with Visual Studio 2017
      QUrl::FormattingOptions flag arguments didn't work for Qt 5
      Make this a proper C++ struct
      Get rid of typedef struct completely, this is C++ code
      Revert "Stylistic changes and refcount fixes in PythonQtImporter_load_module"
      Revert "More potential leak fixes and build fix"
      Revert "Fix name clash with Visual Studio 2017"
      Revert "Fix reference/memory leaks"
      Update __spec__ too (if existing) when setting the import path
      Ignore some file types and directories
      Generate modern C++ code with nullptr and override
      Also consider interfaces of super classes (issue #75)
      Add missing space in message
      initialize members with list-initializers
      Fix crash when converting Python list with None value to QVariant
      Fix crash when using QObject::disconnect method (when multi-threading is enabled)
      Limit string representation of argument list in length
      add option to print parser errors when they occur
      Keep track of current source code in Debug mode,
      always ignore .vs folder
      Don't interpret "= default" or "= delete" to mean this is an abstract method
      Deleted methods need to marked as "invalid" to be handled correctly
      Cover cases where noexcept comes with an expression
      Implement and use Parser::skipFunctionBody
      Simplify skipFunctionBody by only looking at curly braces
      Avoid currently unsupported use of "noexcept(...)"
      Ignore some more macros that lead to parser errors
      Support basic new-style initializers
      Add missing enum used as default value for a method
      Automatically mark methods with r-value references (&&) as invalid
      Don't create wrappers for cbegin and cend
      Hopefully make generator immune against iterator order changes for typeMap
      Don't generate wrappers for templated methods in non-template classes
      Handle ellipsis in type parser
      Improve debugging code for rewind, also show identifiers
      Add qsizetype and qptrdiff as primitive types
      Avoid crash if supposed property setter has no arguments
      Avoid crash in lexer by increasing size of token_stream early
      Make number of classes per generated file configurable
      Add version qualifiers to typesystem XML files
      Don't assume some Qt version if it could not be found/parsed
      Fix workflow for MacOS
      Correct initialization of return value pointer failed
      Some types are aliases in Qt6 now
      Comparison rules of QVariant have changed in Qt6
      Better handling of "auto" and trailing return types "-> decltype()"
      Better handling of variadic templates
      Skip attribute specifiers like [[maybe_unused]]
      Fix types being rejected because they contain "constexpr"
      Handle "friend" functions with implementation body...
      Treat constexpr as a function modifier, not as a type modifier
      Treat noexcept inside of expressions
      Fix expansion of variadic macros in preprocessor
      Fix handling of elif in preprocessor...
      Support for new-style initializers in expressions
      Improve handling of new-style initializers
      Improve type name handling
      Make parsing more robust against shuffling of qualifiers/specifiers
      Fix missing includes for namespace items from different files
      Implement methods with lvalue/rvalue references, ...
      Handle (templated) functions with packed parameters
      Parse inline namespaces,
      Parse string literal operator definition,
      Some necessary defines for Qt6
      Add some entries to typesystem files missing for Qt6
      Add new multimedia classes
      Automatically add enums marked with Q_ENUM to TypeDatabase
      Fix uninitialized member
      Some more defines we don't need to parse
      Q_PROPERTY might contain "REVISION(1, 1)"
      Improve parsing of Q_PROPERTY types starting with "const"
      Rename "after-version" attribute to "since-version"
      More missing or updated type entries
      Also try to build against Qt 6.5
      Handle enum classes
      Complete/fix scope for enum class values
      Remove figureOutEnumValues and company
      Do not add copy constructor if it was deleted or private
      QMutexLocker is a template now, don't know how to handle this
      Fix handling of protected operators
      Fix compiler warning (possibly unintended copy)
      Fix QList::swap missing the template argument in the argument type
      I believe it is not necessary to create a shell for QPagedPaintDevice
      Try to fix library names and linking problems
      Make PythonQtTests compile with Qt6
      Do not prepend enum class name for items of enum classes,
      Avoid emitting QStringList* arguments as QStringList<QString>*
      Avoid some compiler warnings
      Skip alignas specifier
      Enable multi-processor compilation for Visual Studio
      Also enable the XML modules in QtAll project
      Handle QStringView et al as argument/return value
      Filter out methods that do the same (at least in Python)
      Add missing classes
      webenginewidgets were not compiled yet
      Add "enum class" values to the enum type in Python
      Escape reserved names by adding "_"
      Support QByteArrayView arguments + return values
      Suppress some methods of QByteArray and others...
      Fix misspelled attribute name
      More typesystem entries (added classes and rejections)
      Fix irritatingly wrong version number for Qt6
      Remove work-around for package spelling
      Create a global namespace wrapper for each package if required
      Add enum values to the enum type object itself in any case...
      Small documentation updates
      Add generated bindings for Qt 5.15
      On Ubuntu 22.04 this enum value does not exist (yet)
      Ignore static_assert in header files
      Also register std::pair with the generator
      Replace deprecated include qsql.h with qtsqlglobal.h for Qt 6
      6.6.3 introduced a new helper class for QOperatingSystemVersion
      Allow to set and get the render API in QQuickWindow
      QPixmapCache::find(QString, QPixmap*) was suppressed
      Fix a problem with character after comment always added to macro definition
      Fix comma being dropped from macro varargs argument
      Also move friend function definitions to top-level scope if...
      Skip attributes that can occur after the enum identifier
      Also translate standalone unary operators (like -, !, or ~)
      Support for unary + in PythonQt itself
      Qt 6.7 introduced macros to define comparison operators
      Qt sometimes uses the Qt::Disambiguated_t parameter (with a default value)
      decltype can contain a comma-expression
      Correctly parse string literals with a prefix (e.g. raw string: R"...")
      Ignore Q_GADGET_EXPORT for now, it doesn't help us
      Check that externally defined operators are not added twice
      Handle new classes and enums in Qt 6.7
      Introduce alias names for types
      Fix nullptr crash in error message
      Better diagnostic output
      Check for duplicates at one more place
      Remove use of 'OriginalName' option from code generator...
      Filter away static operators in namespaces
      reintroduce the runJavaScript method on QWebEnginePage for Qt 6
      Replace preprocessor with code from simplecpp project
      Set /bigobj option for Visual Studio
      Adjustments for new stuff in Qt 6.8
      CI: Generate wrappers for Qt 6.8
      Fix that registered classes are not added to the designated package
      Fix conversion of large integers to quint64

Yuri Ufimtsev (1):
      Add workflow using generated code (#151)

Yuri Victorovich (1):
      Fix install paths by adding INSTALL_PREFIX

YuriUfimtsev (13):
      Add support for parsing enum class declarations
      Add parsed enums and some more enums from warning messages to typesystem
      Add sanitizers
      Add a token consistency check between enum and array
      Reduce memory leaks by implementing the AbstractMetaBuilder destructor
      Add memory deallocation operators
      Add type copying when creating a getter to correct memory deallocation
      Change pointers to QShared pointers to decrease memory leaks
      Refactor: change casts and remove toItem() to make it compatible with QSharedPointer
      Remove obsolete things; change type to auto
      Add more shared pointers; remove AbstractMetaType::copy; remove some delete operators and destructors
      Cleanup
      Revert copy method

dependabot[bot] (8):
      Bump actions/checkout from 3 to 4 (#158)
      Bump actions/upload-artifact from 3 to 4 (#181)
      Bump actions/setup-python from 4 to 5 (#182)
      Bump egor-tensin/cleanup-path from 3 to 4
      Bump actions/upload-artifact from 3 to 4
      Bump hendrikmuhs/ccache-action from 1.2.14 to 1.2.16
      Bump hendrikmuhs/ccache-action from 1.2.16 to 1.2.17
      Bump hendrikmuhs/ccache-action from 1.2.17 to 1.2.18

githubuser0xFFFF (2):
      Fix setting environment vars in readme (#63)
      Provide missing implementation of PythonQtSlotInfo::getGlobalShouldAllowThreads() (#65)

iakov (11):
      Fix crash in GC: PyTuple_SET_ITEM steals reference
      Fix memory leak
      Add missing break in switch to fix P3K conversion
      Several fixes and patches (#89)
      Add support for Python 3.11 (#91)
      Tiny improvements for build system
      CI runners clean-up  (#104)
      Improve PYTHONQTALL_CONFIG env var handling for CMD (#214)
      Remove duplicate entry in build.yml
      Update install-qt-action to v4
      Update install-qt-action for Win and Mac builds

mrbean-bremen (45):
      Set up CI builds for different gcc versions (#80)
      Add CentOS7 docker image to CI (#84)
      Add -std=c++11 flag to check for problems (#83)
      Create GH action to auto-create documentation (#82)
      Change CentOS image to use Python 2
      Revert accidental change in last commit
      Replace NULL with nullptr
      Add override and noexcept modifiers
      Fix type conversion warnings, use const
      Avoid redefinition warnings, fix export macros
      Add facility to set task done callback
      Make sure queued connection of Signals with Python types are safe
      Add missing GIL scope to single shot timer destructor
      Add initial support for coroutines
      Add wrapper generation to CI builds
      Use ubuntu instead of gcc based images
      Use GitHub actions container
      Revert undefining some defines (#103)
      Add back undefining _POSIX_C_SOURCE and _XOPEN_SOURCE (#106)
      Make the generator compile with C++17
      Add parsing of noexcept exception specifier
      Add support for parsing using declarations
      Fix parse error for function declaration
      Bring back more Qt5 compatibility
      More Qt5 compatibility changes
      Bring back QRegExp and QMatrix for Qt5
      Make sure the ubuntu artifacts do not overwrite each other
      Fix handling of right-shift as template bracket
      Ignore variadic template parameters
      Make sure uploaded wrapper names are different
      Add Windows to CI for checking generated sources
      Unset INCLUDE env var
      Add QtOpenGLWidgets to masterinclude
      Minor documentation updates
      Move implementation from main.h into main.cpp
      Replace INCLUDE by PYTHONQT_INCLUDE env var
      Fix potential crash for unknown inner type
      Register container classes with bool
      Add QVersionNumber to generated code
      Add support for Qt 6.7
      Use latest macOS for CI
      Remove no longer supported CentOS 7 builds
      Replace ubuntu 20.04 with ubuntu 24.04
      Fix PythonQt build under Qt 6.9
      Use Py_REFCNT instead of ob_refcnt in generated code

```

</p>
</details> 
