### PR TITLE
BUG: Update ctkButtonGroup signals to support Qt6

### DIFF
--- a/Libs/Widgets/Testing/Cpp/ctkButtonGroupTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkButtonGroupTest1.cpp
@@ -140,9 +140,15 @@ int ctkButtonGroupTest1(int argc, char * argv [] )
   }
   qRegisterMetaType<QAbstractButton*>("QAbstractButton*");
   QSignalSpy spy(&buttonGroup, SIGNAL(buttonClicked(QAbstractButton*)));
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
   QSignalSpy spyInt(&buttonGroup, SIGNAL(buttonClicked(int)));
+#endif
   button1->click();
-  if (spy.count() != 1 || spyInt.count() != 1)
+  if (spy.count() != 1
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
+      || spyInt.count() != 1
+#endif
+      )
   {
     std::cerr << "ctkButtonGroup::click7 failed"
               << button1->isChecked() << ", "
@@ -150,7 +156,11 @@ int ctkButtonGroupTest1(int argc, char * argv [] )
     return EXIT_FAILURE;
   }
   button4->click();
-  if (spy.count() != 2 || spyInt.count() != 2)
+  if (spy.count() != 2
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
+      || spyInt.count() != 2
+#endif
+      )
   {
     std::cerr << "ctkButtonGroup::click8 failed"
               << button4->isChecked() << ", "
@@ -158,7 +168,11 @@ int ctkButtonGroupTest1(int argc, char * argv [] )
     return EXIT_FAILURE;
   }
   button4->click();
-  if (spy.count() != 3 || spyInt.count() != 3)
+  if (spy.count() != 3
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
+      || spyInt.count() != 3
+#endif
+      )
   {
     std::cerr << "ctkButtonGroup::click9 failed"
               << button4->isChecked() << ", "

--- a/Libs/Widgets/ctkButtonGroup.cpp
+++ b/Libs/Widgets/ctkButtonGroup.cpp
@@ -42,8 +42,8 @@ ctkButtonGroup::ctkButtonGroup(QObject* _parent)
   // we need to connect to button{Clicked,Pressed}(int) instead of
   // button{Clicked,Pressed}(QAbstractButton*) in order to be first to catch the
   // signals
-  connect(this, SIGNAL(buttonClicked(int)), this, SLOT(onButtonClicked(int)));
-  connect(this, SIGNAL(buttonPressed(int)), this, SLOT(onButtonPressed(int)));
+  connect(this, SIGNAL(buttonClicked(QAbstractButton*)), this, SLOT(onButtonClicked(QAbstractButton*)));
+  connect(this, SIGNAL(buttonPressed(QAbstractButton*)), this, SLOT(onButtonPressed(QAbstractButton*)));
 }
 
 //------------------------------------------------------------------------------
@@ -71,11 +71,9 @@ ctkButtonGroup::~ctkButtonGroup()
 }
 
 //------------------------------------------------------------------------------
-void ctkButtonGroup::onButtonClicked(int buttonId)
+void ctkButtonGroup::onButtonClicked(QAbstractButton* clickedButton)
 {
   Q_D(ctkButtonGroup);
-  QAbstractButton* clickedButton = this->button(buttonId);
-  Q_ASSERT(clickedButton);
   if (!this->exclusive() || !d->IsLastButtonPressedChecked)
   {
     return;
@@ -88,7 +86,9 @@ void ctkButtonGroup::onButtonClicked(int buttonId)
   clickedButton->setChecked(false);
   this->addButton(clickedButton, oldId);
   d->IsLastButtonPressedChecked = false;
-#if (QT_VERSION >= QT_VERSION_CHECK(5,15,0))
+#if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
+  // NA
+#elif (QT_VERSION >= QT_VERSION_CHECK(5,15,0))
   emit idToggled(oldId, false);
 #elif (QT_VERSION >= QT_VERSION_CHECK(5,2,0))
   emit buttonToggled(oldId, false);
@@ -99,10 +99,8 @@ void ctkButtonGroup::onButtonClicked(int buttonId)
 }
 
 //------------------------------------------------------------------------------
-void ctkButtonGroup::onButtonPressed(int buttonId)
+void ctkButtonGroup::onButtonPressed(QAbstractButton* pressedButton)
 {
   Q_D(ctkButtonGroup);
-  QAbstractButton* pressedButton = this->button(buttonId);
-  Q_ASSERT(pressedButton);
   d->IsLastButtonPressedChecked = pressedButton->isChecked();
 }

--- a/Libs/Widgets/ctkButtonGroup.h
+++ b/Libs/Widgets/ctkButtonGroup.h
@@ -58,8 +58,8 @@ public Q_SLOTS:
   void setChecked(QAbstractButton* button, bool checked = true);
 
 protected Q_SLOTS:
-  void onButtonClicked(int button);
-  void onButtonPressed(int button);
+  void onButtonClicked(QAbstractButton* button);
+  void onButtonPressed(QAbstractButton* button);
 
 protected:
   QScopedPointer<ctkButtonGroupPrivate> d_ptr;


### PR DESCRIPTION
This changes the connections of internal signals in ctkButtonGroup to use QAbstractButton* instead of int, ensuring compatibility with Qt6. Relevant tests are also updated to handle the changes in signal signature.