### PR TITLE
COMP: Update PythonQt with Qt6 support

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -91,7 +91,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
 
   ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
 
-  set(revision_tag 4d4800bea3559222c76433d5974c75a01dbec728) # patched-v3.6.1-2025-09-30-f4769f190
+  set(revision_tag 4869cbe540e383c8e25c8796269442d7865653f8) # patched-v3.6.1-2025-09-30-f4769f190
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()


### PR DESCRIPTION
List of PythonQt changes:

```
$ git shortlog 4d4800be..4869cbe5 --no-merges
Jean-Christophe Fillion-Robin (5):
      [commontk] cmake: Prefer using CorePrivate Qt target
      [commontk] cmake: Add Qt6 support for building PythonQt and PythonQtGenerator
      [commontk] cmake: Simplify mapping of Qt wrapped library to component
      [commontk] cmake: Update Qt wrapped library to component mapping for Qt6
      [commontk] cmake: Address build error by partially reverting AUTOMOC changes
```