### PR TITLE
COMP: Fix Qt >= 6.7 QCheckBox stateChanged -> checkStateChanged

### DIFF
--- a/Libs/DICOM/Widgets/Resources/UI/ctkDICOMAppWidget.ui
+++ b/Libs/DICOM/Widgets/Resources/UI/ctkDICOMAppWidget.ui
@@ -696,22 +696,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>AutoPlayCheckbox</sender>
-   <signal>stateChanged(int)</signal>
-   <receiver>ctkDICOMAppWidget</receiver>
-   <slot>onAutoPlayCheckboxStateChanged(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>430</x>
-     <y>596</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>369</x>
-     <y>318</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>ThumbnailWidthSlider</sender>
    <signal>valueChanged(int)</signal>
    <receiver>ctkDICOMAppWidget</receiver>

--- a/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
@@ -266,6 +266,12 @@ ctkDICOMAppWidget::ctkDICOMAppWidget(QWidget* _parent):Superclass(_parent),
   d->ThumbnailsWidget->setThumbnailSize(
     QSize(d->ThumbnailWidthSlider->value(), d->ThumbnailWidthSlider->value()));
 
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    connect(d->AutoPlayCheckbox, &QCheckBox::checkStateChanged, this, &ctkDICOMAppWidget::onAutoPlayCheckboxStateChanged);
+#else
+    connect(d->AutoPlayCheckbox, &QCheckBox::stateChanged, this, &ctkDICOMAppWidget::onAutoPlayCheckboxStateChanged);
+#endif
+
   // Treeview signals
   connect(d->TreeView, SIGNAL(collapsed(QModelIndex)), this, SLOT(onTreeCollapsed(QModelIndex)));
   connect(d->TreeView, SIGNAL(expanded(QModelIndex)), this, SLOT(onTreeExpanded(QModelIndex)));

--- a/Libs/DICOM/Widgets/ctkDICOMServerNodeWidget2.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMServerNodeWidget2.cpp
@@ -354,8 +354,13 @@ void ctkDICOMServerNodeWidget2Private::init()
 
   q->readSettings();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+  QObject::connect(this->StorageEnabledCheckBox, &QCheckBox::checkStateChanged,
+                   q, &ctkDICOMServerNodeWidget2::onSettingsModified);
+#else
   QObject::connect(this->StorageEnabledCheckBox, SIGNAL(stateChanged(int)),
                    q, SLOT(onSettingsModified()));
+#endif
   QObject::connect(this->StorageAETitle, SIGNAL(textChanged(QString)),
                    q, SLOT(onSettingsModified()));
   QObject::connect(this->StoragePort, SIGNAL(textChanged(QString)),

--- a/Libs/Widgets/ctkModalityWidget.cpp
+++ b/Libs/Widgets/ctkModalityWidget.cpp
@@ -87,8 +87,13 @@ void ctkModalityWidgetPrivate::init()
   this->setupUi(q);
 
   this->AnyCheckBox->setTristate(true);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+  QObject::connect(this->AnyCheckBox, &QCheckBox::checkStateChanged,
+      q, &ctkModalityWidget::onAnyChanged);
+#else
   QObject::connect(this->AnyCheckBox, SIGNAL(stateChanged(int)),
                    q, SLOT(onAnyChanged(int)));
+#endif
 
   foreach(QCheckBox* modalityBox, q->findChildren<QCheckBox*>())
   {


### PR DESCRIPTION
Starting with Qt 6.7 (corrected, was incorrect 6.9), the `stateChanged` signal in `QCheckBox` has been deprecated in favor of the `checkStateChanged` signal; this pull request applies this change also in CTK code  (and updates it to the new connection syntax, which can be checked during compile time).