### PR TITLE
COMP: Migrate deprecated Q_ENUMS to Q_ENUM (Qt >= 5.5)

### DIFF
--- a/Libs/CommandLineModules/Core/ctkCmdLineModuleFrontend.h
+++ b/Libs/CommandLineModules/Core/ctkCmdLineModuleFrontend.h
@@ -52,7 +52,6 @@ struct ctkCmdLineModuleFrontendPrivate;
 class CTK_CMDLINEMODULECORE_EXPORT ctkCmdLineModuleFrontend : public QObject
 {
   Q_OBJECT
-  Q_ENUMS(ParameterValueRole)
 
 public:
 
@@ -89,6 +88,7 @@ public:
      */
     UserRole = 8
   };
+  Q_ENUM(ParameterValueRole)
 
   enum ParameterFilter {
     /** Parameters with channel = "input" */

--- a/Libs/Core/ctkAbstractJob.h
+++ b/Libs/Core/ctkAbstractJob.h
@@ -41,7 +41,6 @@ class ctkAbstractWorker;
 class CTK_CORE_EXPORT ctkAbstractJob : public QObject
 {
   Q_OBJECT
-  Q_ENUMS(JobStatus);
   Q_PROPERTY(QString jobUID READ jobUID WRITE setJobUID);
   Q_PROPERTY(QString className READ className);
   Q_PROPERTY(JobStatus status READ status WRITE setStatus);
@@ -91,6 +90,7 @@ public:
     Failed,
     Finished,
   };
+  Q_ENUM(JobStatus)
   JobStatus status() const;
   virtual void setStatus(JobStatus status);
   ///@}

--- a/Libs/Core/ctkWorkflow.h
+++ b/Libs/Core/ctkWorkflow.h
@@ -39,7 +39,6 @@ class QAbstractState;
 class CTK_CORE_EXPORT ctkWorkflow : public QObject
 {
   Q_OBJECT
-  Q_ENUMS(TransitionDirectionality)
   Q_PROPERTY(bool isRunning READ isRunning DESIGNABLE false)
   Q_PROPERTY(bool goBackToOriginStepUponSuccess READ goBackToOriginStepUponSuccess WRITE setGoBackToOriginStepUponSuccess)
   Q_PROPERTY(bool verbose READ verbose WRITE setVerbose)
@@ -77,6 +76,7 @@ public:
     Forward,
     Backward
   };
+  Q_ENUM(TransitionDirectionality)
 
   /// \brief Creates a transition between two steps, and adds the two steps to the workflow if they
   /// have not been previously added. (Cannot add two steps with the same id).

--- a/Libs/Core/ctkWorkflowTransitions.h
+++ b/Libs/Core/ctkWorkflowTransitions.h
@@ -132,8 +132,6 @@ struct CTK_CORE_EXPORT ctkWorkflowInterstepTransitionEvent : public QEvent
 class CTK_CORE_EXPORT ctkWorkflowInterstepTransition : public QAbstractTransition
 {
   Q_OBJECT
-  Q_ENUMS(InterstepTransitionType)
-
 public:
 
   enum InterstepTransitionType
@@ -144,7 +142,7 @@ public:
     StoppingWorkflow,
     TransitionToPreviousStartingStepAfterSuccessfulGoToFinishStep
   };
-
+  Q_ENUM(InterstepTransitionType)
   ctkWorkflowInterstepTransition(InterstepTransitionType newTransitionType)
     : TransitionType(newTransitionType){}
   ctkWorkflowInterstepTransition(InterstepTransitionType newTransitionType, const QString& newId)

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -55,7 +55,6 @@ class ctkDICOMJobResponseSet;
 class CTK_DICOM_CORE_EXPORT ctkDICOMDatabase : public QObject
 {
   Q_OBJECT
-  Q_ENUMS(InsertResult)
   Q_PROPERTY(bool isOpen READ isOpen)
   Q_PROPERTY(bool isInMemory READ isInMemory)
   Q_PROPERTY(QString lastError READ lastError)
@@ -289,6 +288,7 @@ public:
     NotInserted,
     Inserted
   };
+  Q_ENUM(InsertResult)
   Q_INVOKABLE InsertResult insert(const QList<ctkDICOMJobResponseSet*>& jobResponseSets);
 
   /// When a DICOM file is stored in the database (insert is called with storeFile=true) then

--- a/Libs/DICOM/Core/ctkDICOMJob.h
+++ b/Libs/DICOM/Core/ctkDICOMJob.h
@@ -40,7 +40,6 @@
 class CTK_DICOM_CORE_EXPORT ctkDICOMJob : public ctkAbstractJob
 {
   Q_OBJECT
-  Q_ENUMS(DICOMLevel)
   Q_PROPERTY(QString patientID READ patientID WRITE setPatientID);
   Q_PROPERTY(QString studyInstanceUID READ studyInstanceUID WRITE setStudyInstanceUID);
   Q_PROPERTY(QString seriesInstanceUID READ seriesInstanceUID WRITE setSeriesInstanceUID);
@@ -60,7 +59,8 @@ public:
     Studies,
     Series,
     Instances
-  }; Q_ENUM(DICOMLevels);
+  };
+  Q_ENUM(DICOMLevels)
 
   ///@{
   /// DICOM Level

