### PR TITLE
BUG: Fix null d_ptr in alternate ctkMessageBox constructor

### DIFF
--- a/Libs/Widgets/ctkMessageBox.cpp
+++ b/Libs/Widgets/ctkMessageBox.cpp
@@ -189,6 +189,7 @@ ctkMessageBox::ctkMessageBox(Icon icon, const QString& title,
                              const QString& text, StandardButtons buttons,
                              QWidget* parent, Qt::WindowFlags f)
   : QMessageBox(icon, title, text, buttons, parent, f)
+  , d_ptr(new ctkMessageBoxPrivate(*this))
 {
   Q_D(ctkMessageBox);
   d->init();


### PR DESCRIPTION
Initialize d_ptr in the alternative ctkMessageBox constructor before calling d->init(), preventing a potential null dereference crash and addressing the compiler warning.

Fixes the following warning;

```
/path/to/CTK/Libs/Widgets/ctkMessageBox.cpp: In constructor ‘ctkMessageBox::ctkMessageBox(QMessageBox::Icon, const QString&, const QString&, QMessageBox::StandardButtons, QWidget*, Qt::WindowFlags)’:
/path/to/CTK/Libs/Widgets/ctkMessageBox.cpp:194:10: warning: ‘this’ pointer is null [-Wnonnull]
  194 |   d->init();
      |   ~~~~~~~^~
```