### PR TITLE
BUG: Fix crash under Qt6 when proxyStyle is not a QProxyStyle

### DIFF
--- a/Libs/Widgets/ctkProxyStyle.cpp
+++ b/Libs/Widgets/ctkProxyStyle.cpp
@@ -114,15 +114,18 @@ void ctkProxyStyle::ensureBaseStyle() const
   // Set the proxy to the entire hierarchy.
   QProxyStyle* proxyStyle = const_cast<QProxyStyle*>(qobject_cast<const QProxyStyle*>(
     this->proxy() ? this->proxy() : this));
-  QStyle* proxyBaseStyle = proxyStyle->baseStyle(); // calls ensureBaseStyle
-  QStyle* baseStyle = proxyBaseStyle;
-  while (baseStyle)
+  if (proxyStyle) // avoid crash when no proxy style in use
   {
-    d->setProxyStyle(proxyStyle, baseStyle);// set proxy on itself to all children
-    QProxyStyle* proxy = qobject_cast<QProxyStyle*>(baseStyle);
-    baseStyle = proxy ? proxy->baseStyle() : 0;
+    QStyle* proxyBaseStyle = proxyStyle->baseStyle(); // calls ensureBaseStyle
+    QStyle* baseStyle = proxyBaseStyle;
+    while (baseStyle)
+    {
+      d->setProxyStyle(proxyStyle, baseStyle);// set proxy on itself to all children
+      QProxyStyle* proxy = qobject_cast<QProxyStyle*>(baseStyle);
+      baseStyle = proxy ? proxy->baseStyle() : 0;
+    }
+    d->setBaseStyle(proxyStyle, proxyBaseStyle);
   }
-  d->setBaseStyle(proxyStyle, proxyBaseStyle);
   d->ensureBaseStyleInProgress = false;
 }
 


### PR DESCRIPTION
 A custom application based on Slicer crashes in `ctkProxyStyle::ensureBaseStyle` - when the style returned by `proxy()` is not a `QProxyStyle` - because then the `proxyStyle` variable is `nullptr` and subsequent, previously unchecked access causes an access violation.

I have to clearly state that I don't fully understand the circumstances under which this happens yet; nor why this only happens with Qt6.

I'm just putting my proposed quick fix here for discussion. It seems to work in our case, but I have not yet looked into potential unwanted consequences; because this would require a deeper understanding of what ctkProxyStyle actually does, which I don't have; @lassoan, @finetjul could you maybe help me here?