### PR TITLE
COMP: Fix Qt6 metatype errors for VTK types in ctkVTKScalarsToColorsView

### DIFF
--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsView.h
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsView.h
@@ -28,9 +28,11 @@ class ctkVTKScalarsToColorsViewPrivate;
 
 // VTK includes
 #include <vtkChartXY.h>
+// Qt6 requires complete type definitions for Q_INVOKABLE methods
+#include <vtkPlot.h>
+#include <vtkControlPointsItem.h>
 
 class vtkColorTransferFunction;
-class vtkControlPointsItem;
 class vtkLookupTable;
 class vtkPiecewiseFunction;
 


### PR DESCRIPTION
Qt6 requires complete type definitions for types used in Q_INVOKABLE methods.

Replace forward declarations with includes:
- Add #include <vtkPlot.h>
- Add #include <vtkControlPointsItem.h>
- Remove forward declaration: class vtkControlPointsItem;

This fixes compilation errors on Qt 6.4.2:
  error: invalid application of 'sizeof' to incomplete type 'vtkPlot' error: invalid application of 'sizeof' to incomplete type 'vtkControlPointsItem'

Qt6's metatype system requires complete type information when types are used in Q_INVOKABLE method signatures. Forward declarations that were sufficient in Qt5 no longer work in Qt6.

Tested on Ubuntu 24.04 with Qt 6.4.2.

Related to #947 (Qt6 support tracking issue)