### PR TITLE
COMP: Fix Qt 5/6 compatibility and Qt 6.4+ deprecations

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMTester.cpp
+++ b/Libs/DICOM/Core/ctkDICOMTester.cpp
@@ -170,13 +170,13 @@ void ctkDICOMTesterPrivate::printProcessOutputs(const QString& program, QProcess
   out << "Process " << program << " is finished.\n";
 
   QByteArray standardOutput = process->readAllStandardOutput();
-  if (standardOutput.count())
+  if (standardOutput.size())
   {
     out << "Standard Output:\n";
     out << standardOutput;
   }
   QByteArray standardError = process->readAllStandardError();
-  if (standardError.count())
+  if (standardError.size())
   {
     out << "Standard Error:\n";
     out << standardError;

--- a/Libs/Widgets/ctkBasePopupWidget.cpp
+++ b/Libs/Widgets/ctkBasePopupWidget.cpp
@@ -787,7 +787,14 @@ void ctkBasePopupWidget::hidePopup()
       d->PopupPixmapWidget->show();
       if (this->isActiveWindow())
       {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+        if (!d->BaseWidget.isNull())
+        {
+          d->BaseWidget->activateWindow();
+        }
+#else
         qApp->setActiveWindow(!d->BaseWidget.isNull() ? d->BaseWidget->window() : 0);
+#endif
       }
       this->hide();
       break;

--- a/Libs/Widgets/ctkLanguageComboBox.cpp
+++ b/Libs/Widgets/ctkLanguageComboBox.cpp
@@ -195,7 +195,11 @@ bool ctkLanguageComboBoxPrivate::languageItem(const QString& localeCode,
       // There are multiple countries for the locale's language therefore include the country name.
       text = QString("%1 (%2)")
         .arg(QLocale::languageToString(locale.language()))
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0))
+        .arg(QLocale::territoryToString(locale.territory()));
+#else
         .arg(QLocale::countryToString(locale.country()));
+#endif
     }
     else
     {

--- a/Libs/Widgets/ctkPopupWidget.cpp
+++ b/Libs/Widgets/ctkPopupWidget.cpp
@@ -133,7 +133,11 @@ bool ctkPopupWidgetPrivate::eventFilter(QObject* obj, QEvent* event)
   }
   else if (event->type() == QEvent::RequestSoftwareInputPanel)
   {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+    widget->window()->activateWindow();
+#else
     qApp->setActiveWindow(widget->window());
+#endif
   }
   return false;
 }

--- a/Libs/Widgets/ctkQImageView.cpp
+++ b/Libs/Widgets/ctkQImageView.cpp
@@ -1047,7 +1047,11 @@ void ctkQImageView::update( bool zoomChanged,
           QFont textFont( fontFamily, fontPointSize );
           painter.setFont( textFont );
           QColor textColor;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0))
+          textColor = QColor::fromString( "lime" );
+#else
           textColor.setNamedColor( "lime" );
+#endif
           textColor.setAlpha( 128 );
           painter.setPen( textColor );
 
@@ -1146,7 +1150,11 @@ void ctkQImageView::update( bool zoomChanged,
         }
 
         QColor lineColor;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0))
+        lineColor = QColor::fromString( "red" );
+#else
         lineColor.setNamedColor( "red" );
+#endif
         lineColor.setAlpha( 128 );
         painter.setPen( lineColor );
         double x = ( this->xPosition() - d->TmpXMin )

