### PR TITLE
COMP: Fix ctkDICOM moc with strict Qt 6.x meta-type checks

### DIFF
--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -37,6 +37,10 @@ class ctkDICOMAbstractThumbnailGenerator;
 class ctkDICOMDisplayedFieldGenerator;
 class ctkDICOMJobResponseSet;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+Q_MOC_INCLUDE("ctkDICOMJobResponseSet.h") // Ensure moc sees ctkDICOMJobResponseSet for meta-type generation (needed for stricter Qt 6.4+)
+#endif
+
 /// \ingroup DICOM_Core
 ///
 /// Class handling a database of DICOM objects. So far, an underlying

--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRuleFactory.h
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGeneratorRuleFactory.h
@@ -31,6 +31,10 @@ class ctkDICOMDatabase;
 class ctkDICOMDisplayedFieldGeneratorAbstractRule;
 class ctkDICOMDisplayedFieldGeneratorRuleFactoryCleanup;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+Q_MOC_INCLUDE("ctkDICOMDisplayedFieldGeneratorAbstractRule.h") // Ensure moc sees ctkDICOMDisplayedFieldGeneratorAbstractRule for meta-type generation (needed for stricter Qt 6.4+)
+#endif
+
 /// \ingroup SlicerRt_QtModules_Segmentations
 /// \class ctkDICOMDisplayedFieldGeneratorRuleFactory
 /// \brief Singleton class managing displayed field generator rules


### PR DESCRIPTION
Some Qt 6.x versions (e.g. 6.4) require pointer types used in the meta-object system to refer to complete types when generating meta-type information for Q_INVOKABLEs, signals, and slots.

`ctkDICOMJobResponseSet` and `ctkDICOMDisplayedFieldGeneratorAbstractRule` are only forward-declared in `ctkDICOMDatabase.h` and `ctkDICOMDisplayedFieldGeneratorRuleFactory.h`, respectively, which causes moc in these stricter Qt versions to treat them as incomplete and fail meta-type checks.

Add `Q_MOC_INCLUDE` entries so moc sees the full definitions without introducing circular includes at the C++ level. This mirrors the workflow fix in e531993a ("COMP: Fix ctkWorkflow moc with strict Qt 6.x meta-type checks", 2025-11-09) while restoring compatibility with stricter Qt 6.x releases and remaining safe for newer versions.

---

Related pull requests:
* https://github.com/commontk/CTK/pull/1311