### PR TITLE
COMP: Update Log4Qt to support Qt6

### DIFF
--- a/CMakeExternals/Log4Qt.cmake
+++ b/CMakeExternals/Log4Qt.cmake
@@ -24,7 +24,7 @@ endif()
 
 if(NOT DEFINED Log4Qt_DIR)
 
-  set(revision_tag e2a65d5d0c626a33f9384f2a9227efee3035dbf9)
+  set(revision_tag 7406782e7d3babe95486b84ee97fc39c927a8c0f)
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()


### PR DESCRIPTION
This updates Log4Qt to a newer version that includes support for Qt6. Notable changes include:
- Simplified CMake support for Qt6
- Inclusion of QMetaType and std::as_const for compatibility with C++17
- Various CI improvements and updates for better compatibility with Qt versions
- Fixes for several cppcheck and clazy warnings
- Optional QML support with registration via CMake

List of changes:

```
Andreas Bacher (89):
      Avid Qt Module-wide QtTest includes
      Pass QDate, QTime & QDateTime by value
      Fixed cpp check warnings
      Move default to implementation
      Fix setEncoding in WriterAppender
      Update Readme.md
      Create main.yml
      Delete main.yml
      Simplified cmake Qt6 support by using QT_VERSION_MAJOR
      qmake remove deprecated ordered
      Prefix cmake output with Log4Qt
      Add detection of standalone build
      Introduce check for min QT version, add filewatchertest to cmake build
      Add Qt6.2 to appveyor ci build
      cmake: replace BUILD_STATIC_LOG4CXX_LIB with standard BUILD_SHARED_LIBS
      Added documentation for filter decision enum
      Github actions for ubuntu build and test (PR-66)
      Split StringMatchFilter unit test CaseInsensitive and CaseSensitive test case
      Update ChangeLog
      Update Readme.md
      Replace Q_DISABLE_COPY with Q_DISABLE_COPY_MOVE
      Fix for Qt6.7
      Use explicit
      Update github actions and appveyor
      Fix qt versions for CI
      Remove qt versions for CI
      Use latest actions
      Use latest checkout action
      Compatibility with Qt5.12
      Compatibility with Qt5.x
      QtClassHelperMacros header only exists for Qt version >= 6.5
      Update appveyor and github action build matrix
      update github work flows
      update github work flows
      update github work flows
      Replace Q_DISABLE_COPY with Q_DISABLE_COPY_MOVE
      Fix for Qt6.7
      Use explicit
      Update github actions and appveyor
      Fix qt versions for CI
      Remove qt versions for CI
      Use latest actions
      Use latest checkout action
      Compatibility with Qt5.12
      Compatibility with Qt5.x
      QtClassHelperMacros header only exists for Qt version >= 6.5
      Remove Q_DISABLE_COPY_MOVE for member less non constructible class (Q_DECLARE_TYPEINFO) fails on clang)
      Remove Q_DISABLE_COPY_MOVE for member less non constructible class (Q_DECLARE_TYPEINFO) fails on clang)
      Make target link libraries Concurrent private
      Remove unneeded mutex lock, update change log
      update qt versions for github workflows
      githib workflows fix
      ggithib workflows fix
      Add log4qtdefs.h to headers, so that it is deployed in install
      Add log4qtdefs.h to headers, so that it is deployed in install
      Remove unneeded mutex lock, update change log
      update qt versions for github workflows
      githib workflows fix
      ggithib workflows fix
      remove failing ci builds
      Use std::as_const instead of deprecated qAsConst for c++17 and greater
      Use QMetaType instead of QVariant type
      Use timezone
      add registration of qml module via cmake (qt_add_qml_module) and make qml support optional
      qml support default off
      add QML_NAMED_ELEMENT
      add qt 6.8.1 to github actions build
      Use std::as_const instead of deprecated qAsConst for c++17 and greater
      Use QMetaType instead of variant type
      add include
      QML_NAMED_ELEMENT for qt version >= 6.5
      corrected documentation
      Fixed version depending doku
      Use QTimeZone::utc()
      Use std::as_const instead of deprecated qAsConst for c++17 and greater
      Use QMetaType instead of QVariant type
      Use timezone
      add registration of qml module via cmake (qt_add_qml_module) and make qml support optional
      qml support default off
      add QML_NAMED_ELEMENT
      add qt 6.8.1 to github actions build
      Use QMetaType instead of variant type Use std::as_const instead of deprecated qAsConst for c++17 and greater
      qmake: Make database, telnet appender and qml logger optional depending on CONFIG
      Fix some cpp check and clazy warnings
      Remove qbs support
      Fixed api change for Qt 6.9
      Fixed waring in unittest
      github workflows update and expand qt versions
      github workflows fix

Bartosz Bilas (1):
      CMakeLists.txt: fix wrong copy&pasta in comment about telnet logging

Johann Anhofer (9):
      Use atomic instead of mutex
      if console is blocked by debugger use OutputDebugString
      Log unconditional to console if QT_ASSUME_STDERR_HAS_CONSOLE is set.
      Fix checking for force stderr logging and asume stderr has console
      Log unconditional to console if QT_ASSUME_STDERR_HAS_CONSOLE is set.
      Fix checking for force stderr logging and asume stderr has console
      Add .gitgnore file
      Use 3.10 as minimum required cmake version set cmake policy CMP0071 to new (AUTOMOC, AUTOUIC)
      Replace ; in filter rules with \n to match QLoggingCategory::setFilterRules()

Rashad KM (1):
      gcc: Fix compilation on Linux (Ubuntu 16)  (PR-64)

kuzzh (1):
      Add support for the property "encoding" in the configuration file (PR-72)

noksel (1):
      TTCCLayout(QString dateFormat) crash fix (PR-69)

siyuhong (1):
      fix the decision of Filter (PR-63)
```