### PR TITLE
COMP: Replace QRegExp with QRegularExpression

### DIFF
--- a/Libs/Core/ctkCommandLineParser.cpp
+++ b/Libs/Core/ctkCommandLineParser.cpp
@@ -23,6 +23,7 @@
 
 // Qt includes
 #include <QHash>
+#include <QRegExp>
 #include <QStringList>
 #include <QTextStream>
 #include <QDebug>

--- a/Libs/Core/ctkErrorLogAbstractModel.cpp
+++ b/Libs/Core/ctkErrorLogAbstractModel.cpp
@@ -27,6 +27,7 @@
 #include <QMetaType>
 #include <QMutexLocker>
 #include <QPointer>
+#include <QRegularExpression>
 #include <QStringList>
 #include <QThread>
 
@@ -376,9 +377,9 @@ void ctkErrorLogAbstractModel::filterEntry(const ctkErrorLogLevel::LogLevels& lo
   Q_D(ctkErrorLogAbstractModel);
 
   QStringList patterns;
-  if (!this->filterRegExp().pattern().isEmpty())
+  if (!this->filterRegularExpression().pattern().isEmpty())
   {
-    patterns << this->filterRegExp().pattern().split("|");
+    patterns << this->filterRegularExpression().pattern().split("|");
   }
   patterns.removeAll(d->ErrorLogLevel(ctkErrorLogLevel::None));
 
@@ -414,7 +415,7 @@ void ctkErrorLogAbstractModel::filterEntry(const ctkErrorLogLevel::LogLevels& lo
   }
 
   bool filterChanged = true;
-  QStringList currentPatterns = this->filterRegExp().pattern().split("|");
+  QStringList currentPatterns = this->filterRegularExpression().pattern().split("|");
   if (currentPatterns.count() == patterns.count())
   {
     foreach(const QString& p, patterns)
@@ -424,7 +425,7 @@ void ctkErrorLogAbstractModel::filterEntry(const ctkErrorLogLevel::LogLevels& lo
     filterChanged = currentPatterns.count() > 0;
   }
 
-  this->setFilterRegExp(patterns.join("|"));
+  this->setFilterRegularExpression(patterns.join("|"));
 
   if (filterChanged)
   {
@@ -440,7 +441,7 @@ ctkErrorLogLevel::LogLevels ctkErrorLogAbstractModel::logLevelFilter()const
   Q_ASSERT(QString("LogLevel").compare(logLevelEnum.name()) == 0);
 
   ctkErrorLogLevel::LogLevels filter = ctkErrorLogLevel::Unknown;
-  foreach(const QString& filterAsString, this->filterRegExp().pattern().split("|"))
+  foreach(const QString& filterAsString, this->filterRegularExpression().pattern().split("|"))
   {
     filter |= static_cast<ctkErrorLogLevel::LogLevels>(logLevelEnum.keyToValue(filterAsString.toLatin1()));
   }

--- a/Libs/Core/ctkUtils.cpp
+++ b/Libs/Core/ctkUtils.cpp
@@ -21,7 +21,6 @@
 // Qt includes
 #include <QDebug>
 #include <QDir>
-#include <QRegExp>
 #include <QString>
 #include <QStringList>
 
@@ -152,14 +151,17 @@ QString ctk::extensionToRegExp(const QString& extension)
 }
 
 //-----------------------------------------------------------------------------
-QRegExp ctk::nameFiltersToRegExp(const QStringList& nameFilters)
+namespace
+{
+// Convert name filters to a regular expression pattern string for use with QRegularExpression.
+QString nameFiltersToRegExpPattern(const QStringList& nameFilters)
 {
   QString pattern;
   foreach(const QString& nameFilter, nameFilters)
   {
-    foreach(const QString& extension, nameFilterToExtensions(nameFilter))
+    foreach(const QString& extension, ctk::nameFilterToExtensions(nameFilter))
     {
-      QString regExpExtension = extensionToRegExp(extension);
+      QString regExpExtension = ctk::extensionToRegExp(extension);
       if (!regExpExtension.isEmpty())
       {
         if (pattern.isEmpty())
@@ -182,7 +184,21 @@ QRegExp ctk::nameFiltersToRegExp(const QStringList& nameFilters)
   {
     pattern += ")";
   }
-  return QRegExp(pattern);
+  return pattern;
+}
+
+} // namespace
+
+//-----------------------------------------------------------------------------
+QRegExp ctk::nameFiltersToRegExp(const QStringList& nameFilters)
+{
+    return QRegExp(nameFiltersToRegExpPattern(nameFilters));
+}
+
+//-----------------------------------------------------------------------------
+QRegularExpression ctk::nameFiltersToRegularExpression(const QStringList& nameFilters)
+{
+  return QRegularExpression(nameFiltersToRegExpPattern(nameFilters));
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Core/ctkUtils.h
+++ b/Libs/Core/ctkUtils.h
@@ -30,6 +30,8 @@
 #include <QLinkedList>
 #endif
 #include <QModelIndex>
+#include <QRegExp>
+#include <QRegularExpression>
 #include <QStringList>
 
 // STD includes
@@ -147,6 +149,7 @@ CTK_CORE_EXPORT QString extensionToRegExp(const QString& extension);
 /// into a regular expression string
 /// "*.jpg", "*.txt" -> "(.*\\.jpg?$|.*\\.txt?$)"
 CTK_CORE_EXPORT QRegExp nameFiltersToRegExp(const QStringList& nameFilters);
+CTK_CORE_EXPORT QRegularExpression nameFiltersToRegularExpression(const QStringList& nameFilters);
 
 ///
 /// \ingroup Core

--- a/Libs/DICOM/Core/ctkDICOMFilterProxyModel.cpp
+++ b/Libs/DICOM/Core/ctkDICOMFilterProxyModel.cpp
@@ -22,6 +22,9 @@
 
 #include "ctkDICOMModel.h"
 
+// Qt includes
+#include <QRegularExpression>
+
 //logger
 #include <ctkLogger.h>
 static ctkLogger logger("org.commontk.DICOM.Core.ctkDICOMFilterProxyModel");
@@ -96,21 +99,21 @@ bool ctkDICOMFilterProxyModel::filterAcceptsRow(int source_row, const QModelInde
     if(model){
         QModelIndex index = model->index(source_row, 0, source_parent);
         if(model->data(index, ctkDICOMModel::TypeRole) == static_cast<int>(ctkDICOMModel::PatientType)){
-            QRegExp regExp = QRegExp(d->searchTextName);
+            QRegularExpression regExp = QRegularExpression(d->searchTextName);
             if(model->data(index, Qt::DisplayRole).toString().contains(regExp)){
                 return true;
             }else{
                 return false;
             }
         }else if(model->data(index, ctkDICOMModel::TypeRole) == static_cast<int>(ctkDICOMModel::StudyType)){
-            QRegExp regExp = QRegExp(d->searchTextStudy);
+            QRegularExpression regExp = QRegularExpression(d->searchTextStudy);
             if(model->data(index, Qt::DisplayRole).toString().contains(regExp)){
                 return true;
             }else{
                 return false;
             }
         }else if(model->data(index, ctkDICOMModel::TypeRole) == static_cast<int>(ctkDICOMModel::SeriesType)){
-            QRegExp regExp = QRegExp(d->searchTextSeries);
+            QRegularExpression regExp = QRegularExpression(d->searchTextSeries);
             if(model->data(index, Qt::DisplayRole).toString().contains(regExp)){
                 return true;
             }else{

--- a/Libs/Visualization/VTK/Core/ctkVTKConnection.cpp
+++ b/Libs/Visualization/VTK/Core/ctkVTKConnection.cpp
@@ -21,7 +21,7 @@
 // Qt includes
 #include <QDebug>
 #include <QPointer>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 #include <QTextStream>
 
@@ -323,7 +323,7 @@ void ctkVTKConnection::setup(vtkObject* vtk_obj, unsigned long vtk_event,
   d->Priority = priority;
   d->ConnectionType = connectionType;
 
-  if (d->QtSlot.contains(QRegExp(QString("\\( ?vtkObject ?\\* ?, ?vtkObject ?\\* ?\\)"))))
+  if (d->QtSlot.contains(QRegularExpression(QString("\\( ?vtkObject ?\\* ?, ?vtkObject ?\\* ?\\)"))))
   {
     d->SlotType = ctkVTKConnectionPrivate::ARG_VTKOBJECT_AND_VTKOBJECT;
   }

--- a/Libs/Widgets/Testing/Cpp/ctkSearchBoxTest2.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSearchBoxTest2.cpp
@@ -23,6 +23,7 @@
 #include <QDebug>
 #include <QLabel>
 #include <QListView>
+#include <QRegularExpression>
 #include <QSortFilterProxyModel>
 #include <QStringListModel>
 #include <QTimer>
@@ -48,7 +49,10 @@ int ctkSearchBoxTest2(int argc, char* argv[])
 
   search3.setText("phone");
 
-  QRegExp regExp(search3.text(),Qt::CaseInsensitive, QRegExp::Wildcard);
+  QRegularExpression regExp(
+      QRegularExpression::wildcardToRegularExpression(search3.text()),
+      QRegularExpression::CaseInsensitiveOption
+      );
 
   //QStringList testFilter = stringList.filter(search3.text());
   QStringList testFilter = stringList.filter(regExp);

--- a/Libs/Widgets/ctkCompleter.cpp
+++ b/Libs/Widgets/ctkCompleter.cpp
@@ -20,6 +20,7 @@
 
 // Qt includes
 #include <QDebug>
+#include <QRegularExpression>
 #include <QSortFilterProxyModel>
 #include <QStringList>
 
@@ -87,9 +88,9 @@ QStringList ctkCompleterPrivate::splitPath(const QString& s)
     case ctkCompleter::FilterWordStartsWith:
     {
       this->updateSortFilterProxyModel();
-      QRegExp regexp = QRegExp(QRegExp::escape(s));
-      regexp.setCaseSensitivity(q->caseSensitivity());
-      this->SortFilterProxyModel->setFilterRegExp(regexp);
+      QRegularExpression regexp(QRegularExpression::escape(s));
+      regexp.setPatternOptions(regexp.patternOptions().setFlag(QRegularExpression::CaseInsensitiveOption, q->caseSensitivity() == Qt::CaseInsensitive));
+      this->SortFilterProxyModel->setFilterRegularExpression(regexp);
       paths = QStringList();
       break;
     }

--- a/Libs/Widgets/ctkConsole.cpp
+++ b/Libs/Widgets/ctkConsole.cpp
@@ -60,6 +60,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QMimeData>
 #include <QPointer>
 #include <QPushButton>
+#include <QRegExp>
+#include <QRegularExpression>
 #include <QTextBlock>
 #include <QTextCursor>
 #include <QVBoxLayout>
@@ -720,7 +722,7 @@ void ctkConsolePrivate::updateCompleter()
     }
     commandText.remove(q_ptr->ps1());
     commandText.remove('\r'); // not recongnize by python
-    //commandText.replace(QRegExp("\\s*$"), ""); // Remove trailing spaces ---- DOESN'T WORK ----
+    //commandText.replace(QRegularExpression("\\s*$"), ""); // Remove trailing spaces ---- DOESN'T WORK ----
 
     // Save current positions: Since some implementation of
     // updateCompletionModel (e.g python) can display messages
@@ -815,7 +817,7 @@ void ctkConsolePrivate::internalExecuteCommand()
   QString command = this->commandBuffer();
   if (this->EditorHints & ctkConsole::RemoveTrailingSpaces)
   {
-    command.replace(QRegExp("\\s*$"), ""); // Remove trailing spaces
+    command.replace(QRegularExpression("\\s*$"), ""); // Remove trailing spaces
     this->commandBuffer() = command; // Update buffer
   }
 
@@ -862,7 +864,7 @@ void ctkConsolePrivate::processInput()
 
   if (this->EditorHints & ctkConsole::RemoveTrailingSpaces)
   {
-    command.replace(QRegExp("\\s*$"), ""); // Remove trailing spaces
+    command.replace(QRegularExpression("\\s*$"), ""); // Remove trailing spaces
     this->commandBuffer() = command; // Update buffer
   }
 
@@ -1086,7 +1088,7 @@ void ctkConsolePrivate::pasteText(const QString& text)
   if (this->EditorHints & ctkConsole::SplitCopiedTextByLine)
   {
     // Execute line by line
-    QStringList lines = text.split(QRegExp("(?:\r\n|\r|\n)"));
+    QStringList lines = text.split(QRegularExpression("(?:\r\n|\r|\n)"));
     for(int i=0; i < lines.count(); ++i)
     {
       this->switchToUserInputTextColor(&textCursor);

--- a/Libs/Widgets/ctkPathLineEdit.cpp
+++ b/Libs/Widgets/ctkPathLineEdit.cpp
@@ -29,7 +29,8 @@
 #include <QHBoxLayout>
 #include <QLineEdit>
 #include <QRegExp>
-#include <QRegExpValidator>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 #include <QSettings>
 #include <QStyleOptionComboBox>
 #include <QToolButton>
@@ -294,7 +295,7 @@ public:
   mutable QSize MinimumSizeHint;
 
   ctkFileCompleter* Completer;
-  QRegExpValidator* Validator;
+  QRegularExpressionValidator* Validator;
 };
 
 QString ctkPathLineEditPrivate::sCurrentDirectory = "";
@@ -326,7 +327,7 @@ void ctkPathLineEditPrivate::init()
   this->Completer = new ctkFileCompleter(q, true);
 
   // don't accept invalid path
-  this->Validator = new QRegExpValidator(q);
+  this->Validator = new QRegularExpressionValidator(q);
 
   this->createPathLineEditWidget(true);
 
@@ -480,7 +481,7 @@ void ctkPathLineEditPrivate::updateFilter()
   Q_Q(ctkPathLineEdit);
   this->Completer->setShowFiles(this->Filters & QDir::Files);
   this->Completer->setNameFilters(ctk::nameFiltersToExtensions(this->NameFilters));
-  this->Validator->setRegExp(ctk::nameFiltersToRegExp(this->NameFilters));
+  this->Validator->setRegularExpression(ctk::nameFiltersToRegularExpression(this->NameFilters));
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Widgets/ctkSettingsDialog.cpp
+++ b/Libs/Widgets/ctkSettingsDialog.cpp
@@ -140,7 +140,7 @@ void ctkSettingsDialogPrivate::updatePanelTitle(ctkSettingsPanel* panel)
 {
   QTreeWidgetItem* panelItem = this->item(panel);
   QString title = panelItem->text(0);
-  title.replace(QRegExp("\\*$"),"");
+  title.replace(QRegularExpression("\\*$"), "");
   if (!panel->changedSettings().isEmpty())
   {
     title.append('*');

--- a/Libs/Widgets/ctkWorkflowWidget.cpp
+++ b/Libs/Widgets/ctkWorkflowWidget.cpp
@@ -22,6 +22,7 @@
 #include <QApplication>
 #include <QDebug>
 #include <QPointer>
+#include <QRegExp>
 #include <QStyle>
 
 // CTK includes


### PR DESCRIPTION
This changes instances of QRegExp to QRegularExpression to comply with the Qt6 API. Remaining uses of QRegExp that do not require immediate changes are maintained for now. QRegExp will be made available through the Core5Compat Qt6 component.