### PR TITLE
BUG: Fix out of range array access in ctkPythonConsole

### DIFF
--- a/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
+++ b/Libs/Scripting/Python/Widgets/ctkPythonConsole.cpp
@@ -361,7 +361,7 @@ QString ctkPythonConsoleCompleterPrivate::searchUsableCharForCompletion(const QS
 //----------------------------------------------------------------------------
 bool ctkPythonConsoleCompleterPrivate::PythonAttributeLessThan(const QString& s1, const QString& s2)
 {
-  if (!s1.isEmpty() || !s2.isEmpty())
+  if (!s1.isEmpty() && !s2.isEmpty())
   {
     // Move Python private attributes to the back (start with underscore)
     if (s1[0] == QChar('_') && s2[0] != QChar('_'))


### PR DESCRIPTION
PythonAttributeLessThan method check if both
QString parameters are not empty before accessing
first element of both QString.