### PR TITLE
COMP: Fix PythonQt & PythonQtGenerator build ensuring Qt DIR is passed

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -50,13 +50,15 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
     endif()
     set(_qt_version_string "${Qt5_VERSION_MAJOR}.${Qt5_VERSION_MINOR}.${Qt5_VERSION_PATCH}")
   elseif(CTK_QT_VERSION VERSION_EQUAL "6")
-    list(APPEND ep_cache_args
+    list(APPEND ep_PythonQt_args
       -DQt6_DIR:PATH=${Qt6_DIR}
       )
     set(_qt_version_string "${Qt6_VERSION_MAJOR}.${Qt6_VERSION_MINOR}.${Qt6_VERSION_PATCH}")
   else()
     message(FATAL_ERROR "Support for Qt${CTK_QT_VERSION} is not implemented")
   endif()
+
+  set(ep_PythonQtGenerator_args ${ep_PythonQt_args})
 
   # Enable PythonQt wrappers
   foreach(qtlib All ${qtlibs})
@@ -125,6 +127,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
     CMAKE_CACHE_ARGS
       ${ep_common_cache_args}
       -DPythonQtGenerator_QT_VERSION:STRING=${CTK_QT_VERSION}
+      ${ep_PythonQtGenerator_args}
     INSTALL_COMMAND ""
     DEPENDS
       ${proj}-source


### PR DESCRIPTION
Fixes regressions introduced in 069eef8d ("COMP: Update PythonQt and add for building wrappers based on current Qt version", 2025-10-30) and a0e74a08 ("COMP: Update CMake files removing support for Qt 4.x", 2023-07-18).

This change ensures that the correct Qt directory is passed to both PythonQt and PythonQtGenerator during the build process.