### PR TITLE
COMP: Pass macOS architecture settings to external projects

### DIFF
--- a/CMake/ctkBlockCheckDependencies.cmake
+++ b/CMake/ctkBlockCheckDependencies.cmake
@@ -43,6 +43,20 @@ if(CTK_SUPERBUILD)
     set(ep_cxx_standard_arg "-DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}")
   endif()
 
+  # macOS-specific architecture settings
+  set(ep_osx_arch_args)
+  if(APPLE)
+    if(CMAKE_OSX_ARCHITECTURES)
+      list(APPEND ep_osx_arch_args -DCMAKE_OSX_ARCHITECTURES:STRING=${CMAKE_OSX_ARCHITECTURES})
+    endif()
+    if(CMAKE_OSX_DEPLOYMENT_TARGET)
+      list(APPEND ep_osx_arch_args -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET})
+    endif()
+    if(CMAKE_OSX_SYSROOT)
+      list(APPEND ep_osx_arch_args -DCMAKE_OSX_SYSROOT:PATH=${CMAKE_OSX_SYSROOT})
+    endif()
+  endif()
+
   set(ep_common_cache_args
       -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
@@ -54,6 +68,7 @@ if(CTK_SUPERBUILD)
       -DBUILD_TESTING:BOOL=OFF
       -DCMAKE_MACOSX_RPATH:BOOL=${CMAKE_MACOSX_RPATH}
       ${ep_cxx_standard_arg}
+      ${ep_osx_arch_args}
      )
 endif()
 


### PR DESCRIPTION
## Summary
- Adds CMAKE_OSX_ARCHITECTURES, CMAKE_OSX_DEPLOYMENT_TARGET, and CMAKE_OSX_SYSROOT to `ep_common_cache_args`
- Fixes native ARM64 builds on Apple Silicon Macs

## Problem
When building CTK with `-DCMAKE_OSX_ARCHITECTURES=arm64` on a Mac with ARM64 Qt5, PythonQtGenerator fails to link:

```
ld: warning: ignoring file 'QtCore': found architecture 'arm64', required architecture 'x86_64'
ld: symbol(s) not found for architecture x86_64
```

## Root Cause
The `ep_common_cache_args` variable (used by external projects like PythonQt and PythonQtGenerator) doesn't include macOS architecture settings, so nested projects default to x86_64 while trying to link against ARM64 Qt libraries.

## Test Plan
- [x] Built CTK with `-DCMAKE_OSX_ARCHITECTURES=arm64` on macOS Tahoe (M4)
- [x] PythonQtGenerator now builds successfully for ARM64
- [x] Full CTK build completes without architecture mismatch errors