### PR TITLE
COMP: Rename CTK_QT5_COMPONENTS to CTK_QT_COMPONENTS

### DIFF
--- a/CMake/CTKConfig.cmake.in
+++ b/CMake/CTKConfig.cmake.in
@@ -91,7 +91,7 @@ include(${CTK_PLUGIN_USE_FILE})
 
 # Qt configuration
 set(CTK_QT_VERSION "@CTK_QT_VERSION@")
-set(CTK_QT5_COMPONENTS @CTK_QT5_COMPONENTS@)
+set(CTK_QT_COMPONENTS @CTK_QT_COMPONENTS@)
 
 # Update CMake module path so that calling "find_package(DCMTK)" works as expected
 # after calling "find_package(CTK)"

--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -25,20 +25,20 @@ macro(ctkMacroSetupQt)
     cmake_minimum_required(VERSION 3.20.6)
     find_package(Qt5 COMPONENTS Core)
 
-    set(CTK_QT5_COMPONENTS Core)
+    set(CTK_QT_COMPONENTS Core)
 
     # See https://github.com/commontk/CTK/wiki/Maintenance#updates-of-required-qt-components
 
     if(CTK_LIB_Widgets
       OR CTK_LIB_DICOM/Widgets
       )
-      list(APPEND CTK_QT5_COMPONENTS Svg)
+      list(APPEND CTK_QT_COMPONENTS Svg)
     endif()
 
     if(CTK_LIB_Widgets
       OR CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTXML
       )
-      list(APPEND CTK_QT5_COMPONENTS Xml)
+      list(APPEND CTK_QT_COMPONENTS Xml)
     endif()
 
     if(CTK_APP_ctkCommandLineModuleExplorer
@@ -46,7 +46,7 @@ macro(ctkMacroSetupQt)
       OR CTK_LIB_CommandLineModules/Core
       OR CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTXMLPATTERNS
       )
-      list(APPEND CTK_QT5_COMPONENTS XmlPatterns)
+      list(APPEND CTK_QT_COMPONENTS XmlPatterns)
     endif()
 
     if(CTK_APP_ctkCommandLineModuleExplorer
@@ -54,22 +54,22 @@ macro(ctkMacroSetupQt)
       OR CTK_LIB_PluginFramework
       OR CTK_PLUGIN_org.commontk.eventadmin
       )
-      list(APPEND CTK_QT5_COMPONENTS Concurrent)
+      list(APPEND CTK_QT_COMPONENTS Concurrent)
     endif()
 
     if(CTK_LIB_DICOM/Core
       OR CTK_LIB_DICOM/Widgets
       OR CTK_LIB_PluginFramework
       )
-      list(APPEND CTK_QT5_COMPONENTS Sql)
+      list(APPEND CTK_QT_COMPONENTS Sql)
     endif()
 
     if(BUILD_TESTING)
-      list(APPEND CTK_QT5_COMPONENTS Test)
+      list(APPEND CTK_QT_COMPONENTS Test)
     endif()
 
     if(CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTMULTIMEDIA)
-      list(APPEND CTK_QT5_COMPONENTS Multimedia)
+      list(APPEND CTK_QT_COMPONENTS Multimedia)
     endif()
 
     if(CTK_ENABLE_Widgets
@@ -77,37 +77,37 @@ macro(ctkMacroSetupQt)
       OR CTK_LIB_CommandLineModules/Frontend/QtGui
       OR CTK_LIB_QtTesting
       )
-      list(APPEND CTK_QT5_COMPONENTS Widgets)
+      list(APPEND CTK_QT_COMPONENTS Widgets)
     endif()
 
     if(CTK_LIB_Widgets)
-      list(APPEND CTK_QT5_COMPONENTS OpenGL)
+      list(APPEND CTK_QT_COMPONENTS OpenGL)
     endif()
 
     if(CTK_APP_ctkCommandLineModuleExplorer
       OR CTK_LIB_CommandLineModules/Frontend/QtGui
       OR CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTUITOOLS
       )
-      list(APPEND CTK_QT5_COMPONENTS UiTools)
+      list(APPEND CTK_QT_COMPONENTS UiTools)
     endif()
 
     if(CTK_LIB_CommandLineModules/Frontend/QtWebKit
       OR CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTWEBKIT
       OR CTK_LIB_Scripting/Python/Core_PYTHONQT_WRAP_QTWEBKITWIDGETS
       )
-      if(TARGET Qt5::WebKitWidgets)
-        list(APPEND CTK_QT5_COMPONENTS WebKitWidgets)
+      if(TARGET Qt${CTK_QT_VERSION}::WebKitWidgets)
+        list(APPEND CTK_QT_COMPONENTS WebKitWidgets)
       else()
-        list(APPEND CTK_QT5_COMPONENTS WebEngineWidgets)
+        list(APPEND CTK_QT_COMPONENTS WebEngineWidgets)
       endif()
     endif()
 
     if(CTK_LIB_XNAT/Core)
-      list(APPEND CTK_QT5_COMPONENTS Script)
+      list(APPEND CTK_QT_COMPONENTS Script)
     endif()
 
     if(CTK_BUILD_QTDESIGNER_PLUGINS)
-      list(APPEND CTK_QT5_COMPONENTS Designer)
+      list(APPEND CTK_QT_COMPONENTS Designer)
     endif()
 
     if(CTK_LIB_XNAT/Core
@@ -115,10 +115,10 @@ macro(ctkMacroSetupQt)
       OR CTK_PLUGIN_org.commontk.dah.host
       OR CTK_PLUGIN_org.commontk.dah.hostedapp
       )
-      list(APPEND CTK_QT5_COMPONENTS Network)
+      list(APPEND CTK_QT_COMPONENTS Network)
     endif()
 
-    find_package(Qt5 COMPONENTS ${CTK_QT5_COMPONENTS} REQUIRED)
+    find_package(Qt5 COMPONENTS ${CTK_QT_COMPONENTS} REQUIRED)
 
     mark_as_superbuild(Qt5_DIR) # Qt 5
 
@@ -131,7 +131,7 @@ macro(ctkMacroSetupQt)
     set(_minor ${Qt5_VERSION_MINOR})
     set(_patch ${Qt5_VERSION_PATCH})
 
-    ctk_list_to_string(", " "${CTK_QT5_COMPONENTS}" comma_separated_module_list)
+    ctk_list_to_string(", " "${CTK_QT_COMPONENTS}" comma_separated_module_list)
     message(STATUS "Configuring CTK with Qt ${_major}.${_minor}.${_patch} (using modules: ${comma_separated_module_list})")
 
   else()


### PR DESCRIPTION
This change updates the naming convention for Qt components from CTK_QT5_COMPONENTS to CTK_QT_COMPONENTS. This makes the codebase more flexible and forward-compatible with future Qt releases.