### PR TITLE
COMP: Use QRecursiveMutex (Qt >= 5.14) instead of QMutex(QMutex::Recursive)

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMIndexer_p.h
+++ b/Libs/DICOM/Core/ctkDICOMIndexer_p.h
@@ -50,7 +50,11 @@ public:
   DICOMIndexingQueue()
     : IsIndexing(false)
     , StopRequested(false)
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    , Mutex()
+#else
     , Mutex(QMutex::Recursive)
+#endif
   {
   }
 
@@ -198,7 +202,11 @@ protected:
   bool IsIndexing;
   bool StopRequested;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  mutable QRecursiveMutex Mutex;
+#else
   mutable QMutex Mutex;
+#endif
 };
 
 

--- a/Plugins/org.commontk.configadmin/ctkManagedServiceFactoryTracker.cpp
+++ b/Plugins/org.commontk.configadmin/ctkManagedServiceFactoryTracker.cpp
@@ -39,7 +39,11 @@ ctkManagedServiceFactoryTracker::ctkManagedServiceFactoryTracker(
   : ctkServiceTracker<ctkManagedServiceFactory*>(context),
     context(context),
     configurationAdminFactory(configurationAdminFactory),
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    configurationStoreMutex(),
+#else
     configurationStoreMutex(QMutex::Recursive),
+#endif
     configurationStore(configurationStore),
     queue("ctkManagedServiceFactory Update Queue")
 {

--- a/Plugins/org.commontk.configadmin/ctkManagedServiceTracker.cpp
+++ b/Plugins/org.commontk.configadmin/ctkManagedServiceTracker.cpp
@@ -36,7 +36,11 @@ ctkManagedServiceTracker::ctkManagedServiceTracker(ctkConfigurationAdminFactory*
   : ctkServiceTracker<ctkManagedService*>(context),
     context(context),
     configurationAdminFactory(configurationAdminFactory),
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    configurationStoreMutex(),
+#else
     configurationStoreMutex(QMutex::Recursive),
+#endif
     configurationStore(configurationStore),
     queue("ctkManagedService Update Queue")
 {

--- a/Plugins/org.commontk.eventadmin/dispatch/ctkEAThreadFactoryUser.cpp
+++ b/Plugins/org.commontk.eventadmin/dispatch/ctkEAThreadFactoryUser.cpp
@@ -43,7 +43,12 @@ ctkEAInterruptibleThread* ctkEAThreadFactoryUser::DefaultThreadFactory::newThrea
 
 
 ctkEAThreadFactoryUser::ctkEAThreadFactoryUser()
-  : mutex(QMutex::Recursive), threadFactory(new DefaultThreadFactory())
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  : mutex(),
+#else
+  : mutex(QMutex::Recursive),
+#endif
+    threadFactory(new DefaultThreadFactory())
 {
 
 }

--- a/Plugins/org.commontk.eventadmin/dispatch/ctkEAThreadFactoryUser_p.h
+++ b/Plugins/org.commontk.eventadmin/dispatch/ctkEAThreadFactoryUser_p.h
@@ -23,7 +23,12 @@
 #ifndef CTKEATHREADFACTORYUSER_P_H
 #define CTKEATHREADFACTORYUSER_P_H
 
+#include <QtGlobal>
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+#include <QRecursiveMutex>
+#else
 #include <QMutex>
+#endif
 
 #include "ctkEAThreadFactory_p.h"
 #include "ctkEAInterruptibleThread_p.h"
@@ -38,7 +43,11 @@ class ctkEAThreadFactoryUser
 
 protected:
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  mutable QRecursiveMutex mutex;
+#else
   mutable QMutex mutex;
+#endif
 
   ctkEAThreadFactory* threadFactory;
 


### PR DESCRIPTION
This changes the mutex implementation to use QRecursiveMutex if Qt version is 5.14 or higher.