### PR TITLE
ENH: Update ExternalProjectDependency based on commontk/Artichoke@00601c2

### DIFF
--- a/CMake/ctkMacroCheckExternalProjectDependency.cmake
+++ b/CMake/ctkMacroCheckExternalProjectDependency.cmake
@@ -529,6 +529,15 @@ function(_sb_get_external_project_arguments proj varname)
     # See https://cmake.org/cmake/help/latest/policy/CMP0135.html
     list(APPEND _ep_arguments DOWNLOAD_EXTRACT_TIMESTAMP 1)
   endif()
+  if(CMAKE_VERSION VERSION_EQUAL "3.28" OR CMAKE_VERSION VERSION_GREATER "3.28")
+    # Address "gmake[N]: *** read jobs pipe: Bad file descriptor." issue associated with
+    # build command.
+    # For more details:
+    # - https://gitlab.kitware.com/cmake/cmake/-/issues/26398
+    # - https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8667
+    # - https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10014
+    list(APPEND _ep_arguments BUILD_JOB_SERVER_AWARE ON)
+  endif()
   set(${varname} ${_ep_arguments} PARENT_SCOPE)
 endfunction()
 
@@ -643,7 +652,7 @@ endfunction()
 #
 # .. code-block:: cmake
 #
-#  DEPENDS  List of additional dependencies to associat with `<project_name>`.
+#  DEPENDS  List of additional dependencies to associate with `<project_name>`.
 #
 macro(ExternalProject_Add_Dependencies project_name)
   set(options)


### PR DESCRIPTION
This changes ensures BUILD_JOB_SERVER_AWARE option is set on each external projects for CMake >= 3.28 and above. It addresses the `gmake[N]: *** read jobs pipe: Bad file descriptor.` issue associated with the build command.

List of changes:

```
$ git shortlog dff357a..00601c2 --no-merges
Jean-Christophe Fillion-Robin (19):
      style: Fix typos identified using codespell
      ci: Add "codespell" GitHub Actions workflow
      ci: Update CI workflow runner from ubuntu-20.04 to ubuntu-22.04
      ci: Update CI workflow to test newer CMake versions >= 3.28.x
      ci: Ensure all jobs run independently of failure
      ci: Update CI workflow to report installed CMake version
      ci: Fix ctest execution for CMake >= 3.30 passing an empty string as label to exclude
      ci: Support testing using CMake >= 4.0
      ci: Update CI workflow pinning GitHub actions to full-length commit SHA
      ci: Add dependabot configuration files
      ci: Add convenient "pass" job to streamline branch protection
      ci: Retire CircleCI
      ci: Update GitHub workflow to run tests in selected docker containers
      ci: Test against "dockbuild/almalinux8-devtoolset14-gcc14" container
      ci: Fix execution steps in container tests using GITHUB_WORKSPACE env var
      ci: Retire testing of "dockbuild/centos7-devtoolset7-gcc7" docker env
      tests: Change "add_project_test" from macro to function
      ExternalProjectDependency: Ensure BUILD_JOB_SERVER_AWARE options is set
      tests: Add IncludeDependencies-JOB_SERVER_AWARE-Test

dependabot[bot] (1):
      Bump the actions group with 3 updates
```