### PR TITLE
COMP: Update PythonQt with previously missing commit

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -91,7 +91,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
 
   ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
 
-  set(revision_tag ef4ebfbae0620e688c9732baeb7ae09fc2f75dc2) # patched-v3.6.1-2025-12-22-469f01f6a
+  set(revision_tag ec7e1416e17fae645f3b99a8df4533719e17cbf6) # patched-v3.6.1-2025-12-22-469f01f6a
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()

--- a/Libs/Core/ctkErrorLogLevel.h
+++ b/Libs/Core/ctkErrorLogLevel.h
@@ -32,6 +32,7 @@
 class CTK_CORE_EXPORT ctkErrorLogLevel : public QObject
 {
   Q_OBJECT
+  Q_FLAGS(LogLevel)
 public:
   typedef QObject Superclass;
   ctkErrorLogLevel(QObject* parent = 0);
@@ -49,7 +50,6 @@ public:
     Fatal    = 0x100,
     None     = 0x200,
   };
-  Q_ENUM(LogLevel)
   Q_DECLARE_FLAGS(LogLevels, LogLevel)
 
   QString operator ()(LogLevel logLevel);

--- a/Libs/Core/ctkErrorLogTerminalOutput.h
+++ b/Libs/Core/ctkErrorLogTerminalOutput.h
@@ -36,6 +36,7 @@ class ctkErrorLogTerminalOutputPrivate;
 class CTK_CORE_EXPORT ctkErrorLogTerminalOutput : public QObject
 {
   Q_OBJECT
+  Q_FLAGS(TerminalOutputs)
 
 public:
   typedef QObject Superclass;
@@ -49,7 +50,6 @@ public:
     StandardOutput  = 0x2,
     All             = StandardError | StandardOutput
   };
-  Q_ENUM(TerminalOutput)
   Q_DECLARE_FLAGS(TerminalOutputs, TerminalOutput)
 
   bool enabled()const;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKDataSetModel.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKDataSetModel.h
@@ -51,6 +51,7 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKDataSetModel
 {
   Q_OBJECT
   QVTK_OBJECT
+  Q_FLAGS(AttributeType AttributeTypes)
 
   /// This property holds the type of attribute that should be listed in the model.
   /// By default all attributes are considered.
@@ -83,7 +84,6 @@ public:
     EdgeFlagAttribute = 0x100,
     AllAttribute = NoAttribute | ScalarsAttribute | VectorsAttribute | NormalsAttribute | TCoordsAttribute | TensorsAttribute | GlobalIDsAttribute | PedigreeIDsAttribute | EdgeFlagAttribute
   };
-  Q_ENUM(AttributeType)
   Q_DECLARE_FLAGS(AttributeTypes, AttributeType)
 
   virtual void setDataSet(vtkDataSet* dataSet);

--- a/Libs/Visualization/VTK/Widgets/ctkVTKPropertyWidget.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKPropertyWidget.h
@@ -40,6 +40,8 @@ class CTK_VISUALIZATION_VTK_WIDGETS_EXPORT ctkVTKPropertyWidget
   QVTK_OBJECT;
   typedef QWidget Superclass;
 
+  Q_FLAGS(GroupsState)
+
   /// Show/Hide, expand/collapse groups in the widget.
   /// Groups are visible by default and Color is the only expanded group.
   /// \sa groupsState(), setGroupsState()
@@ -63,7 +65,6 @@ public:
     AllVisible            = RepresentationVisible | ColorVisible | LightingVisible | MaterialVisible,
     AllCollapsed          = RepresentationCollapsed | ColorCollapsed | LightingCollapsed | MaterialCollapsed
   };
-  Q_ENUM(GroupState)
   Q_DECLARE_FLAGS(GroupsState, GroupState)
 
   /// Construct a ctkVTKPropertyWidget with a default vtkProperty.

--- a/Libs/Widgets/ctkColorPickerButton.h
+++ b/Libs/Widgets/ctkColorPickerButton.h
@@ -38,6 +38,7 @@ class ctkColorPickerButtonPrivate;
 class CTK_WIDGETS_EXPORT ctkColorPickerButton : public QPushButton
 {
   Q_OBJECT
+  Q_FLAGS(ColorDialogOption ColorDialogOptions)
 
   /// This property controls the name of the color.
   /// Black (0,0,0) by default.
@@ -62,7 +63,6 @@ public:
     DontUseNativeDialog = 0x00000004,
     UseCTKColorDialog   = 0x0000000C
   };
-  Q_ENUM(ColorDialogOption)
   Q_DECLARE_FLAGS(ColorDialogOptions, ColorDialogOption)
 
   /// By default, the color is black

--- a/Libs/Widgets/ctkConsole.h
+++ b/Libs/Widgets/ctkConsole.h
@@ -79,10 +79,12 @@ class CTK_WIDGETS_EXPORT ctkConsole : public QWidget
   Q_PROPERTY(int cursorPosition READ cursorPosition)
   Q_PROPERTY(int cursorColumn READ cursorColumn)
   Q_PROPERTY(int cursorLine READ cursorLine)
