### PR TITLE
COMP: Fix ctkDICOMSchedulerTest1 test

### DIFF
--- a/Libs/DICOM/Core/Testing/Cpp/ctkDICOMSchedulerTest1.cpp
+++ b/Libs/DICOM/Core/Testing/Cpp/ctkDICOMSchedulerTest1.cpp
@@ -151,7 +151,10 @@ int ctkDICOMSchedulerTest1(int argc, char* argv[])
       sopIstanceUID, QThread::LowPriority, QStringList("Test"));
   }
 
-  CHECK_INT(scheduler.numberOfJobs(), numberOfImages);
+  // Check the number of running jobs instead of the total number of jobs
+  // because jobs are not automatically destroyed when they finish.
+  // This ensures the test is checking the active jobs accurately.
+  CHECK_INT(scheduler.numberOfRunningJobs(), numberOfImages);
   scheduler.waitForFinish(false, true);
 
   instances = database.instancesForSeries(seriesIstanceUID);


### PR DESCRIPTION
This changes the test to check the number of running jobs instead of the total number of jobs. The previous check was incorrect because jobs are not automatically destroyed when they finish, leading to a mismatch in the expected number of jobs.

The updated check ensures that the number of running jobs matches the number of images. This should generally hold true unless an image retrieval finishes before the check, making the test non-deterministic in some cases. We can observe this behavior and adjust if necessary.