### PR TITLE
COMP: Add missing export to QDebug operator<< for ctkVTKConnection

### DIFF
--- a/Libs/Visualization/VTK/Core/ctkVTKConnection.h
+++ b/Libs/Visualization/VTK/Core/ctkVTKConnection.h
@@ -126,10 +126,10 @@ protected:
 private:
   Q_DECLARE_PRIVATE(ctkVTKConnection);
   Q_DISABLE_COPY(ctkVTKConnection);
-  friend QDebug operator<<(QDebug dbg, const ctkVTKConnection& connection);
+  friend CTK_VISUALIZATION_VTK_CORE_EXPORT QDebug operator<<(QDebug dbg, const ctkVTKConnection& connection);
 };
 
 /// \ingroup Visualization_VTK_Core
-QDebug operator<<(QDebug dbg, const ctkVTKConnection& connection);
+CTK_VISUALIZATION_VTK_CORE_EXPORT QDebug operator<<(QDebug dbg, const ctkVTKConnection& connection);
 
 #endif


### PR DESCRIPTION
When building the [Slicer Qt6 pull request](https://github.com/Slicer/Slicer/pull/8825) in debug mode, linking complains about unresolved external `qDebug operator<<` for `ctkVTKConnection`; indeed, that operator was not marked for export. This pull request fixes that.