### PR TITLE
COMP: Replace deprecated QtScript with QtQml in XNAT library

### DIFF
--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -115,10 +115,8 @@ macro(ctkMacroSetupQt)
       endif()
     endif()
 
-    if(CTK_QT_VERSION VERSION_LESS "6")
-      if(CTK_LIB_XNAT/Core)
-        list(APPEND CTK_QT_COMPONENTS Script)
-      endif()
+    if(CTK_LIB_XNAT/Core)
+      list(APPEND CTK_QT_COMPONENTS Qml)
     endif()
 
     if(CTK_BUILD_QTDESIGNER_PLUGINS)

--- a/CMakeExternals/qRestAPI.cmake
+++ b/CMakeExternals/qRestAPI.cmake
@@ -24,7 +24,7 @@ endif()
 
 if(NOT DEFINED ${proj}_DIR)
 
-  set(revision_tag "ddc0cfcc220d0ccd02b4afdd699d1e780dac3fa3")
+  set(revision_tag "6bcb79d1d1c2df9b3ebb30bf6e27f7b23cdc793c")
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()

--- a/Libs/XNAT/Core/ctkXnatAPI.cpp
+++ b/Libs/XNAT/Core/ctkXnatAPI.cpp
@@ -123,12 +123,12 @@ QList<QVariantMap> ctkXnatAPI::parseXmlResponse(qRestResult* /*restResult*/, con
 // --------------------------------------------------------------------------
 QList<QVariantMap> ctkXnatAPI::parseJsonResponse(qRestResult* restResult, const QByteArray& response)
 {
-  QScriptValue scriptValue = this->ScriptEngine.evaluate("(" + QString(response) + ")");
+  QJSValue scriptValue = this->ScriptEngine.evaluate("(" + QString(response) + ")");
 
   QList<QVariantMap> result;
 
   // e.g. {"ResultSet":{"Result": [{"p1":"v1","p2":"v2",...}], "totalRecords":"13"}}
-  QScriptValue resultSet = scriptValue.property("ResultSet");
+  QJSValue resultSet = scriptValue.property("ResultSet");
   if (!resultSet.isObject())
   {
     // Plain JSON object without the XNAT ResultSet wrapper, e.g. XAPI
@@ -136,7 +136,7 @@ QList<QVariantMap> ctkXnatAPI::parseJsonResponse(qRestResult* restResult, const 
     qRestAPI::appendScriptValueToVariantMapList(result, scriptValue);
     return result;
   }
-  QScriptValue data = resultSet.property("Result");
+  QJSValue data = resultSet.property("Result");
   if (!data.isObject())
   {
     if (!data.toString().isEmpty())
@@ -146,7 +146,7 @@ QList<QVariantMap> ctkXnatAPI::parseJsonResponse(qRestResult* restResult, const 
   }
   if (data.isArray())
   {
-    quint32 length = data.property("length").toUInt32();
+    quint32 length = data.property("length").toUInt();
     for(quint32 i = 0; i < length; ++i)
     {
       qRestAPI::appendScriptValueToVariantMapList(result, data.property(i));

--- a/Libs/XNAT/Core/ctkXnatAPI_p.h
+++ b/Libs/XNAT/Core/ctkXnatAPI_p.h
@@ -25,8 +25,8 @@
 #include "qRestAPI.h"
 
 #include <QList>
-#include <QScriptEngine>
-#include <QScriptValue>
+#include <QJSEngine>
+#include <QJSValue>
 
 /**
  * ctkXnatAPI is a simple interface class to communicate with an XNAT
@@ -56,7 +56,7 @@ private:
 
   QList<QVariantMap> parseJsonResponse(qRestResult* restResult, const QByteArray& response);
 
-  QScriptEngine ScriptEngine;
+  QJSEngine ScriptEngine;
 
   Q_DISABLE_COPY(ctkXnatAPI)
 };

--- a/Libs/XNAT/Core/target_libraries.cmake
+++ b/Libs/XNAT/Core/target_libraries.cmake
@@ -3,17 +3,10 @@
 #
 # This file should list the libraries required to build the current CTK libraries
 #
-if(CTK_QT_VERSION VERSION_EQUAL "5")
-  set(target_libraries
-    CTKCore
-    qRestAPI_LIBRARIES
-    QT_LIBRARIES
-    QtScript
-    )
-else()
-  set(target_libraries
-    CTKCore
-    qRestAPI_LIBRARIES
-    QT_LIBRARIES
-    )
-endif()
+
+set(target_libraries
+  CTKCore
+  qRestAPI_LIBRARIES
+  QT_LIBRARIES
+  QtQml
+  )


### PR DESCRIPTION
This changes the XNAT library to use QtQml instead of the deprecated QtScript.