### PR TITLE
BUG: Fix ctkPathLineEdit Filter enums unavailable to PythonQt with Qt6

### DIFF
--- a/Libs/Widgets/ctkPathLineEdit.h
+++ b/Libs/Widgets/ctkPathLineEdit.h
@@ -65,7 +65,7 @@ class CTK_WIDGETS_EXPORT ctkPathLineEdit: public QWidget
   Q_PROPERTY(QString label READ label WRITE setLabel)
 
   Q_PROPERTY(Filters filters READ filters WRITE setFilters)
-  Q_FLAGS(Filters)
+  Q_FLAGS(Filter Filters)
 
   Q_PROPERTY(QString currentPath READ currentPath WRITE setCurrentPath USER true)
 
@@ -140,6 +140,7 @@ public:
                 NoDotDot      = 0x4000,
                 NoFilter = -1
   };
+  Q_ENUM(Filter)
   Q_DECLARE_FLAGS(Filters, Filter)
 
 #ifndef USE_QFILEDIALOG_OPTIONS
@@ -154,6 +155,7 @@ public:
     ReadOnly              = 0x00000020,
     HideNameFilterDetails = 0x00000040
   };
+  Q_ENUM(Option)
   Q_DECLARE_FLAGS(Options, Option)
 #endif
 


### PR DESCRIPTION
Update Q_FLAGS to register both enum and flags types consistently.

Add Q_ENUM declarations for Filter and Option enums to fix PythonQt enum value accessibility in Qt6.

Fixes: AttributeError: ctkPathLineEdit has no attribute 'Dirs'

This helps resolve some testing failures in the context of 3D Slicer when using Qt6 where there was observations of:
```
  File "C:/S5R2/Slicer-build/lib/Slicer-5.11/qt-scripted-modules/ScreenCapture.py", line 204, in setup
    self.outputDirSelector.filters = ctk.ctkPathLineEdit.Dirs
                                     ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: ctkPathLineEdit has no attribute named 'Dirs'
```