### PR TITLE
COMP: Use QEnterEvent instead of QEvent for enterEvent() in Qt 6

### DIFF
--- a/Libs/Widgets/ctkQImageView.cpp
+++ b/Libs/Widgets/ctkQImageView.cpp
@@ -875,7 +875,7 @@ void ctkQImageView::mouseMoveEvent( QMouseEvent * event )
 }
 
 // -------------------------------------------------------------------------
-void ctkQImageView::enterEvent( QEvent * )
+void ctkQImageView::enterEvent( QEnterEvent * )
 {
   Q_D( ctkQImageView );
   QApplication::setOverrideCursor( QCursor(Qt::CrossCursor) );

--- a/Libs/Widgets/ctkQImageView.h
+++ b/Libs/Widgets/ctkQImageView.h
@@ -77,6 +77,10 @@ public:
 
   double zoom( void );
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+  using QEnterEvent = QEvent;
+#endif
+
 public Q_SLOTS:
 
   void addImage( const QImage & image );
@@ -95,7 +99,7 @@ public Q_SLOTS:
   virtual void mousePressEvent( QMouseEvent * event );
   virtual void mouseReleaseEvent( QMouseEvent * event );
   virtual void mouseMoveEvent( QMouseEvent * event );
-  virtual void enterEvent( QEvent * event );
+  virtual void enterEvent( QEnterEvent * event );
   virtual void leaveEvent( QEvent * event );
 
   void setCenter( double x, double y );


### PR DESCRIPTION
Follow-up of the following pull request:
* https://github.com/commontk/CTK/pull/1288