--- a/Libs/DICOM/Core/ctkDICOMJobResponseSet.h
+++ b/Libs/DICOM/Core/ctkDICOMJobResponseSet.h
@@ -39,7 +39,6 @@ class ctkDICOMJobResponseSetPrivate;
 class CTK_DICOM_CORE_EXPORT ctkDICOMJobResponseSet : public QObject
 {
   Q_OBJECT
-  Q_ENUMS(JobType)
   Q_PROPERTY(QString filePath READ filePath WRITE setFilePath);
   Q_PROPERTY(bool copyFile READ copyFile WRITE setCopyFile);
   Q_PROPERTY(bool overwriteExistingDataset READ overwriteExistingDataset WRITE setOverwriteExistingDataset);
@@ -92,6 +91,7 @@ public:
     Echo,
     ThumbnailGenerator,
   };
+  Q_ENUM(JobType)
   void setJobType(JobType jobType);
   JobType jobType() const;
   QString jobTypeString() const;

--- a/Libs/DICOM/Core/ctkDICOMModel.h
+++ b/Libs/DICOM/Core/ctkDICOMModel.h
@@ -39,7 +39,6 @@ class CTK_DICOM_CORE_EXPORT ctkDICOMModel
 {
   Q_OBJECT
   typedef QAbstractItemModel Superclass;
-  Q_ENUMS(IndexType)
   /// startLevel contains the hierarchy depth the model contains
   Q_PROPERTY(IndexType endLevel READ endLevel WRITE setEndLevel);
 public:
@@ -56,6 +55,7 @@ public:
     SeriesType,
     ImageType
   };
+  Q_ENUM(IndexType)
 
   explicit ctkDICOMModel(QObject* parent = 0);
   virtual ~ctkDICOMModel();

--- a/Libs/DICOM/Core/ctkDICOMServer.h
+++ b/Libs/DICOM/Core/ctkDICOMServer.h
@@ -35,7 +35,6 @@ class ctkDICOMServerPrivate;
 class CTK_DICOM_CORE_EXPORT ctkDICOMServer : public QObject
 {
   Q_OBJECT
-  Q_ENUMS(RetrieveProtocol)
   Q_PROPERTY(QString connectionName READ connectionName WRITE setConnectionName);
   Q_PROPERTY(bool queryRetrieveEnabled READ queryRetrieveEnabled WRITE setQueryRetrieveEnabled);
   Q_PROPERTY(bool storageEnabled READ storageEnabled WRITE setStorageEnabled);
@@ -116,6 +115,7 @@ public:
     CMOVE
     // WADO // To Do
   };
