### PR TITLE
COMP: Duplicate class name disambiguated

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
@@ -67,10 +67,10 @@ QColor ctkDICOMVisualBrowserWidgetDefaultColor(Qt::white);
 QColor ctkDICOMVisualBrowserWidgetDarkModeDefaultColor(50, 50, 50);
 QColor ctkDICOMVisualBrowserWidgetWarningColor(Qt::darkYellow);
 
-class ctkDICOMMetadataDialog : public QDialog
+class ctkDICOMWidgetMetadataDialog : public QDialog
 {
 public:
-  ctkDICOMMetadataDialog(QWidget* parent = 0)
+  ctkDICOMWidgetMetadataDialog(QWidget* parent = 0)
     : QDialog(parent)
   {
     this->setWindowFlags(Qt::WindowMaximizeButtonHint | Qt::WindowCloseButtonHint | Qt::Window);
@@ -82,7 +82,7 @@ public:
     layout->addWidget(this->tagListWidget);
   }
 
-  virtual ~ctkDICOMMetadataDialog()
+  virtual ~ctkDICOMWidgetMetadataDialog()
   {
   }
 
@@ -215,7 +215,7 @@ public:
   int SeriesAddedDuringImport;
   int InstancesAddedDuringImport;
   ctkFileDialog* ImportDialog;
-  ctkDICOMMetadataDialog* MetadataDialog;
+  ctkDICOMWidgetMetadataDialog* MetadataDialog;
 
   // Settings key that stores database directory
   QString DatabaseDirectorySettingsKey;
@@ -276,7 +276,7 @@ ctkDICOMVisualBrowserWidgetPrivate::ctkDICOMVisualBrowserWidgetPrivate(ctkDICOMV
   this->Indexer->setDatabase(this->DicomDatabase.data());
   this->Indexer->setBackgroundImportEnabled(true);
 
-  this->MetadataDialog = new ctkDICOMMetadataDialog();
+  this->MetadataDialog = new ctkDICOMWidgetMetadataDialog();
   this->MetadataDialog->setObjectName("DICOMMetadata");
   this->MetadataDialog->setWindowTitle(ctkDICOMVisualBrowserWidget::tr("DICOM File Metadata"));
 


### PR DESCRIPTION
The same class is duplicated in two .cpp files.  Duplicate symbols were created.

Renamed the Widget dialog to be unique `ctkDICOMMetadataDialog` to `ctkDICOMWidgetMetadataDialog`
