### PR TITLE
COMP: Exclude use of globalStrut() anticipating transition to Qt6

### DIFF
--- a/Libs/Widgets/ctkCollapsibleButton.cpp
+++ b/Libs/Widgets/ctkCollapsibleButton.cpp
@@ -446,8 +446,10 @@ QSize ctkCollapsibleButton::buttonSizeHint()const
   }
   h = qMax(h, sz.height());
   //opt.rect.setSize(QSize(w, h)); // PM_MenuButtonIndicator depends on the height
-  QSize buttonSize = (style()->sizeFromContents(QStyle::CT_PushButton, &opt, QSize(w, h), this).
-                      expandedTo(QApplication::globalStrut()));
+  QSize buttonSize = style()->sizeFromContents(QStyle::CT_PushButton, &opt, QSize(w, h), this);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+  buttonSize = buttonSize.expandedTo(QApplication::globalStrut());
+#endif
   return buttonSize;
 }
 

--- a/Libs/Widgets/ctkColorPickerButton.cpp
+++ b/Libs/Widgets/ctkColorPickerButton.cpp
@@ -296,18 +296,20 @@ QSize ctkColorPickerButton::sizeHint()const
     opt.icon = d->Icon;
     opt.iconSize = QSize(iconSize, iconSize);
     opt.rect.setSize(opt.iconSize); // PM_MenuButtonIndicator depends on the height
-    d->CachedSizeHint = this->style()->sizeFromContents(
-      QStyle::CT_ToolButton, &opt, opt.iconSize, this).
-      expandedTo(QApplication::globalStrut());
+    d->CachedSizeHint = this->style()->sizeFromContents(QStyle::CT_ToolButton, &opt, opt.iconSize, this);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    d->CachedSizeHint = d->CachedSizeHint.expandedTo(QApplication::globalStrut());
+#endif
   }
   else
   {
     pushButtonOpt.icon = d->Icon;
     pushButtonOpt.iconSize = QSize(iconSize, iconSize);
     pushButtonOpt.rect.setSize(pushButtonOpt.iconSize); // PM_MenuButtonIndicator depends on the height
-    d->CachedSizeHint = (style()->sizeFromContents(
-                           QStyle::CT_PushButton, &pushButtonOpt, pushButtonOpt.iconSize, this).
-                         expandedTo(QApplication::globalStrut()));
+    d->CachedSizeHint = style()->sizeFromContents(QStyle::CT_PushButton, &pushButtonOpt, pushButtonOpt.iconSize, this);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    d->CachedSizeHint = d->CachedSizeHint.expandedTo(QApplication::globalStrut());
+#endif
   }
   return d->CachedSizeHint;
 }

--- a/Libs/Widgets/ctkComboBox.cpp
+++ b/Libs/Widgets/ctkComboBox.cpp
@@ -65,7 +65,11 @@ QSize ctkComboBoxPrivate::recomputeSizeHint(QSize &sh) const
   Q_Q(const ctkComboBox);
   if (sh.isValid())
   {
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
     return sh.expandedTo(QApplication::globalStrut());
+#else
+      return sh;
+#endif
   }
 
   bool hasIcon = false;
@@ -151,7 +155,11 @@ QSize ctkComboBoxPrivate::recomputeSizeHint(QSize &sh) const
   QStyleOptionComboBox opt;
   this->initStyleOption(&opt);
   sh = q->style()->sizeFromContents(QStyle::CT_ComboBox, &opt, sh, q);
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
   return sh.expandedTo(QApplication::globalStrut());
+#else
+  return sh;
+#endif
 }
 
 // -------------------------------------------------------------------------

--- a/Libs/Widgets/ctkDoubleSpinBox.cpp
+++ b/Libs/Widgets/ctkDoubleSpinBox.cpp
@@ -1094,8 +1094,10 @@ QSize ctkDoubleSpinBox::sizeHint() const
 
   opt.rect = this->rect();
   d->CachedSizeHint = this->style()->sizeFromContents(
-    QStyle::CT_SpinBox, &opt, newSizeHint, this)
-    .expandedTo(QApplication::globalStrut());
+      QStyle::CT_SpinBox, &opt, newSizeHint, this);
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
+  d->CachedSizeHint = d->CachedSizeHint.expandedTo(QApplication::globalStrut());
+#endif
   return d->CachedSizeHint;
 }
 