+  Q_ENUM(RetrieveProtocol)
   void setRetrieveProtocol(RetrieveProtocol protocol);
   RetrieveProtocol retrieveProtocol() const;
   Q_INVOKABLE void setRetrieveProtocolAsString(const QString& protocolString);

--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.h
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.h
@@ -58,7 +58,6 @@ class QModelIndex;
 class CTK_DICOM_WIDGETS_EXPORT ctkDICOMBrowser : public QWidget
 {
   Q_OBJECT
-  Q_ENUMS(ImportDirectoryMode)
   Q_PROPERTY(QString databaseDirectory READ databaseDirectory WRITE setDatabaseDirectory)
   Q_PROPERTY(QString databaseDirectorySettingsKey READ databaseDirectorySettingsKey WRITE setDatabaseDirectorySettingsKey)
   Q_PROPERTY(QString databaseDirectoryBase READ databaseDirectoryBase WRITE setDatabaseDirectoryBase)
@@ -134,6 +133,7 @@ public:
     ImportDirectoryCopy = 0,
     ImportDirectoryAddLink
   };
+  Q_ENUM(ImportDirectoryMode)
 
   /// \brief Get value of ImportDirectoryMode settings.
   ///

--- a/Libs/DICOM/Widgets/ctkDICOMObjectModel.h
+++ b/Libs/DICOM/Widgets/ctkDICOMObjectModel.h
@@ -43,7 +43,6 @@ class CTK_DICOM_WIDGETS_EXPORT ctkDICOMObjectModel
   Q_OBJECT
   typedef QStandardItemModel Superclass;
   //Q_PROPERTY(setFile);
-  Q_ENUMS(ColumnIndex)
 
 public:
 
@@ -59,6 +58,7 @@ public:
     VRColumn = 3,
     LengthColumn = 4
   };
+  Q_ENUM(ColumnIndex)
 
 protected:
   QScopedPointer<ctkDICOMObjectModelPrivate> d_ptr;

--- a/Libs/DICOM/Widgets/ctkDICOMPatientItemWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMPatientItemWidget.h
@@ -43,7 +43,6 @@ class ctkDICOMStudyItemWidget;
 class CTK_DICOM_WIDGETS_EXPORT ctkDICOMPatientItemWidget : public QWidget
 {
   Q_OBJECT;
-  Q_ENUMS(DateType)
   Q_PROPERTY(QString patientItem READ patientItem WRITE setPatientItem);
   Q_PROPERTY(QString patientID READ patientID WRITE setPatientID);
   Q_PROPERTY(QString patientName READ patientName WRITE setPatientName);
@@ -105,6 +104,7 @@ public:
     LastMonth,
     LastYear
   };
+  Q_ENUM(DateType)
 
   ///@{
   /// Available values:

--- a/Libs/DICOM/Widgets/ctkDICOMStudyItemWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMStudyItemWidget.h
@@ -48,7 +48,6 @@ class ctkDICOMStudyItemWidgetPrivate;
 class CTK_DICOM_WIDGETS_EXPORT ctkDICOMStudyItemWidget : public QWidget
 {
   Q_OBJECT;
-  Q_ENUMS(ThumbnailSizeOption)
   Q_PROPERTY(QString studyItem READ studyItem WRITE setStudyItem);
   Q_PROPERTY(QString patientID READ patientID WRITE setPatientID);
   Q_PROPERTY(QString studyInstanceUID READ studyInstanceUID WRITE setStudyInstanceUID);
@@ -117,6 +116,7 @@ public:
     Medium,
     Large,
   };
+  Q_ENUM(ThumbnailSizeOption)
 
   ///@{
   /// Set the thumbnail size: small, medium, large

