### PR TITLE
COMP: Remove EXCEPTION QVariant insertion incompatible with Qt 6

### DIFF
--- a/Plugins/org.commontk.eventadmin/adapter/ctkEALogEventAdapter.cpp
+++ b/Plugins/org.commontk.eventadmin/adapter/ctkEALogEventAdapter.cpp
@@ -75,7 +75,7 @@ void _LogListener::logged(ctkLogEntryPtr entry)
                         message);
     }
 
-    properties.insert(ctkEventConstants::EXCEPTION, exc);
+    // properties.insert(ctkEventConstants::EXCEPTION, exc);
   }
 
   ctkServiceReference service = entry->getServiceReference();


### PR DESCRIPTION
Qt 6 restricts `QVariant` to registered/meta-typed values. Inserting `const std::exception*` into the properties map now fails with `QVariant<const std::exception*, false>` being deleted.

- Comment out insertion of `tkEventConstants::EXCEPTION` in `ctkEALogEventAdapter` to restore Qt 6 build compatibility.
- Note: this removes the `EXCEPTION` event property; a follow-up change could store `exc->what()` as a string instead.

This fixes the following error:

```
ctkEALogEventAdapter.cpp:78:53: Attempt to use a deleted function
qvariant.h:314:5: 'QVariant<const std::exception *, false>' has been explicitly marked deleted here
```