### PR TITLE
COMP: Fix genex associated with CTKVisualizationVTKCore compile definition

### DIFF
--- a/Libs/Visualization/VTK/Core/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Core/CMakeLists.txt
@@ -239,7 +239,7 @@ ctkMacroBuildLib(
 
 target_compile_definitions(${PROJECT_NAME}
   PUBLIC
-    $<$<BOOL:CTK_LIB_Visualization/VTK/Widgets_USE_TRANSFER_FUNCTION_CHARTS>:CTK_USE_CHARTS>
+    $<$<BOOL:${CTK_LIB_Visualization/VTK/Widgets_USE_TRANSFER_FUNCTION_CHARTS}>:CTK_USE_CHARTS>
   )
 
 if(CTK_WRAP_PYTHONQT_LIGHT)


### PR DESCRIPTION
Follow-up of e57bc570 ("COMP: Simplify CTK_USE_CHARTS definition leveraging usage requirement", 2025-11-03) introduced through https://github.com/commontk/CTK/pull/1266