+  Q_FLAGS(EditorHint EditorHints)
   Q_PROPERTY(EditorHints editorHints READ editorHints WRITE setEditorHints)
   Q_ENUM(Qt::ScrollBarPolicy)
   Q_PROPERTY(Qt::ScrollBarPolicy scrollBarPolicy READ scrollBarPolicy WRITE setScrollBarPolicy)
   Q_PROPERTY(QList<QKeySequence> completerShortcuts READ completerShortcuts WRITE setCompleterShortcuts)
+  Q_FLAGS(RunFileOption RunFileOptions)
   Q_PROPERTY(RunFileOptions runFileOptions READ runFileOptions WRITE setRunFileOptions)
   Q_PROPERTY(int maxVisibleCompleterItems READ maxVisibleCompleterItems WRITE setMaxVisibleCompleterItems)
   Q_PROPERTY(QString commandBuffer READ commandBuffer WRITE setCommandBuffer)
@@ -97,7 +99,6 @@ public:
     RemoveTrailingSpaces = 0x02, /*!< Remove trailing spaces of the entered command */
     SplitCopiedTextByLine = 0x4  /*!< Copied text is split by lines and each one is executed (expected the last one) */
   };
-  Q_ENUM(EditorHint)
   Q_DECLARE_FLAGS(EditorHints, EditorHint)
 
   enum RunFileOption
@@ -106,7 +107,6 @@ public:
     RunFileButton = 0x01,   /*!< Show a button at the bottom of the console to run a file */
     RunFileShortcut = 0x02, /*!< Add the shortcut CTRL+G to run a file */
   };
-  Q_ENUM(RunFileOption)
   Q_DECLARE_FLAGS(RunFileOptions, RunFileOption)
 
   ctkConsole(QWidget* parentObject = 0);

--- a/Libs/Widgets/ctkCrosshairLabel.h
+++ b/Libs/Widgets/ctkCrosshairLabel.h
@@ -43,6 +43,7 @@ class ctkCrosshairLabelPrivate;
 class CTK_WIDGETS_EXPORT ctkCrosshairLabel : public QLabel
 {
   Q_OBJECT
+  Q_FLAGS(CrosshairType CrosshairTypes)
   Q_PROPERTY(bool showCrosshair READ showCrosshair WRITE setShowCrosshair)
   // QT designer does not yet support QPen properties, so we provide the
   // temporary properties crosshairColor and lineWidth.
@@ -65,7 +66,6 @@ public:
     SimpleCrosshair = 0,
     BullsEyeCrosshair
   };
-  Q_ENUM(CrosshairType)
   Q_DECLARE_FLAGS(CrosshairTypes, CrosshairType)
 
   /// Set/get whether or not to draw the crosshair.  Default True.

--- a/Libs/Widgets/ctkDirectoryButton.h
+++ b/Libs/Widgets/ctkDirectoryButton.h
@@ -81,6 +81,7 @@ class CTK_WIDGETS_EXPORT ctkDirectoryButton: public QWidget
   Q_PROPERTY(QFileDialog::Options options READ options WRITE setOptions)
 #else
   Q_PROPERTY(Options options READ options WRITE setOptions)
+  Q_FLAGS(Option Options);
 #endif
 
 public:
@@ -96,7 +97,6 @@ public:
     ReadOnly              = 0x00000020,
     HideNameFilterDetails = 0x00000040
   };
-  Q_ENUM(Option)
   Q_DECLARE_FLAGS(Options, Option)
 #endif
 

--- a/Libs/Widgets/ctkDoubleSpinBox.h
+++ b/Libs/Widgets/ctkDoubleSpinBox.h
@@ -45,6 +45,7 @@ class ctkValueProxy;
 class CTK_WIDGETS_EXPORT ctkDoubleSpinBox : public QWidget
 {
   Q_OBJECT
+  Q_FLAGS(DecimalsOption DecimalsOptions)
 
   Q_PROPERTY(Qt::Alignment alignment READ alignment WRITE setAlignment)
   Q_PROPERTY(bool frame READ hasFrame WRITE setFrame)
@@ -151,7 +152,6 @@ public:
     /// \sa decimals
     DecimalPointAlwaysVisible = 0x080
   };
-  Q_ENUM(DecimalsOption)
   Q_DECLARE_FLAGS(DecimalsOptions, DecimalsOption)
 
   enum SizeHintPolicy

--- a/Libs/Widgets/ctkPathLineEdit.h
+++ b/Libs/Widgets/ctkPathLineEdit.h
@@ -65,6 +65,7 @@ class CTK_WIDGETS_EXPORT ctkPathLineEdit: public QWidget
   Q_PROPERTY(QString label READ label WRITE setLabel)
 
   Q_PROPERTY(Filters filters READ filters WRITE setFilters)
+  Q_FLAGS(Filters)
 
   Q_PROPERTY(QString currentPath READ currentPath WRITE setCurrentPath USER true)
 
