### PR TITLE
COMP: Use QtConcurrent::run lambda overload for background tasks

### DIFF
--- a/Libs/PluginFramework/ctkPluginFramework_p.cpp
+++ b/Libs/PluginFramework/ctkPluginFramework_p.cpp
@@ -146,7 +146,7 @@ void ctkPluginFrameworkPrivate::shutdown(bool restart)
       {
         const bool wa = wasActive;
         shuttingDown.fetchAndStoreOrdered(1);
-        QtConcurrent::run(this, &ctkPluginFrameworkPrivate::shutdown0, restart, wa);
+        QFuture<void> future = QtConcurrent::run([=]() { shutdown0(restart, wa); });
       }
       catch (const ctkException& e)
       {

--- a/Plugins/org.commontk.eventadmin/ctkEAConfiguration.cpp
+++ b/Plugins/org.commontk.eventadmin/ctkEAConfiguration.cpp
@@ -311,7 +311,7 @@ void ctkEAConfiguration::updated(const ctkDictionary& properties)
 {
   // do this in the background as we don't want to stop
   // the config admin
-  QtConcurrent::run(this, &ctkEAConfiguration::updateFromConfigAdmin, properties);
+  QFuture<void> future = QtConcurrent::run([=]() { updateFromConfigAdmin(properties); });
 }
 
 int ctkEAConfiguration::getIntProperty(const QString& key, const QVariant& value,


### PR DESCRIPTION
Switch `QtConcurrent::run()` calls to the lambda-based overload and capture arguments by value to ensure correct behavior with Qt 6 and avoid lifetime issues when tasks run asynchronously.

This updates:
- `ctkPluginFrameworkPrivate::shutdown` to run `shutdown0(restart, wasActive)` in the background using a by-value lambda capture.
- `ctkEAConfiguration::updated` to run `updateFromConfigAdmin(properties)` in the background using a by-value lambda capture.