### PR TITLE
COMP: Update QVariant to QMetaType for Qt6 compatibility

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMDirectoryListWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMDirectoryListWidget.cpp
@@ -87,7 +87,11 @@ void ctkDICOMDirectoryListWidget::addDirectory(const QString& newDir)
 {
   Q_D(ctkDICOMDirectoryListWidget);
   QSqlRecord newDirRecord;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+  newDirRecord.append(QSqlField("Dirname", QMetaType(QMetaType::QString)));
+#else
   newDirRecord.append(QSqlField("Dirname",QVariant::String));
+#endif
   newDirRecord.setValue("Dirname",newDir);
   /*bool success = */d->directoryListModel->insertRecord(-1,newDirRecord);
   bool success2 = d->directoryListModel->submitAll();

--- a/Libs/PluginFramework/ctkPluginFrameworkLauncher.cpp
+++ b/Libs/PluginFramework/ctkPluginFrameworkLauncher.cpp
@@ -158,7 +158,11 @@ public:
   {
     for (ctkProperties::iterator iter = result.begin(); iter != result.end(); ++iter)
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+      if (iter.value().typeId() == QMetaType::QString)
+#else
       if (iter.value().type() == QVariant::String)
+#endif
       {
         iter.value() = substituteVars(iter.value().toString());
       }
@@ -302,7 +306,11 @@ public:
     }
 
     QStringList installEntries;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    if (pluginsProp.typeId() == QMetaType::QStringList)
+#else
     if (pluginsProp.type() == QVariant::StringList)
+#endif
     {
       installEntries = pluginsProp.toStringList();
     }

--- a/Libs/PluginFramework/service/metatype/ctkAttributeDefinition.h
+++ b/Libs/PluginFramework/service/metatype/ctkAttributeDefinition.h
@@ -41,7 +41,11 @@
  */
 struct CTK_PLUGINFW_EXPORT ctkAttributeDefinition
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+  typedef QMetaType::Type Type;
+#else
   typedef QVariant::Type Type;
+#endif
 
   static const int PASSWORD;
 
@@ -121,9 +125,14 @@ struct CTK_PLUGINFW_EXPORT ctkAttributeDefinition
    * Return the type for this attribute.
    *
    * <p>
-   * The following types from QVariant::Type are supported:
+   * With Qt 5, the following types from QVariant::Type are supported:
    * QVariant::String, QVariant::LongLong, QVariant::Int, QVariant::Char,
    * QVariant::Double, QVariant::Bool, QVariant::UserType.
+   *
+   * <p>
+   * With Qt 6, the following types from QMetaType::Type are supported:
+   * QMetaType::QString, QMetaType::LongLong, QMetaType::Int, QMetaType::Char,
+   * QMetaType::Double, QMetaType::Bool, QMetaType::User.
    *
    * <p>
    * QVariant::UserType maps to ctkAttributeDefinition::Password only.

--- a/Libs/Widgets/ctkMatrixWidget.cpp
+++ b/Libs/Widgets/ctkMatrixWidget.cpp
@@ -77,9 +77,17 @@ public:
   {
     ctkMatrixWidget* matrix = qobject_cast<ctkMatrixWidget*>(this->parent());
     Q_ASSERT(matrix);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    switch(value.typeId())
+#else
     switch(value.type())
+#endif
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+      case QMetaType::Double:
+#else
       case QVariant::Double:
+#endif
         return locale.toString(value.toDouble(), 'f', matrix->decimals());
       default:
         return this->QStyledItemDelegate::displayText(value, locale);
@@ -158,7 +166,11 @@ void ctkMatrixWidgetPrivate::init()
 
   // Register custom editors
   QItemEditorFactory *editorFactory = new QItemEditorFactory;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+  editorFactory->registerEditor(QMetaType::Double, new QStandardItemEditorCreator<ctkMatrixDoubleSpinBox>);
+#else
   editorFactory->registerEditor(QVariant::Double, new QStandardItemEditorCreator<ctkMatrixDoubleSpinBox>);
+#endif
 
   QStyledItemDelegate* defaultItemDelegate =
     qobject_cast<QStyledItemDelegate*>(this->Table->itemDelegate());

--- a/Libs/XNAT/Core/ctkXnatSession.cpp
+++ b/Libs/XNAT/Core/ctkXnatSession.cpp
@@ -270,7 +270,11 @@ QList<ctkXnatObject*> ctkXnatSessionPrivate::results(qRestResult* restResult, QS
     // try to create an object based on the custom schema type first
     if (!customSchemaType.isEmpty())
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+      typeId = QMetaType::fromName(qPrintable(customSchemaType)).id();
+#else
       typeId = QMetaType::type(qPrintable(customSchemaType));
+#endif
     }
 
     // Fall back. Create the default class according to the default schema type
@@ -280,7 +284,11 @@ QList<ctkXnatObject*> ctkXnatSessionPrivate::results(qRestResult* restResult, QS
       {
         qWarning() << QString("No ctkXnatObject sub-class registered for the schema %1. Falling back to the default class %2.").arg(customSchemaType).arg(schemaType);
       }
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+      typeId = QMetaType::fromName(qPrintable(schemaType)).id();
+#else
       typeId = QMetaType::type(qPrintable(schemaType));
+#endif
     }
 
     if (!typeId)

--- a/Plugins/org.commontk.eventadmin/ctkEAMetaTypeProvider.cpp
+++ b/Plugins/org.commontk.eventadmin/ctkEAMetaTypeProvider.cpp
@@ -180,7 +180,12 @@ ctkObjectClassDefinitionPtr ctkEAMetaTypeProvider::getObjectClassDefinition(cons
                        new AttributeDefinitionImpl(ctkEAConfiguration::PROP_CACHE_SIZE, "Cache Size",
                                                    "The size of various internal caches. The default value is 30. Increase in case "
                                                    "of a large number (more then 100) of services. A value less then 10 triggers the "
-                                                   "default value.", QVariant::Int, QStringList(QString::number(m_cacheSize)))));
+                                                   "default value.",
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+                                                   QMetaType::Int, QStringList(QString::number(m_cacheSize)))));
+#else
+                                                   QVariant::Int, QStringList(QString::number(m_cacheSize)))));
+#endif
 
     adList.push_back(ctkAttributeDefinitionPtr(
                        new AttributeDefinitionImpl(ctkEAConfiguration::PROP_THREAD_POOL_SIZE, "Thread Pool Size",
@@ -188,14 +193,22 @@ ctkObjectClassDefinitionPtr ctkEAMetaTypeProvider::getObjectClassDefinition(cons
                                                    "of synchronous events where the event handler services in turn send new synchronous events in "
                                                    "the event dispatching thread or a lot of timeouts are to be expected. A value of "
                                                    "less then 2 triggers the default value. A value of 2 effectively disables thread pooling.",
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+                                                   QMetaType::Int, QStringList(QString::number(m_threadPoolSize)))));
+#else
                                                    QVariant::Int, QStringList(QString::number(m_threadPoolSize)))));
