### PR TITLE
COMP: Switch to QStyleOption::initFrom anticipating Qt6 transition

### DIFF
--- a/Libs/Widgets/ctkCheckablePushButton.cpp
+++ b/Libs/Widgets/ctkCheckablePushButton.cpp
@@ -88,7 +88,7 @@ QStyleOptionButton ctkCheckablePushButtonPrivate::drawIcon(QPainter* p)
 
   QStyleOptionButton indicatorOpt;
 
-  indicatorOpt.init(q);
+  indicatorOpt.initFrom(q);
   if (!this->CheckBoxUserCheckable)
   {
     indicatorOpt.state &= ~QStyle::State_Enabled;

--- a/Libs/Widgets/ctkCollapsibleButton.cpp
+++ b/Libs/Widgets/ctkCollapsibleButton.cpp
@@ -555,7 +555,7 @@ void ctkCollapsibleButton::paintEvent(QPaintEvent * _event)
   int buttonMargin = this->style()->pixelMetric(QStyle::PM_ButtonMargin, &opt, this);
   // Draw Indicator
   QStyleOption indicatorOpt;
-  indicatorOpt.init(this);
+  indicatorOpt.initFrom(this);
   if (d->IndicatorAlignment & Qt::AlignLeft)
   {
     indicatorOpt.rect = QRect((buttonHeight - indicatorSize.width()) / 2,
@@ -645,7 +645,7 @@ void ctkCollapsibleButton::paintEvent(QPaintEvent * _event)
 
   // Draw Frame around contents
   QStyleOptionFrame fopt;
-  fopt.init(this);
+  fopt.initFrom(this);
   // HACK: on some styles, the frame doesn't exactly touch the button.
   // this is because the button has some kind of extra border.
   {

--- a/Libs/Widgets/ctkExpandButton.cpp
+++ b/Libs/Widgets/ctkExpandButton.cpp
@@ -102,7 +102,7 @@ void ctkExpandButton::setOrientation(Qt::Orientation newOrientation)
 {
   Q_D(ctkExpandButton);
   QStyleOption opt;
-  opt.init(this);
+  opt.initFrom(this);
   if(newOrientation == Qt::Horizontal)
   {
     d->defaultPixmap = this->style()->standardPixmap(

--- a/Libs/Widgets/ctkMenuButton.cpp
+++ b/Libs/Widgets/ctkMenuButton.cpp
@@ -159,7 +159,7 @@ void ctkMenuButton::paintEvent(QPaintEvent * _event)
                    QPoint(downArrowRect.left(), downArrowRect.bottom() - borderSize));
   // Draw arrow
   QStyleOption indicatorOpt;
-  indicatorOpt.init(this);
+  indicatorOpt.initFrom(this);
   indicatorOpt.rect = downArrowRect.adjusted(borderSize, borderSize, -borderSize, -borderSize);
   painter.drawPrimitive(QStyle::PE_IndicatorArrowDown, indicatorOpt);
 

--- a/Libs/Widgets/ctkPushButton.cpp
+++ b/Libs/Widgets/ctkPushButton.cpp
@@ -160,7 +160,7 @@ QStyleOptionButton ctkPushButtonPrivate::drawIcon(QPainter* p)
 {
   Q_Q(ctkPushButton);
   QStyleOptionButton iconOpt;
-  iconOpt.init(q);
+  iconOpt.initFrom(q);
   iconOpt.rect = this->iconRect();
   if (q->icon().isNull())
   {

--- a/Libs/Widgets/ctkSizeGrip.cpp
+++ b/Libs/Widgets/ctkSizeGrip.cpp
@@ -223,7 +223,7 @@ QSize ctkSizeGrip::sizeHint() const
       break;
   };
   QStyleOption opt(0);
-  opt.init(this);
+  opt.initFrom(this);
   return (this->style()->sizeFromContents(contents, &opt, minSize, this).
           expandedTo(QApplication::globalStrut()));
 }
@@ -262,7 +262,7 @@ void ctkSizeGrip::paintEvent(QPaintEvent *event)
     default:
     {
       QStyleOptionSizeGrip opt;
-      opt.init(this);
+      opt.initFrom(this);
       opt.corner = this->isLeftToRight() ? Qt::BottomRightCorner : Qt::BottomLeftCorner;
       style()->drawControl(QStyle::CE_SizeGrip, &opt, &painter, this);
       break;


### PR DESCRIPTION
Since `QStyleOption::initFrom` and `QStyleOption::init` are equivalent and `QStyleOption::init` is removed in Qt6, this commit switches to the expected function.