--- a/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.h
@@ -74,7 +74,6 @@ class ctkFileDialog;
 class CTK_DICOM_WIDGETS_EXPORT ctkDICOMVisualBrowserWidget : public QWidget
 {
   Q_OBJECT;
-  Q_ENUMS(ImportDirectoryMode)
   Q_PROPERTY(QString databaseDirectory READ databaseDirectory WRITE setDatabaseDirectory)
   Q_PROPERTY(QString databaseDirectorySettingsKey READ databaseDirectorySettingsKey WRITE setDatabaseDirectorySettingsKey)
   Q_PROPERTY(QString databaseDirectoryBase READ databaseDirectoryBase WRITE setDatabaseDirectoryBase)
@@ -278,6 +277,7 @@ public:
     ImportDirectoryCopy = 0,
     ImportDirectoryAddLink
   };
+  Q_ENUM(ImportDirectoryMode)
 
   /// \brief Get value of ImportDirectoryMode settings.
   ///

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.h
@@ -96,7 +96,7 @@ public:
     FileInput,
     SingleInput
   };
-  Q_ENUMS(ExecuteStringMode);
+  Q_ENUM(ExecuteStringMode)
 
   /// Execute a python of python code (can be multiple lines separated with newline)
   /// and return the result as a QVariant.

--- a/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKRenderView.h
@@ -37,7 +37,6 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKRenderView : public ctkVTKAbstr
              WRITE setOrientationWidgetVisible)
   Q_PROPERTY(double zoomFactor READ zoomFactor WRITE setZoomFactor)
   Q_PROPERTY(double pitchRollYawIncrement READ pitchRollYawIncrement WRITE setPitchRollYawIncrement)
-  Q_ENUMS(RotateDirection)
   Q_PROPERTY(RotateDirection pitchDirection READ pitchDirection WRITE setPitchDirection)
   Q_PROPERTY(RotateDirection rollDirection READ rollDirection WRITE setRollDirection)
   Q_PROPERTY(RotateDirection yawDirection READ yawDirection WRITE setYawDirection)
@@ -51,6 +50,7 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKRenderView : public ctkVTKAbstr
 public:
 
   enum RotateDirection { PitchUp, PitchDown, RollLeft, RollRight, YawLeft, YawRight };
+  Q_ENUM(RotateDirection)
 
   typedef ctkVTKAbstractView Superclass;
   explicit ctkVTKRenderView(QWidget* parent = 0);

--- a/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKSliceView.h
@@ -38,7 +38,6 @@ class vtkAlgorithmOutput;
 class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKSliceView : public ctkVTKAbstractView
 {
   Q_OBJECT
-  Q_ENUMS(RenderWindowLayoutType)
   Q_PROPERTY(RenderWindowLayoutType renderWindowLayoutType
              READ renderWindowLayoutType WRITE setRenderWindowLayoutType)
   Q_PROPERTY(QColor highlightedBoxColor READ highlightedBoxColor WRITE setHighlightedBoxColor)
@@ -55,6 +54,7 @@ public:
   /// within the different render view items.
   /// \sa setRenderWindowLayout() renderWindowLayoutType()
   enum RenderWindowLayoutType{LeftRightTopBottom = 0, LeftRightBottomTop};
+  Q_ENUM(RenderWindowLayoutType)
 
   /// Set active camera
   void setActiveCamera(vtkCamera * newActiveCamera);

--- a/Libs/Widgets/ctkAxesWidget.h
+++ b/Libs/Widgets/ctkAxesWidget.h
@@ -34,7 +34,6 @@ class ctkAxesWidgetPrivate;
 class CTK_WIDGETS_EXPORT ctkAxesWidget : public QWidget
 {
   Q_OBJECT
-  Q_ENUMS(Axis)
   Q_PROPERTY(Axis currentAxis READ currentAxis WRITE setCurrentAxis NOTIFY currentAxisChanged)
   Q_PROPERTY(bool autoReset READ autoReset WRITE setAutoReset)
   Q_PROPERTY(QStringList axesLabels READ axesLabels WRITE setAxesLabels)
@@ -50,6 +49,7 @@ public :
     Anterior,
     Posterior,
   };
+  Q_ENUM(Axis)
 
   ctkAxesWidget(QWidget *parent = 0);
   virtual ~ctkAxesWidget();

--- a/Libs/Widgets/ctkBasePopupWidget.h
+++ b/Libs/Widgets/ctkBasePopupWidget.h
@@ -43,9 +43,6 @@ class CTK_WIDGETS_EXPORT ctkBasePopupWidget : public QFrame
 {
   Q_OBJECT
 
-  Q_ENUMS(AnimationEffect)
-  Q_ENUMS(VerticalDirection)
-
   /// This property controls the effect to apply when the popup is being
   /// opened or closed. The total duration and the easing curve of the effect
   /// are controlled by \a effectDuration and \easingCurve respectively.
@@ -111,6 +108,7 @@ public:
     ScrollEffect,
     FadeEffect
   };
+  Q_ENUM(AnimationEffect)
 
   /// Return the animationEffect property value.
   /// \sa animationEffect
@@ -151,6 +149,7 @@ public:
     TopToBottom = 1,
     BottomToTop = 2
   };
