### PR TITLE
WIP: BUG: Fix ctkFontButtonTest hang and disable stale modal dialog tests

### DIFF
--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/CMakeLists.txt
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/CMakeLists.txt
@@ -237,6 +237,8 @@ if(CTK_USE_QTTESTING)
 #    SIMPLE_TEST( ctkVTKSliceViewEventTranslatorPlayerTest1 )
 #    SIMPLE_TEST( ctkVTKSurfaceMaterialPropertyWidgetEventTranslatorPlayerTest1 )
     SIMPLE_TEST( ctkVTKTextPropertyWidgetEventTranslatorPlayerTest1 )
+    set_tests_properties(ctkVTKTextPropertyWidgetEventTranslatorPlayerTest1
+      PROPERTIES LABELS "ModalDialogHang" DISABLED TRUE)
 #    SIMPLE_TEST( ctkVTKThresholdWidgetEventTranslatorPlayerTest1 )
 #    SIMPLE_TEST( ctkVTKVolumePropertyWidgetEventTranslatorPlayerTest1 )
 endif()

--- a/Libs/Widgets/Testing/Cpp/CMakeLists.txt
+++ b/Libs/Widgets/Testing/Cpp/CMakeLists.txt
@@ -423,4 +423,14 @@ if(CTK_USE_QTTESTING)
     ctkDoubleSliderEventTranslatorPlayerTest1
     PROPERTIES TIMEOUT 180
     )
+  # These tests open modal dialogs during event playback that block
+  # the event dispatcher. The recorded XML events reference stale
+  # widget paths inside the dialogs, preventing them from closing.
+  # Disabled until the XML files are re-recorded. See #1394.
+  set_tests_properties(
+    ctkColorPickerButtonEventTranslatorPlayerTest1
+    ctkDirectoryButtonEventTranslatorPlayerTest1
+    ctkFileDialogEventTranslatorPlayerTest1
+    PROPERTIES LABELS "ModalDialogHang" DISABLED TRUE
+    )
 endif()

--- a/Libs/Widgets/Testing/Cpp/ctkFontButtonTest.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkFontButtonTest.cpp
@@ -163,7 +163,14 @@ void ctkFontButtonTester::testUpdateText()
 void ctkFontButtonTester::testBrowseFont()
 {
   ctkFontButton fontButton;
-  QTimer::singleShot(200, qApp, SLOT(quit()));
+  // Close all top-level widgets (including modal QFontDialog) to exit.
+  // QApplication::quit() does not close modal dialogs in Qt6.
+  QTimer::singleShot(200, qApp, []() {
+    foreach (QWidget* w, QApplication::topLevelWidgets())
+    {
+      w->close();
+    }
+  });
   QTimer::singleShot(100, &fontButton, SLOT(browseFont()));
   fontButton.show();
   qApp->exec();


### PR DESCRIPTION
## Summary

Fix `ctkFontButtonTest::testBrowseFont()` which hung on Qt6 because `QApplication::quit()` does not close modal dialogs. Replace with closing all top-level widgets from a timer (Slicer pattern from `dd577f3f`).

Disable 4 EventTranslatorPlayer tests that hang due to stale XML widget paths inside modal dialogs (see #1394):
- `ctkColorPickerButtonEventTranslatorPlayerTest1`
- `ctkDirectoryButtonEventTranslatorPlayerTest1`
- `ctkFileDialogEventTranslatorPlayerTest1`
- `ctkVTKTextPropertyWidgetEventTranslatorPlayerTest1`

## Test plan

- [x] ctkFontButtonTest passes on both Qt5 and Qt6
- [x] 4 stale-XML modal dialog tests show as "Disabled"
- [x] Cherry-picks cleanly onto current master

🤖 Generated with [Claude Code](https://claude.com/claude-code)