### PR TITLE
BUG: Fix crash in ctkRangeWidgetPrivate::synchronizeSiblingSpinBox

### DIFF
--- a/Libs/Widgets/ctkRangeWidget.cpp
+++ b/Libs/Widgets/ctkRangeWidget.cpp
@@ -166,6 +166,10 @@ int ctkRangeWidgetPrivate::synchronizedSpinBoxWidth()const
 void ctkRangeWidgetPrivate::synchronizeSiblingSpinBox(int width)
 {
   Q_Q(const ctkRangeWidget);
+  if (!q->parent())
+  {
+    return;
+  }
   QList<ctkRangeWidget*> siblings =
     q->parent()->findChildren<ctkRangeWidget*>();
   foreach(ctkRangeWidget* sibling, siblings)


### PR DESCRIPTION
When widget parent was not set in ctkRangeWidget then synchronizeSiblingSpinBox method crashed.