+  Q_ENUM(VerticalDirection)
 
   /// Return the verticalDirection property value.
   /// \sa verticalDirection

--- a/Libs/Widgets/ctkComboBox.h
+++ b/Libs/Widgets/ctkComboBox.h
@@ -55,7 +55,6 @@ class CTK_WIDGETS_EXPORT ctkComboBox : public QComboBox
   /// Current item's user data as string (Qt::UserRole role)
   Q_PROPERTY(QString currentUserDataAsString READ currentUserDataAsString WRITE setCurrentUserDataAsString)
 
-  Q_ENUMS(ScrollEffect);
 public:
   /// Constructor, build a ctkComboBox that behaves like QComboBox.
   explicit ctkComboBox(QWidget* parent = 0);
@@ -93,6 +92,7 @@ public:
     /// a visible vertical scrollbar.
     ScrollWithNoVScrollBar
   };
+  Q_ENUM(ScrollEffect)
   /// Return the scrollWheelEffect property value.
   /// \sa scrollEffect
   ScrollEffect scrollWheelEffect()const;

--- a/Libs/Widgets/ctkCompleter.h
+++ b/Libs/Widgets/ctkCompleter.h
@@ -52,7 +52,6 @@ class ctkCompleterPrivate;
 class CTK_WIDGETS_EXPORT ctkCompleter: public QCompleter
 {
   Q_OBJECT
-  Q_ENUMS(ModelFiltering)
   /// FilterStartsWith is the default behavior (same as QCompleter).The
   /// completer filters out strings that don't start with \sa completionPrefix
   /// FilterContains is the most permissive filter, the completer filters out
@@ -74,6 +73,7 @@ public:
     FilterContains,
     FilterWordStartsWith
   };
+  Q_ENUM(ModelFiltering)
 
   ModelFiltering modelFiltering()const;
   void setModelFiltering(ModelFiltering filter);

--- a/Libs/Widgets/ctkConsole.h
+++ b/Libs/Widgets/ctkConsole.h
@@ -81,7 +81,7 @@ class CTK_WIDGETS_EXPORT ctkConsole : public QWidget
   Q_PROPERTY(int cursorLine READ cursorLine)
   Q_FLAGS(EditorHint EditorHints)
   Q_PROPERTY(EditorHints editorHints READ editorHints WRITE setEditorHints)
-  Q_ENUMS(Qt::ScrollBarPolicy)
+  Q_ENUM(Qt::ScrollBarPolicy)
   Q_PROPERTY(Qt::ScrollBarPolicy scrollBarPolicy READ scrollBarPolicy WRITE setScrollBarPolicy)
   Q_PROPERTY(QList<QKeySequence> completerShortcuts READ completerShortcuts WRITE setCompleterShortcuts)
   Q_FLAGS(RunFileOption RunFileOptions)

