### PR TITLE
COMP: Update PythonQt with Qt 6.10 wrapping fixes

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -91,7 +91,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
 
   ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
 
-  set(revision_tag a1ab55c35a49221d208858c5b0ae003d83c87ed0) # patched-v3.6.1-2025-12-22-469f01f6a
+  set(revision_tag ef4ebfbae0620e688c9732baeb7ae09fc2f75dc2) # patched-v3.6.1-2025-12-22-469f01f6a
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()


### PR DESCRIPTION
See https://github.com/commontk/PythonQt/commit/ef4ebfbae0620e688c9732baeb7ae09fc2f75dc2
```
Commontk/PythonQt:
$ git shortlog a1ab55c..ef4ebfb
James Butler (1):
      [Backport] Adjustments for Qt 6.10
```

This helps resolve some testing failures in the context of 3D Slicer when using Qt 6.10 where there was observations of:
```
Traceback (most recent call last):
  File "C:/S5R2/Slicer-build/lib/Slicer-5.11/qt-scripted-modules/SampleData.py", line 1266, in test_downloadFromSource_downloadZipFile
    filePaths = logic.downloadFromSource(SampleDataSource(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/S5R2/Slicer-build/lib/Slicer-5.11/qt-scripted-modules/SampleData.py", line 895, in downloadFromSource
    qt.QDir().mkpath(outputDir)
    ^^^^^^^^^^^^^^^^
AttributeError: QDir has no attribute named 'mkpath'. Did you mean: 'path'?
```