### PR TITLE
COMP: Fix ctkWorkflow moc with strict Qt 6.x meta-type checks

### DIFF
--- a/Libs/Core/ctkWorkflow.h
+++ b/Libs/Core/ctkWorkflow.h
@@ -32,6 +32,10 @@ class ctkWorkflowStep;
 class ctkWorkflowPrivate;
 class QAbstractState;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+Q_MOC_INCLUDE("ctkWorkflowStep.h") // Ensure moc sees ctkWorkflowStep for meta-type generation (needed for stricter Qt 6.4+)
+#endif
+
 /// \ingroup Core
 /// \brief ctkWorkflow is the basis for a workflow engine, i.e. a state
 /// machine with enhancements to support ctkWorkflowStep.


### PR DESCRIPTION
Some Qt 6.x versions (e.g. 6.4) enforce that pointer types used in the meta-object system (`ctkWorkflowStep*`, `QList<ctkWorkflowStep*>`) refer to complete types when generating meta-type information for Q_INVOKABLEs and signals.

`ctkWorkflow.h` only forward-declares `ctkWorkflowStep`, which causes `moc` in these stricter versions to instantiate `QMetaType` for an incomplete type and fail with:

```
/path/to/CTK-build/Libs/Core/CTKCore_autogen/EWIEGA46WW/moc_ctkWorkflow.cpp:301:5:   required from here
/path/to/Qt/6.4.2/gcc_64/include/QtCore/qmetatype.h:842:23: error: invalid application of ‘sizeof’ to incomplete type ‘ctkWorkflowStep’
  842 |         static_assert(sizeof(T), "Type argument of Q_PROPERTY or Q_DECLARE_METATYPE(T*) must be fully defined");
```

Add `Q_MOC_INCLUDE("ctkWorkflowStep.h")` so `moc` sees the full type without introducing a circular include at the C++ level.

This restores compatibility with stricter Qt 6.x releases while remaining valid for newer versions where `moc` is more permissive.