### PR TITLE
BUG: Fixed VTK views not updating

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
@@ -262,6 +262,7 @@ void ctkVTKAbstractView::forceRender()
     return;
   }
   d->RenderWindow->Render();
+  this->update();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
On some computers, VTK views were not updating until the mouse was moved on the screen. This was due to Qt not repainting the view after the VTK rendering was completed, because the widget was not scheduled for repaint.

fixes https://github.com/Slicer/Slicer/issues/7206