### PR TITLE
BUG: Fix display of spacing string in ctkQImageView

### DIFF
--- a/Libs/Widgets/ctkQImageView.cpp
+++ b/Libs/Widgets/ctkQImageView.cpp
@@ -1075,9 +1075,9 @@ void ctkQImageView::update( bool zoomChanged,
           }
 
           QString spacingString = tr("Spacing = %1, %2, %3")
-            .arg(QString::number(this->xSpacing()), 'f', 3)
-            .arg(QString::number(this->ySpacing()), 'f', 3)
-            .arg(QString::number(this->sliceThickness()), 'f', 3);
+            .arg(QString::number(this->xSpacing(), 'f', 3))
+            .arg(QString::number(this->ySpacing(), 'f', 3))
+            .arg(QString::number(this->sliceThickness(), 'f', 3));
           QRectF spacingBound = painter.boundingRect( pointRect, textFlags,
             spacingString );
           QRectF spacingRect(


### PR DESCRIPTION
- Also fixes a warning/error depending on the build settings

--- 

_Description updated by @jcfr_

This pull request addresses a regression in `ctkQImageView` where the spacing string was not being formatted correctly. The issue was introduced in a previous commit (e6d44f8a) while marking strings translatable. The patch ensures that `QString::number` is called with the correct arguments to format the spacing  values properly.
