### PR TITLE
COMP: Add conditional for VTK version in color assignment

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsView.cpp
@@ -194,7 +194,11 @@ vtkPlot* ctkVTKScalarsToColorsView
     vtkSmartPointer<vtkPiecewiseFunctionItem>::New();
   item->SetPiecewiseFunction(piecewiseTF);
   QColor defaultColor = this->palette().highlight().color();
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9,3,0)
+  item->SetColorF(defaultColor.redF(), defaultColor.greenF(), defaultColor.blueF());
+#else
   item->SetColor(defaultColor.redF(), defaultColor.greenF(), defaultColor.blueF());
+#endif
   item->SetMaskAboveCurve(true);
   this->addPlot(item);
   if (editable)


### PR DESCRIPTION
Use `SetColorF` for VTK 9.3.0+ and fallback to `SetColor`
for compatibility with older versions.
