### PR TITLE
COMP: Explicitly include headers to support mocing with Qt6

### DIFF
--- a/Libs/Core/Documentation/Snippets/CommandLineParser/main.cpp
+++ b/Libs/Core/Documentation/Snippets/CommandLineParser/main.cpp
@@ -2,6 +2,7 @@
 #include <ctkCommandLineParser.h>
 
 #include <QCoreApplication>
+#include <QIODevice>
 #include <QTextStream>
 
 #include <cstdlib>

--- a/Libs/DICOM/Core/ctkDICOMItem.cpp
+++ b/Libs/DICOM/Core/ctkDICOMItem.cpp
@@ -26,6 +26,8 @@
 #include <dcmtk/dcmdata/dcostrmb.h>
 #include <dcmtk/dcmdata/dcistrmb.h>
 
+#include <QTextDecoder>
+
 #include <stdexcept>
 
 

--- a/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
@@ -54,7 +54,6 @@
 #include "ctkDICOMAppWidget.h"
 #include "ctkDICOMThumbnailGenerator.h"
 #include "ctkThumbnailLabel.h"
-#include "ctkDICOMQueryResultsTabWidget.h"
 #include "ctkDICOMQueryRetrieveWidget.h"
 #include "ctkDICOMQueryWidget.h"
 

--- a/Libs/DICOM/Widgets/ctkDICOMAppWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMAppWidget.h
@@ -25,11 +25,11 @@
 #include <QWidget>
 
 #include "ctkDICOMWidgetsExport.h"
+#include <ctkDICOMDatabase.h>
 
 class ctkDICOMAppWidgetPrivate;
 class ctkThumbnailLabel;
 class QModelIndex;
-class ctkDICOMDatabase;
 
 /// \ingroup DICOM_Widgets
 class CTK_DICOM_WIDGETS_EXPORT ctkDICOMAppWidget : public QWidget

--- a/Libs/DICOM/Widgets/ctkDICOMMetadataDialog.h
+++ b/Libs/DICOM/Widgets/ctkDICOMMetadataDialog.h
@@ -23,7 +23,7 @@
 
 // Qt includes
 #include <QDialog>
-class QStringList;
+#include <QStringList>
 
 // CTK includes
 #include "ctkDICOMWidgetsExport.h"

--- a/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.h
+++ b/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.h
@@ -32,8 +32,8 @@
 #include <ctkDICOMDatabase.h>
 
 // ctkDICOMWidgets includes
+#include <ctkDICOMTableManager.h>
 #include "ctkDICOMWidgetsExport.h"
-class ctkDICOMTableManager;
 class ctkDICOMQueryRetrieveWidgetPrivate;
 
 /// \ingroup DICOM_Widgets

--- a/Libs/DICOM/Widgets/ctkDICOMTableView.h
+++ b/Libs/DICOM/Widgets/ctkDICOMTableView.h
@@ -23,6 +23,7 @@
 
 // Qt includes
 #include <QItemSelection>
+#include <QTableView>
 #include <QWidget>
 
 // ctkDICOMCore includes
@@ -30,7 +31,6 @@
 #include "ctkDICOMWidgetsExport.h"
 
 class ctkDICOMTableViewPrivate;
-class QTableView;
 
 /**
  * @brief The ctkDICOMTableView displays the content of a specific table of the ctkDICOMDatabase

--- a/Libs/Widgets/ctkActionsWidget.cpp
+++ b/Libs/Widgets/ctkActionsWidget.cpp
@@ -22,6 +22,7 @@
 #include <QAction>
 #include <QDebug>
 #include <QHeaderView>
+#include <QMenu>
 #include <QPainter>
 #include <QSortFilterProxyModel>
 #include <QStandardItem>

--- a/Libs/Widgets/ctkCollapsibleButton.cpp
+++ b/Libs/Widgets/ctkCollapsibleButton.cpp
@@ -27,7 +27,6 @@
 #include <QPushButton>
 #include <QStyle>
 #include <QStyleOptionButton>
-#include <QStyleOptionFrameV3>
 
 // CTK includes
 #include "ctkCollapsibleButton.h"

--- a/Libs/Widgets/ctkSettingsDialog.h
+++ b/Libs/Widgets/ctkSettingsDialog.h
@@ -23,15 +23,15 @@
 
 // Qt includes
 #include <QDialog>
+#include <QSettings>
 
 // CTK includes
 #include "ctkWidgetsExport.h"
+#include "ctkSettingsPanel.h"
 
 class QAbstractButton;
-class QSettings;
 class QTreeWidgetItem;
 class ctkSettingsDialogPrivate;
-class ctkSettingsPanel;
 
 /// \ingroup Widgets
 class CTK_WIDGETS_EXPORT ctkSettingsDialog : public QDialog

--- a/Libs/Widgets/ctkSettingsPanel.h
+++ b/Libs/Widgets/ctkSettingsPanel.h
@@ -23,12 +23,12 @@
 
 // Qt includes
 #include <QMetaType>
+#include <QSettings>
 #include <QWidget>
 
 // CTK includes
 #include "ctkWidgetsExport.h"
 
-class QSettings;
 class ctkSettingsPanelPrivate;
 
 /// \ingroup Widgets


### PR DESCRIPTION
This changes the code to include specific headers directly instead of using forward declarations. This is necessary to support the mocing process with Qt6.

It also removes unused headers.