### PR TITLE
COMP: Fix Qt6 build with tests

### DIFF
--- a/Libs/ImageProcessing/ITK/Core/Testing/Cpp/ctkITKErrorLogModelFileLoggingTest1.cpp
+++ b/Libs/ImageProcessing/ITK/Core/Testing/Cpp/ctkITKErrorLogModelFileLoggingTest1.cpp
@@ -22,6 +22,7 @@
 #include <QCoreApplication>
 #include <QDebug>
 #include <QDir>
+#include <QRegExp>
 #include <QTemporaryFile>
 
 // CTK includes


### PR DESCRIPTION
Fixes CTK build against Qt6 with tests (BUILD_TESTING) enabled - an include is missing.