### PR TITLE
COMP: Update PythonQt with Qt 6.10 compatibility fix

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -91,7 +91,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
 
   ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
 
-  set(revision_tag 0f8486a7ad0e95bfbf1be57600e42d6e2ed136ea) # patched-v3.6.1-2025-09-30-f4769f190
+  set(revision_tag a1ab55c35a49221d208858c5b0ae003d83c87ed0) # patched-v3.6.1-2025-12-22-469f01f6a
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()


### PR DESCRIPTION
```
List of changes:
Bernhard Froehler (1):
      [commontk] cmake: Add 6.10 support (additional CorePrivate component)

MinyazevR (1):
      Add clang-format configuration (# 326)

dependabot[bot] (3):
      chore(deps): bump actions/upload-artifact from 4 to 5
      chore(deps): bump actions/checkout from 5 to 6
      chore(deps): bump hendrikmuhs/ccache-action from 1.2.19 to 1.2.20

mrbean-bremen (6):
      Remove clean cache workflow
      Add pre-commit hook for clang-format
      Changes after applying clang-format
      Changes after removing training spaces
      Use Qt 6.10.0 explicitly in CI, as 6.10.1 fails
      Revert explicit use of Qt 6.10.0 in CI

pre-commit-ci[bot] (3):
      [pre-commit.ci] pre-commit autoupdate
      [pre-commit.ci] pre-commit autoupdate
      [pre-commit.ci] pre-commit autoupdate
```