### PR TITLE
COMP: Set CMP0177 to ensure install() DESTINATION paths are normalized

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@
 cmake_minimum_required(VERSION 3.20.6)
 
 foreach(p
+  CMP0177 # CMake 3.31
   )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)


### PR DESCRIPTION
This fixes warning like the following:

```
CMake Warning (dev) at CMake/ctkMacroBuildQtPlugin.cmake:145 (install):
  Policy CMP0177 is not set: install() DESTINATION paths are normalized.  Run
  "cmake --help-policy CMP0177" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
Call Stack (most recent call first):
  CMake/ctkMacroBuildQtPlugin.cmake:182 (ctkMacroBuildQtPlugin)
  Libs/Visualization/VTK/Widgets/Plugins/CMakeLists.txt:59 (ctkMacroBuildQtDesignerPlugin)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

See https://cmake.org/cmake/help/latest/policy/CMP0177.html