### PR TITLE
COMP: Update active window handling for Qt 6.5+ in ctkBasePopupWidget

### DIFF
--- a/Libs/Widgets/ctkBasePopupWidget.cpp
+++ b/Libs/Widgets/ctkBasePopupWidget.cpp
@@ -441,7 +441,14 @@ void ctkBasePopupWidgetPrivate::hideAll()
 #ifndef Q_OS_MAC // See Slicer issue #3850
   if (q->isActiveWindow() && !this->BaseWidget.isNull())
   {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+    if (!this->BaseWidget.isNull())
+    {
+      this->BaseWidget->activateWindow();
+    }
+#else
     qApp->setActiveWindow(this->BaseWidget->window());
+#endif
   }
 #endif
 


### PR DESCRIPTION
- For Qt >= 6.5, replace deprecated `QApplication::setActiveWindow()` with `activateWindow()` on the relevant widget, as recommended by Qt.
- Keep `QApplication::setActiveWindow()` for Qt 5.x / Qt < 6.5 to preserve existing behavior

Follow-up of similar changes integrated in the following pull request:
- https://github.com/commontk/CTK/pull/1298