--- a/Libs/Widgets/ctkDoubleSpinBox.h
+++ b/Libs/Widgets/ctkDoubleSpinBox.h
@@ -45,9 +45,7 @@ class ctkValueProxy;
 class CTK_WIDGETS_EXPORT ctkDoubleSpinBox : public QWidget
 {
   Q_OBJECT
-  Q_ENUMS(SetMode)
   Q_FLAGS(DecimalsOption DecimalsOptions)
-  Q_ENUMS(SizeHintPolicy)
 
   Q_PROPERTY(Qt::Alignment alignment READ alignment WRITE setAlignment)
   Q_PROPERTY(bool frame READ hasFrame WRITE setFrame)
@@ -110,6 +108,7 @@ public:
     SetAlways,
     SetIfDifferent,
   };
+  Q_ENUM(SetMode)
 
   /// DecimalsOption enums the input style of the spinbox decimals.
   /// Default option is DecimalsByShortcuts.
@@ -160,6 +159,7 @@ public:
     SizeHintByMinMax,
     SizeHintByValue
   };
+  Q_ENUM(SizeHintPolicy)
 
   typedef QWidget Superclass;
 

--- a/Libs/Widgets/ctkMaterialPropertyWidget.h
+++ b/Libs/Widgets/ctkMaterialPropertyWidget.h
@@ -39,7 +39,6 @@ class QListWidgetItem;
 class CTK_WIDGETS_EXPORT ctkMaterialPropertyWidget : public QWidget
 {
   Q_OBJECT
-  Q_ENUMS(InterpolationMode)
 
   /// This property holds the color of the material.
   Q_PROPERTY(QColor color  READ color WRITE setColor);
@@ -103,6 +102,7 @@ public:
     InterpolationPhong,
     InterpolationPBR
   };
+  Q_ENUM(InterpolationMode)
 
   /// Constructor
   explicit ctkMaterialPropertyWidget(QWidget* parent = 0);

--- a/Libs/Widgets/ctkMenuComboBox.h
+++ b/Libs/Widgets/ctkMenuComboBox.h
@@ -53,7 +53,6 @@ class ctkMenuComboBoxPrivate;
 class CTK_WIDGETS_EXPORT ctkMenuComboBox : public QWidget
 {
   Q_OBJECT
-  Q_ENUMS(EditableBehavior)
   /// This property holds the text shown on the combobox when there is no
   /// selected item.
   /// Empty by default.
@@ -83,6 +82,7 @@ public:
     EditableOnFocus,
     EditableOnPopup
   };
+  Q_ENUM(EditableBehavior)
 
   /// Superclass typedef
   typedef QWidget Superclass;

--- a/Libs/Widgets/ctkPathLineEdit.h
+++ b/Libs/Widgets/ctkPathLineEdit.h
@@ -106,7 +106,6 @@ class CTK_WIDGETS_EXPORT ctkPathLineEdit: public QWidget
   /// The default value is AdjustToMinimumContentsLength to prevent displaying
   /// of a long path making the layout too wide.
   Q_PROPERTY(SizeAdjustPolicy sizeAdjustPolicy READ sizeAdjustPolicy WRITE setSizeAdjustPolicy)
-  Q_ENUMS(SizeAdjustPolicy)
 
   /// This property holds the minimum number of characters that should fit into
   /// the path line edit.
@@ -168,7 +167,7 @@ public:
     /// use this policy on large models.
     AdjustToMinimumContentsLength
   };
-
+  Q_ENUM(SizeAdjustPolicy)
   /** Default constructor
   */
   ctkPathLineEdit(QWidget *parent = 0);

