### PR TITLE
COMP: QAction changed locations for Qt6 Support

### DIFF
--- a/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerShowXmlAction.h
+++ b/Applications/ctkCommandLineModuleExplorer/ctkCmdLineModuleExplorerShowXmlAction.h
@@ -25,7 +25,12 @@
 
 #include "ctkCmdLineModuleReference.h"
 
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 
 class ctkCmdLineModuleExplorerShowXmlAction : public QAction
 {

--- a/Libs/Core/ctkCoreTestingUtilities.tpp
+++ b/Libs/Core/ctkCoreTestingUtilities.tpp
@@ -63,7 +63,6 @@ bool CheckList(int line, const QString& description,
                const QList<TYPE>& current, const QList<TYPE>& expected,
                const QString& testName)
 {
-  QString msg;
   if (current.count() != expected.count())
     {
     qWarning() << "\nLine " << line << " - " << description

--- a/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
@@ -24,7 +24,12 @@
 #include <dcmtk/dcmimgle/dcmimage.h>
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QCoreApplication>
 #include <QCheckBox>
 #include <QDebug>

--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QCoreApplication>
 #include <QCheckBox>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKAbstractMatrixWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKAbstractMatrixWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKAbstractViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKAbstractViewEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKChartViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKChartViewEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKDataSetArrayComboBoxEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKDataSetArrayComboBoxEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QSignalSpy>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKDataSetModelEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKDataSetModelEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QComboBox>
 #include <QDebug>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMagnifyViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMagnifyViewEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QHBoxLayout>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMatrixWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKMatrixWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKRenderViewEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarBarWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarBarWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsUtilsEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsUtilsEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsViewEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSliceViewEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSurfaceMaterialPropertyWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKSurfaceMaterialPropertyWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKTextPropertyWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKTextPropertyWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKThresholdWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKThresholdWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKThumbnailViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKThumbnailViewEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKVolumePropertyWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKVolumePropertyWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKWidgetsUtilsEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKWidgetsUtilsEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkActionsWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkActionsWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkActionsWidgetTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkActionsWidgetTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QIcon>

--- a/Libs/Widgets/Testing/Cpp/ctkBasePopupWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkBasePopupWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkButtonGroupEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkButtonGroupEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QPushButton>

--- a/Libs/Widgets/Testing/Cpp/ctkCheckBoxPixmapsEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCheckBoxPixmapsEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkCheckableHeaderViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCheckableHeaderViewEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QSignalSpy>

--- a/Libs/Widgets/Testing/Cpp/ctkCollapsibleGroupBoxEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCollapsibleGroupBoxEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QCheckBox>
 #include <QDebug>

--- a/Libs/Widgets/Testing/Cpp/ctkColorDialogEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkColorDialogEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkColorPickerButtonEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkColorPickerButtonEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkComboBoxEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkComboBoxEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkCompleterEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCompleterEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkConfirmExitDialogEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkConfirmExitDialogEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkConsoleEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkConsoleEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkCoordinatesWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCoordinatesWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkCrosshairLabelEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkCrosshairLabelEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkDirectoryButtonEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkDirectoryButtonEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkDynamicSpacerEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkDynamicSpacerEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkErrorLogStatusMessageHandlerEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkErrorLogStatusMessageHandlerEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkErrorLogWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkErrorLogWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkExpandButtonEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkExpandButtonEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QHBoxLayout>

--- a/Libs/Widgets/Testing/Cpp/ctkFileDialogEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkFileDialogEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QCheckBox>
 #include <QDebug>

--- a/Libs/Widgets/Testing/Cpp/ctkFittedTextBrowserEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkFittedTextBrowserEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkFlowLayoutEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkFlowLayoutEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkFontButtonEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkFontButtonEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkIconEnginePluginEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkIconEnginePluginEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkLayoutManagerEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkLayoutManagerEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkMaterialPropertyPreviewLabelEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkMaterialPropertyPreviewLabelEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkMaterialPropertyWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkMaterialPropertyWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkMatrixWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkMatrixWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkMenuButtonEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkMenuButtonEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QMenu>

--- a/Libs/Widgets/Testing/Cpp/ctkMenuComboBoxEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkMenuComboBoxEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QSignalSpy>

--- a/Libs/Widgets/Testing/Cpp/ctkMenuEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkMenuEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QMenu>

--- a/Libs/Widgets/Testing/Cpp/ctkModalityWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkModalityWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkPathLineEditEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkPathLineEditEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkPixmapIconEngineEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkPixmapIconEngineEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkPopupWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkPopupWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QComboBox>
 #include <QDebug>

--- a/Libs/Widgets/Testing/Cpp/ctkQImageViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkQImageViewEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkRangeWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkRangeWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkScreenshotDialogEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkScreenshotDialogEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkSearchBoxEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSearchBoxEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkSettingsDialogEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSettingsDialogEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QCheckBox>
 #include <QDebug>

--- a/Libs/Widgets/Testing/Cpp/ctkSettingsEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSettingsEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkSettingsPanelEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSettingsPanelEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkSignalMapperEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSignalMapperEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkSignalMapperTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSignalMapperTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QActionGroup>

--- a/Libs/Widgets/Testing/Cpp/ctkSimpleLayoutManagerEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSimpleLayoutManagerEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkSliderWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSliderWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkTemplateWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkTemplateWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkTestApplicationEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkTestApplicationEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkThumbnailListWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkThumbnailListWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkThumbnailWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkThumbnailWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkToolTipTrapperEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkToolTipTrapperEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkTransferFunctionBarsItemEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkTransferFunctionBarsItemEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkTransferFunctionControlPointsItemEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkTransferFunctionControlPointsItemEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkTransferFunctionGradientItemEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkTransferFunctionGradientItemEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkTransferFunctionItemEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkTransferFunctionItemEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkTransferFunctionNativeItemEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkTransferFunctionNativeItemEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkTransferFunctionSceneEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkTransferFunctionSceneEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkTransferFunctionViewEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkTransferFunctionViewEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkTreeComboBoxEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkTreeComboBoxEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QSignalSpy>

--- a/Libs/Widgets/Testing/Cpp/ctkWorkflowAbstractPagedWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkWorkflowAbstractPagedWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkWorkflowButtonBoxWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkWorkflowButtonBoxWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkWorkflowGroupBoxEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkWorkflowGroupBoxEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkWorkflowStackedWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkWorkflowStackedWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkWorkflowTabWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkWorkflowTabWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkWorkflowWidgetEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkWorkflowWidgetEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/Testing/Cpp/ctkWorkflowWidgetStepEventTranslatorPlayerTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkWorkflowWidgetStepEventTranslatorPlayerTest1.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QDebug>
 #include <QStandardItemModel>

--- a/Libs/Widgets/ctkActionsWidget.cpp
+++ b/Libs/Widgets/ctkActionsWidget.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QDebug>
 #include <QHeaderView>
 #include <QPainter>

--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -50,7 +50,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Qt includes
 #include <QAbstractItemView>
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 #include <QApplication>
 #include <QClipboard>
 #include <QCompleter>

--- a/Libs/Widgets/ctkSignalMapper.cpp
+++ b/Libs/Widgets/ctkSignalMapper.cpp
@@ -19,7 +19,12 @@
 =========================================================================*/
 
 // Qt includes
-#include <QAction>
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#  include <QtWidgets/QAction>
+#else
+#  include <QtGui/QAction>   // or just <QAction>
+#endif
 
 // qMRMLWidgets includes
 #include "ctkSignalMapper.h"


### PR DESCRIPTION
This ensures that the code compiles correctly under all major Qt versions.

```c++
 #include <QGlobal> // for QT_VERSION_CHECK Macro
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 #  include <QtGui/QAction>
 #elif QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #  include <QtWidgets/QAction>
 #else
 #  include <QtGui/QAction>   // or just <QAction>
 #endif
```

```txt
Qt Version  Header              Module
Qt 4.x      <QtGui/QAction>     QtGui
Qt 5.x      <QtWidgets/QAction> QtWidgets
Qt 6+       <QtGui/QAction>     QtGui
Qt 6_          or <QAction>     QtGui
```

Simplifies conditional imports of QAction to ensure correctness across
Qt versions. Does not support obsolete Qt4-specific conditionals.
