### PR TITLE
COMP: Fix Qt6 build by including <climits> for ULONG_MAX

### DIFF
--- a/Plugins/org.commontk.eventadmin/dispatch/ctkEAInterruptibleThread_p.h
+++ b/Plugins/org.commontk.eventadmin/dispatch/ctkEAInterruptibleThread_p.h
@@ -28,6 +28,7 @@
 #include <QMutex>
 #include <QAtomicInt>
 #include <QRunnable>
+#include <climits>
 
 /**
  * A QRunnable subclass with simple reference counting.


### PR DESCRIPTION
Ensure the `ULONG_MAX` macro is defined by including the `<climits>` header in `ctkEAInterruptibleThread_p.h`. This change addresses build issues when using Qt6.