@@ -75,6 +76,7 @@ class CTK_WIDGETS_EXPORT ctkPathLineEdit: public QWidget
   Q_PROPERTY(QFileDialog::Options options READ options WRITE setOptions)
 #else
   Q_PROPERTY(Options options READ options WRITE setOptions)
+  Q_FLAGS(Option Options)
 #endif
 
   /// This property controls the key used to search the settings for recorded
@@ -138,7 +140,6 @@ public:
                 NoDotDot      = 0x4000,
                 NoFilter = -1
   };
-  Q_ENUM(Filter)
   Q_DECLARE_FLAGS(Filters, Filter)
 
 #ifndef USE_QFILEDIALOG_OPTIONS
@@ -153,7 +154,6 @@ public:
     ReadOnly              = 0x00000020,
     HideNameFilterDetails = 0x00000040
   };
-  Q_ENUM(Option)
   Q_DECLARE_FLAGS(Options, Option)
 #endif
 

--- a/Libs/Widgets/ctkPathListWidget.h
+++ b/Libs/Widgets/ctkPathListWidget.h
@@ -66,6 +66,8 @@ class CTK_WIDGETS_EXPORT ctkPathListWidget : public QListView
   /// The icon to be shown for a directory entry.
   Q_PROPERTY(QIcon directoryIcon READ directoryIcon WRITE setDirectoryIcon RESET unsetDirectoryIcon)
 
+  Q_FLAGS(PathOption PathOptions)
+
 public:
 
   enum
@@ -88,7 +90,6 @@ public:
     /// The path must be executable by the current user.
     Executable = 0x08
   };
-  Q_ENUM(PathOption)
   Q_DECLARE_FLAGS(PathOptions, PathOption)
 
   enum Mode

--- a/Libs/Widgets/ctkSliderWidget.h
+++ b/Libs/Widgets/ctkSliderWidget.h
@@ -43,6 +43,7 @@ class ctkValueProxy;
 class CTK_WIDGETS_EXPORT ctkSliderWidget : public QWidget
 {
   Q_OBJECT
+  Q_FLAGS(SynchronizeSiblings)
 
   /// This property holds the precision of the spin box, in decimals.
   /// 2 by default.
@@ -86,7 +87,6 @@ public:
     SynchronizeWidth = 0x001,
     SynchronizeDecimals = 0x002,
   };
-  Q_ENUM(SynchronizeSibling)
   Q_DECLARE_FLAGS(SynchronizeSiblings, SynchronizeSibling)
 
   /// Superclass typedef

--- a/Libs/Widgets/ctkWorkflowWidgetStep.h
+++ b/Libs/Widgets/ctkWorkflowWidgetStep.h
@@ -66,6 +66,7 @@ class CTK_WIDGETS_EXPORT ctkWorkflowWidgetStep : public QWidget, public ctkWorkf
   Q_PROPERTY(QString statusText READ statusText)
   Q_PROPERTY(QString backButtonText READ backButtonText WRITE setBackButtonText)
   Q_PROPERTY(QString nextButtonText READ nextButtonText WRITE setNextButtonText)
+  Q_FLAGS(ButtonBoxHint ButtonBoxHints)
   Q_PROPERTY(ButtonBoxHints buttonBoxHints READ buttonBoxHints WRITE setButtonBoxHints)
 public:
 


### PR DESCRIPTION
There was a missing PythonQt commit that was not cherry-picked over when the new branch was created that started to be used by CTK in https://github.com/commontk/CTK/commit/b9906abb3248506981ec1e1584cb7d9c69e47412

```
PythonQt:
$ git shortlog ef4ebfb..ec7e141
Jean-Christophe Fillion-Robin (1):
      [commontk] Revert part of r91 preventing QFlags from being wrapped
```

This commit includes reverting of https://github.com/commontk/CTK/commit/c425018742a51befad208fb7b5c17ce91e088f8a and https://github.com/commontk/CTK/commit/3811bcaf0d84e9b43777e6422b2330b84baf2e0b which was trying to handle the updated PythonQt with that missing commit.

In the context of 3D Slicer this resolves failing tests such as https://slicer.cdash.org/tests/31941117, by restoring the previous PythonQt behavior that was present before the new 2025-12-22 PythonQt branch was created.
```
test_SegmentationWidgetsTest1 (SegmentationWidgetsTest1.SegmentationWidgetsTest1.test_SegmentationWidgetsTest1) ... Traceback (most recent call last):
  File "C:\D\P\S-0-build\Slicer-build\lib\Slicer-5.11\qt-scripted-modules\SegmentEditorEffects\SegmentEditorMaskVolumeEffect.py", line 85, in setupOptionsFrame
    fillValueEdit.decimalsOption = ctk.ctkDoubleSpinBox.DecimalsByValue + ctk.ctkDoubleSpinBox.DecimalsByKey + ctk.ctkDoubleSpinBox.InsertDecimals
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: Property 'decimalsOption' of type 'DecimalsOptions' does not accept an object of type int (14)
```