### PR TITLE
COMP: Fix Qt >= 6 updateSetting signal connection

### DIFF
--- a/Libs/Widgets/ctkSettingsPanel.cpp
+++ b/Libs/Widgets/ctkSettingsPanel.cpp
@@ -325,10 +325,14 @@ void ctkSettingsPanel::registerProperty(const QString& key,
   // Create a signal mapper per property to be able to support
   // multiple signals from the same sender.
   QSignalMapper* signalMapper = new QSignalMapper(this);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+  connect(signalMapper, &QSignalMapper::mappedString, this, &ctkSettingsPanel::updateSetting);
+#else
   QObject::connect(signalMapper, SIGNAL(mapped(QString)),
                    this, SLOT(updateSetting(QString)));
+#endif
   signalMapper->setMapping(object, key);
-  this->connect(object, signal, signalMapper, SLOT(map()));
+  connect(object, signal, signalMapper, SLOT(map()));
 
   if (d->SaveToSettingsWhenRegister)
   {


### PR DESCRIPTION
On starting [a slicer built against Qt6](https://github.com/Slicer/Slicer/pull/8825) with the current CTK main branch, it reports many signal connection failures like this:

```
QObject::connect: No such signal QSignalMapper::mapped(QString) in SLICERBUILDDIR\CTK\Libs\Widgets\ctkSettingsPanel.cpp:328
QObject::connect:  (receiver name: 'qSlicerSettingsGeneralPanel')
```

This is because the `mapped()` signal was removed with Qt6.

This pull request makes CTK use the successor `mappedString` instead (and switches to the new style of connecting signals for it, which would cause a compliation failure if the connection cannot be established).