+#endif
 
     adList.push_back(ctkAttributeDefinitionPtr(
                        new AttributeDefinitionImpl(ctkEAConfiguration::PROP_TIMEOUT, "Timeout",
                                                    "The black-listing timeout in milliseconds. The default value is 5000. Increase or decrease "
                                                    "at own discretion. A value of less then 100 turns timeouts off. Any other value is the time "
                                                    "in milliseconds granted to each event handler before it gets blacklisted",
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+                                                   QMetaType::Int, QStringList(QString::number(m_timeout)))));
+#else
                                                    QVariant::Int, QStringList(QString::number(m_timeout)))));
+#endif
 
     adList.push_back(ctkAttributeDefinitionPtr(
                        new AttributeDefinitionImpl(ctkEAConfiguration::PROP_REQUIRE_TOPIC, "Require Topic",
@@ -204,7 +217,11 @@ ctkObjectClassDefinitionPtr ctkEAMetaTypeProvider::getObjectClassDefinition(cons
                                                    "must register with a list of topics they are interested in. Disabling this setting "
                                                    "will enable that handlers without a topic are receiving all events "
                                                    "(i.e., they are treated the same as with a topic=*).",
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+                                                   QMetaType::Bool, m_requireTopic ? QStringList("true") : QStringList("false"))));
+#else
                                                    QVariant::Bool, m_requireTopic ? QStringList("true") : QStringList("false"))));
+#endif
 
     adList.push_back(ctkAttributeDefinitionPtr(
                        new AttributeDefinitionImpl(ctkEAConfiguration::PROP_IGNORE_TIMEOUT, "Ignore Timeouts",
@@ -215,7 +232,11 @@ ctkObjectClassDefinitionPtr ctkEAMetaTypeProvider::getObjectClassDefinition(cons
                                                    "handler. However, the application should work without this configuration property. It is a "
                                                    "pure optimization! The value is a list of strings (separated by comma) which is assumed to define "
                                                    "exact class names.",
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+                                                   QMetaType::QString, m_ignoreTimeout, 0,
+#else
                                                    QVariant::String, m_ignoreTimeout, 0,
+#endif
                                                    QStringList(QString::number(std::numeric_limits<int>::max())))));
 
     ocd = ctkObjectClassDefinitionPtr(new ObjectClassDefinitionImpl(adList));


### PR DESCRIPTION
This changes the code to use `QMetaType` with Qt6 where necessary, replacing `QVariant` usage. This ensures compatibility with both Qt5 and Qt6, maintaining functionality across versions