### PR TITLE
ENH: Replace deprecated AddActor2D method

### DIFF
--- a/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
+++ b/Libs/Visualization/VTK/Core/vtkLightBoxRendererManager.cpp
@@ -399,8 +399,8 @@ void vtkLightBoxRendererManager::vtkInternal
   {
     item->ImageActor->SetVisibility(false);
     item->HighlightedBoxActor->SetVisibility(false);
-    item->Renderer->AddActor2D(item->ImageActor);
-    item->Renderer->AddActor2D(item->HighlightedBoxActor);
+    item->Renderer->AddViewProp(item->ImageActor);
+    item->Renderer->AddViewProp(item->HighlightedBoxActor);
   }
   item->ImageActor->SetVisibility(this->ImageDataConnection != NULL);
 }


### PR DESCRIPTION
As of VTK 9.5.0 (per https://github.com/Kitware/VTK/commit/8ec4ae2050c555d1894e2a90029316be4e1ffbea), AddActor2D is deprecated with a replacement of AddViewProp.