### PR TITLE
BUG: Fixed VTK chart views not updating

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
@@ -353,6 +353,8 @@ void ctkVTKChartView::setChartUserExtent(double* userExtent)
   axis->SetRange(userExtent[4], userExtent[5]);
   axis = chart->GetAxis(vtkAxis::RIGHT);
   axis->SetRange(userExtent[6], userExtent[7]);
+  // Repaint the scene
+  this->scene()->SetDirty(true);
 }
 
 // ----------------------------------------------------------------------------
@@ -405,6 +407,8 @@ void ctkVTKChartView::setAxesToChartBounds()
       chart->GetAxis(i)->SetRange(bounds[2*i], bounds[2*i+1]);
     }
   }
+  // Repaint the scene
+  this->scene()->SetDirty(true);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
When a chart view is zoomed, the mouse middle button double click reset the view, but only after the mouse is moved.
This fix (and bug) is equivalent to:
https://github.com/commontk/CTK/pull/1258