### PR TITLE
COMP: Replace deprecated QDesktopWidget usage with QScreen

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
@@ -26,7 +26,6 @@
 #include <QCloseEvent>
 #include <QComboBox>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QDialogButtonBox>
 #include <QFile>
 #include <QFileInfo>

--- a/Libs/DICOM/Widgets/ctkDICOMMetadataDialog.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMMetadataDialog.cpp
@@ -21,8 +21,13 @@
 // Qt includes
 #include <QApplication>
 #include <QCloseEvent>
+#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
 #include <QDesktopWidget>
+#endif
 #include <QHideEvent>
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+#include <QScreen>
+#endif
 #include <QShowEvent>
 #include <QStringList>
 #include <QVBoxLayout>
@@ -77,7 +82,12 @@ void ctkDICOMMetadataDialog::showEvent(QShowEvent* event)
     this->restoreGeometry(this->savedGeometry);
     if (this->isMaximized())
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+      QScreen* screen = this->screen() ? this->screen() : QGuiApplication::primaryScreen();
+      this->setGeometry(screen->availableGeometry());
+#else
       this->setGeometry(QApplication::desktop()->availableGeometry(this));
+#endif
     }
   }
 }

--- a/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
@@ -25,7 +25,6 @@
 #include <QCloseEvent>
 #include <QDebug>
 #include <QDate>
-#include <QDesktopWidget>
 #include <QFormLayout>
 #include <QMap>
 #include <QMenu>

--- a/Libs/Widgets/Testing/Cpp/ctkSettingsTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkSettingsTest1.cpp
@@ -20,9 +20,14 @@
 
 // Qt includes
 #include <QApplication>
+#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
 #include <QDesktopWidget>
+#endif
 #include <QDialog>
 #include <QMainWindow>
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+#include <QScreen>
+#endif
 #include <QTimer>
 
 // CTK includes
@@ -50,8 +55,13 @@ int ctkSettingsTest1(int argc, char * argv [] )
   QMainWindow mainWindow(0);
   mainWindow.show();
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+  QRect desktopRect = mainWindow.screen()->availableGeometry();
+#else
   QDesktopWidget desktop;
   QRect desktopRect = desktop.availableGeometry(&mainWindow);
+#endif
+
   const QPoint origin = desktopRect.topLeft();
 
   mainWindow.move(origin);

--- a/Libs/Widgets/ctkBasePopupWidget.cpp
+++ b/Libs/Widgets/ctkBasePopupWidget.cpp
@@ -21,7 +21,6 @@
 // Qt includes
 #include <QApplication>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QDir>
 #include <QEvent>
 #include <QLabel>

--- a/Libs/Widgets/ctkCheckableComboBox.cpp
+++ b/Libs/Widgets/ctkCheckableComboBox.cpp
@@ -22,7 +22,6 @@
 #include <QApplication>
 #include <QAbstractItemView>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QItemDelegate>
 #include <QLayout>
 #include <QMouseEvent>

--- a/Libs/Widgets/ctkCheckablePushButton.cpp
+++ b/Libs/Widgets/ctkCheckablePushButton.cpp
@@ -21,7 +21,6 @@
 // Qt includes
 #include <QApplication>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QLayout>
 #include <QMouseEvent>
 #include <QMenu>

--- a/Libs/Widgets/ctkMenuButton.cpp
+++ b/Libs/Widgets/ctkMenuButton.cpp
@@ -21,7 +21,6 @@
 // Qt includes
 #include <QApplication>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QLayout>
 #include <QMouseEvent>
 #include <QMenu>

--- a/Libs/Widgets/ctkPopupWidget.cpp
+++ b/Libs/Widgets/ctkPopupWidget.cpp
@@ -20,7 +20,6 @@
 
 // Qt includes
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QDialog>
 #include <QDir>
 #include <QEvent>


### PR DESCRIPTION
Use `QScreen` instead of the deprecated `QDesktopWidget` in `ctkDICOMMetadataDialog` and `ctkSettingsTest1` when building with Qt >= 5.14, while preserving existing behavior for older Qt versions. Also remove unused `QDesktopWidget` includes from widgets and tests that no longer rely on it, reducing deprecation warnings and preparing for Qt 6 compatibility.