### PR TITLE
COMP: Fix Qt >=6: QComboBox signal: currentIndexChanged(QString) -> currentTextChanged

### DIFF
--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKDataSetModelEventTranslatorPlayerTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKDataSetModelEventTranslatorPlayerTest1.cpp
@@ -92,7 +92,11 @@ int ctkVTKDataSetModelEventTranslatorPlayerTest1(int argc, char * argv [] )
   comboBox.setModel(&dataSetModel);
   comboBox.show();
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+  QSignalSpy spy1(&comboBox, &QComboBox::currentTextChanged);
+#else
   QSignalSpy spy1(&comboBox, SIGNAL(currentIndexChanged(QString)));
+#endif
   Spy1 = &spy1;
 
   etpWidget.addTestCase(&comboBox,

--- a/Libs/Visualization/VTK/Widgets/ctkVTKTextPropertyWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKTextPropertyWidget.cpp
@@ -64,8 +64,13 @@ void ctkVTKTextPropertyWidgetPrivate::init()
                    q, SLOT(setColor(QColor)));
   QObject::connect(this->OpacitySlider, SIGNAL(valueChanged(double)),
                    q, SLOT(setOpacity(double)));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+  QObject::connect(this->FontComboBox, &QComboBox::currentTextChanged,
+                   q, &ctkVTKTextPropertyWidget::setFont);
+#else
   QObject::connect(this->FontComboBox, SIGNAL(currentIndexChanged(QString)),
                    q, SLOT(setFont(QString)));
+#endif
   QObject::connect(this->BoldCheckBox, SIGNAL(toggled(bool)),
                    q, SLOT(setBold(bool)));
   QObject::connect(this->ItalicCheckBox, SIGNAL(toggled(bool)),

--- a/Libs/Widgets/ctkTreeComboBoxEventTranslator.cpp
+++ b/Libs/Widgets/ctkTreeComboBoxEventTranslator.cpp
@@ -63,8 +63,13 @@ bool ctkTreeComboBoxEventTranslator::translateEvent(QObject *Object,
 //      connect(treeCombo, SIGNAL(popupHide()), this, SLOT(onPopupHide()));
       connect(treeCombo, SIGNAL(destroyed(QObject*)),
               this, SLOT(onDestroyed(QObject*)));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+      connect(treeCombo, &QComboBox::currentTextChanged,
+              this, &ctkTreeComboBoxEventTranslator::onCurrentIndexChanged);
+#else
       connect(treeCombo, SIGNAL(currentIndexChanged(const QString&)),
               this, SLOT(onCurrentIndexChanged(const QString&)));
+#endif
       return true;
     }
   }


### PR DESCRIPTION
In Qt 6, the previously overloaded `currentIndexChanged` signal in `QComboBox` has been split up into a `currentIndexChanged` with int parameter and a `currentTextChanged` with QString parameter.

This pull request fixes the one occurrence of `currentIndexChanged(QString)` (and updates it to new connection syntax which can be checked during compile time).

**Note:** 2 out of the 3 changes are currently uncompiled / untested because they depend on QtTesting to be available. To be tested when QtTesting is available again!