--- a/Libs/Widgets/ctkPathListWidget.h
+++ b/Libs/Widgets/ctkPathListWidget.h
@@ -67,7 +67,6 @@ class CTK_WIDGETS_EXPORT ctkPathListWidget : public QListView
   Q_PROPERTY(QIcon directoryIcon READ directoryIcon WRITE setDirectoryIcon RESET unsetDirectoryIcon)
 
   Q_FLAGS(PathOption PathOptions)
-  Q_ENUMS(Mode)
 
 public:
 
@@ -102,6 +101,7 @@ public:
     /// Allow only directory entries.
     DirectoriesOnly
   };
+  Q_ENUM(Mode)
 
   /// Superclass typedef
   typedef QListView Superclass;

--- a/Libs/Widgets/ctkSettingsPanel.h
+++ b/Libs/Widgets/ctkSettingsPanel.h
@@ -35,7 +35,6 @@ class ctkSettingsPanelPrivate;
 class CTK_WIDGETS_EXPORT ctkSettingsPanel : public QWidget
 {
   Q_OBJECT
-  Q_ENUMS(SettingOption)
   Q_FLAGS(SettingOptions)
 
   Q_PROPERTY(QSettings* settings READ settings WRITE setSettings);
@@ -58,6 +57,7 @@ public:
     OptionRequireRestart = 0x0001,
     OptionAll_Mask = ~0
   };
+  Q_ENUM(SettingOption)
   Q_DECLARE_FLAGS(SettingOptions, SettingOption)
   /// Add an entry into the settings uniquely defined by the \a key name and the
   /// current value of the property.

--- a/Libs/Widgets/ctkTransferFunctionBarsItem.h
+++ b/Libs/Widgets/ctkTransferFunctionBarsItem.h
@@ -37,7 +37,6 @@ class ctkTransferFunctionBarsItemPrivate;
 class CTK_WIDGETS_EXPORT ctkTransferFunctionBarsItem: public ctkTransferFunctionItem
 {
   Q_OBJECT
-  Q_ENUMS(LogMode)
   Q_PROPERTY(qreal barWidth READ barWidth WRITE setBarWidth)
   Q_PROPERTY(QColor barColor READ barColor WRITE setBarColor)
   Q_PROPERTY(LogMode logMode READ logMode WRITE setLogMode)
@@ -59,6 +58,7 @@ public:
     UseLog = 1,
     AutoLog =2
   };
+  Q_ENUM(LogMode)
   LogMode logMode() const;
   void setLogMode(const LogMode logMode);
 

--- a/Libs/Widgets/ctkWorkflowWidgetStep.h
+++ b/Libs/Widgets/ctkWorkflowWidgetStep.h
@@ -67,7 +67,6 @@ class CTK_WIDGETS_EXPORT ctkWorkflowWidgetStep : public QWidget, public ctkWorkf
   Q_PROPERTY(QString backButtonText READ backButtonText WRITE setBackButtonText)
   Q_PROPERTY(QString nextButtonText READ nextButtonText WRITE setNextButtonText)
   Q_FLAGS(ButtonBoxHint ButtonBoxHints)
-  Q_ENUMS(ButtonBoxHint)
   Q_PROPERTY(ButtonBoxHints buttonBoxHints READ buttonBoxHints WRITE setButtonBoxHints)
 public:
 
@@ -79,6 +78,7 @@ public:
     NextButtonDisabled = 0x8,
     ButtonBoxHidden = 0x10
   };
+  Q_ENUM(ButtonBoxHint)
   Q_DECLARE_FLAGS(ButtonBoxHints, ButtonBoxHint)
 
   explicit ctkWorkflowWidgetStep(QWidget* newParent = 0);


### PR DESCRIPTION
Replace `Q_ENUMS(...)` with `Q_ENUM(...)` across the codebase and position the macro immediately after the corresponding enum declaration, per Qt guidance.

Removes deprecation warnings and aligns with Qt5.5+ / Qt6.