--- a/Libs/Widgets/ctkTestApplication.cpp
+++ b/Libs/Widgets/ctkTestApplication.cpp
@@ -208,7 +208,7 @@ void ctkTestApplication::mouseDown(QWidget* w, QPoint pos, Qt::MouseButton btn,
                         Qt::KeyboardModifiers mod, int ms)
 {
   delay(ms);
-  QMouseEvent e(QEvent::MouseButtonPress, pos, btn, btn, mod);
+  QMouseEvent e(QEvent::MouseButtonPress, pos, QCursor::pos(), btn, btn, mod);
   if(!simulateEvent(w, &e))
   {
     qWarning("mouseDown not handled\n");
@@ -220,7 +220,7 @@ void ctkTestApplication::mouseUp(QWidget* w, QPoint pos, Qt::MouseButton btn,
                       Qt::KeyboardModifiers mod, int ms)
 {
   delay(ms);
-  QMouseEvent e(QEvent::MouseButtonRelease, pos, btn, btn, mod);
+  QMouseEvent e(QEvent::MouseButtonRelease, pos, QCursor::pos(), btn, btn, mod);
   if(!simulateEvent(w, &e))
   {
     qWarning("mouseUp not handled\n");
@@ -232,7 +232,7 @@ void ctkTestApplication::mouseMove(QWidget* w, QPoint pos, Qt::MouseButton btn,
                         Qt::KeyboardModifiers mod, int ms)
 {
   delay(ms);
-  QMouseEvent e(QEvent::MouseMove, pos, btn, btn, mod);
+  QMouseEvent e(QEvent::MouseMove, pos, QCursor::pos(), btn, btn, mod);
   if(!simulateEvent(w, &e))
   {
     qWarning("mouseMove not handled\n");
@@ -253,7 +253,7 @@ void ctkTestApplication::mouseDClick(QWidget* w, QPoint pos, Qt::MouseButton btn
                          Qt::KeyboardModifiers mod, int ms)
 {
   delay(ms);
-  QMouseEvent e(QEvent::MouseButtonDblClick, pos, btn, btn, mod);
+  QMouseEvent e(QEvent::MouseButtonDblClick, pos, QCursor::pos(), btn, btn, mod);
   if(!simulateEvent(w, &e))
   {
     qWarning("mouseMove not handled\n");

--- a/Plugins/org.commontk.metatype/ctkMTDataParser.cpp
+++ b/Plugins/org.commontk.metatype/ctkMTDataParser.cpp
@@ -82,7 +82,11 @@ QHash<QString, ctkObjectClassDefinitionImplPtr> ctkMTDataParser::doParse()
   CTK_DEBUG(logger) << "Starting to parse metadata";
   while (_dp_xmlReader.readNextStartElement())
   {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QStringView name = _dp_xmlReader.name();
+#else
     QStringRef name = _dp_xmlReader.name();
+#endif
     if (name.compare(METADATA, Qt::CaseInsensitive) == 0)
     {
       metaDataHandler();
@@ -117,7 +121,11 @@ void ctkMTDataParser::metaDataHandler()
   _dp_xmlReader.readNext();
   while(!_dp_xmlReader.hasError() && _dp_xmlReader.readNextStartElement())
   {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QStringView name = _dp_xmlReader.name();
+#else
     QStringRef name = _dp_xmlReader.name();
+#endif
     if (name.compare(DESIGNATE, Qt::CaseInsensitive) == 0)
     {
       designateHandler();
@@ -217,7 +225,11 @@ void ctkMTDataParser::designateHandler()
 
   while (!_dp_xmlReader.hasError() && _dp_xmlReader.readNextStartElement())
   {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QStringView name = _dp_xmlReader.name();
+#else
     QStringRef name = _dp_xmlReader.name();
+#endif
     if (name.compare(OBJECT, Qt::CaseInsensitive) == 0)
     {
      objectHandler(info);
@@ -246,7 +258,11 @@ void ctkMTDataParser::ocdHandler()
 {
   Q_ASSERT(_dp_xmlReader.isStartElement() && _dp_xmlReader.name().compare(OCD, Qt::CaseInsensitive) == 0);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  QStringView name = _dp_xmlReader.name();
+#else
   QStringRef name = _dp_xmlReader.name();
+#endif
   QXmlStreamAttributes atts = _dp_xmlReader.attributes();
   QString ocd_name_val = atts.value(NAME).toString();
   if (ocd_name_val.isNull())
@@ -277,7 +293,11 @@ void ctkMTDataParser::ocdHandler()
   QList<ctkAttributeDefinitionImplPtr> ad_list;
   while (!_dp_xmlReader.hasError() && _dp_xmlReader.readNextStartElement())
   {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QStringView name2 = _dp_xmlReader.name();
+#else
     QStringRef name2 = _dp_xmlReader.name();
+#endif
     if (name2.compare(AD, Qt::CaseInsensitive) == 0)
     {
       attributeDefinitionHandler(ad_list);
@@ -332,7 +352,11 @@ void ctkMTDataParser::objectHandler(DesignateInfo& designateInfo)
 
   while (!_dp_xmlReader.hasError() && _dp_xmlReader.readNextStartElement())
   {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QStringView name = _dp_xmlReader.name();
+#else
     QStringRef name = _dp_xmlReader.name();
+#endif
     if (name.compare(ATTRIBUTE, Qt::CaseInsensitive) == 0)
     {
       attributeHandler();
@@ -378,7 +402,11 @@ void ctkMTDataParser::attributeDefinitionHandler(QList<ctkAttributeDefinitionImp
   }
 
   int dataType;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  QStringView ad_type_val = atts.value("", TYPE);
+#else
   QStringRef ad_type_val = atts.value("", TYPE);
+#endif
   if (ad_type_val.compare(STRING, Qt::CaseInsensitive) == 0)
   {
     dataType = QVariant::String;
@@ -479,7 +507,11 @@ void ctkMTDataParser::attributeDefinitionHandler(QList<ctkAttributeDefinitionImp
   QStringList optionValues;
   while (!_dp_xmlReader.hasError() && _dp_xmlReader.readNextStartElement())
   {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QStringView name2 = _dp_xmlReader.name();
+#else
     QStringRef name2 = _dp_xmlReader.name();
+#endif
     if (name2.compare(OPTION, Qt::CaseInsensitive) == 0)
     {
       OptionInfo optionInfo;


### PR DESCRIPTION
This PR updates several CTK components to improve compatibility across Qt 5.15 and Qt 6.x and to address API changes and deprecations introduced in recent Qt 6 releases:

* Resolve or prevent deprecation warnings with Qt 6.4–6.6.
* Maintain full compatibility with Qt 5.15.
* Prepare CTK for smoother adoption of newer Qt 6 versions without behavioral regressions.

### Changes

* **ctkDICOMTester**

  * Use `QByteArray::size()` instead of the deprecated parameter-less `count()` (Qt 6.4).

* **ctkBasePopupWidget / ctkPopupWidget**

  * For `QT_VERSION >= 6.5.0`, replace deprecated `QApplication::setActiveWindow()` with `activateWindow()` on the appropriate widget.
  * Keep `QApplication::setActiveWindow()` for Qt 5.x / Qt < 6.5 to preserve existing behavior.

* **ctkLanguageComboBox**

  * For `QT_VERSION >= 6.6.0`, use `QLocale::territoryToString(locale.territory())` instead of deprecated `QLocale::countryToString(locale.country())`.
  * Retain the country-based variant for Qt 5.x and earlier Qt 6 versions.

* **ctkQImageView**

  * For `QT_VERSION >= 6.6.0`, use `QColor::fromString()` for named colors instead of deprecated `QColor::setNamedColor()`.
  * Fallback to `setNamedColor()` on older Qt versions.

* **ctkTestApplication**

  * Construct `QMouseEvent` with both local and explicit global positions (`QCursor::pos()`), aligning with modern Qt 5/6 constructors and avoiding deprecated usage.

* **ctkMTDataParser**

  * For `QT_VERSION >= 6.0.0`, use `QStringView` when reading element and attribute names from `QXmlStreamReader`/`QXmlStreamAttributes`, in line with Qt 6 XML APIs.
  * Keep `QStringRef` for Qt 5.x to maintain dual-build compatibility.