@@ -1150,8 +1152,10 @@ QSize ctkDoubleSpinBox::minimumSizeHint() const
 
   opt.rect = this->rect();
   d->CachedMinimumSizeHint = this->style()->sizeFromContents(
-    QStyle::CT_SpinBox, &opt, newSizeHint, this)
-    .expandedTo(QApplication::globalStrut());
+      QStyle::CT_SpinBox, &opt, newSizeHint, this);
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
+  d->CachedMinimumSizeHint = d->CachedMinimumSizeHint.expandedTo(QApplication::globalStrut());
+#endif
   return d->CachedMinimumSizeHint;
 }
 

--- a/Libs/Widgets/ctkPathLineEdit.cpp
+++ b/Libs/Widgets/ctkPathLineEdit.cpp
@@ -472,7 +472,11 @@ QSize ctkPathLineEditPrivate::recomputeSizeHint(QSize& sh)const
     sh.rwidth() = frame + textWidth + browseWidth;
     sh.rheight() = height;
   }
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
   return sh.expandedTo(QApplication::globalStrut());
+#else
+  return sh;
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Widgets/ctkPushButton.cpp
+++ b/Libs/Widgets/ctkPushButton.cpp
@@ -150,8 +150,10 @@ QSize ctkPushButtonPrivate::buttonSizeHint(bool computeMinimum)const
   }
   h = qMax(h, sz.height());
   //opt.rect.setSize(QSize(w, h)); // PM_MenuButtonIndicator depends on the height
-  QSize buttonSize = (q->style()->sizeFromContents(QStyle::CT_PushButton, &opt, QSize(w, h), q).
-                      expandedTo(QApplication::globalStrut()));
+  QSize buttonSize = q->style()->sizeFromContents(QStyle::CT_PushButton, &opt, QSize(w, h), q);
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
+  buttonSize = buttonSize.expandedTo(QApplication::globalStrut());
+#endif
   return buttonSize;
 }
 

--- a/Libs/Widgets/ctkSizeGrip.cpp
+++ b/Libs/Widgets/ctkSizeGrip.cpp
@@ -224,8 +224,12 @@ QSize ctkSizeGrip::sizeHint() const
   };
   QStyleOption opt(0);
   opt.initFrom(this);
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
   return (this->style()->sizeFromContents(contents, &opt, minSize, this).
           expandedTo(QApplication::globalStrut()));
+#else
+  return this->style()->sizeFromContents(contents, &opt, minSize, this);
+#endif
 }
 
 //------------------------------------------------------------------------------
@@ -356,8 +360,9 @@ void ctkSizeGrip::mouseMoveEvent(QMouseEvent * e)
       widgetSizeHint.rheight() = d->WidgetToResize->heightForWidth(widgetSizeHint.width());
     }
   }
-
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
   widgetSizeHint = widgetSizeHint.expandedTo(QApplication::globalStrut());
+#endif
 
   this->setWidgetSizeHint(
     QSize(d->Orientations & Qt::Horizontal ? widgetSizeHint.width() : -1,

--- a/Libs/Widgets/ctkThumbnailLabel.cpp
+++ b/Libs/Widgets/ctkThumbnailLabel.cpp
@@ -402,7 +402,11 @@ QSize ctkThumbnailLabel::sizeHint()const
   Q_D(const ctkThumbnailLabel);
   return d->OriginalThumbnail.isNull() ?
     this->Superclass::sizeHint() :
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     d->OriginalThumbnail.size().expandedTo(QApplication::globalStrut());
+#else
+    d->OriginalThumbnail.size();
+#endif
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This change removes the use of QApplication::globalStrut() in various widgets to ensure compatibility with Qt6. The globalStrut mechanism was originally introduced for touch-friendly UIs on early embedded devices but has seen limited use and relevance in modern desktop applications. By excluding it, we streamline the transition to Qt6 where this feature is deprecated.