### PR TITLE
BUG: Fix ctkLanguageComboBox locale normalization and selection

### DIFF
--- a/Libs/Widgets/ctkLanguageComboBox.cpp
+++ b/Libs/Widgets/ctkLanguageComboBox.cpp
@@ -146,8 +146,13 @@ void ctkLanguageComboBoxPrivate::updateLanguageItems()
   // we now sort based on the displayed text.
   q->model()->sort(0, Qt::AscendingOrder);
 
-  // Restore selection
-  q->setCurrentIndex(q->findData(selectedLocaleCode));
+  // Restore selection (or select default language if no prior selection)
+  int restoredIndex = q->findData(selectedLocaleCode);
+  if (restoredIndex < 0 && !this->DefaultLanguage.isEmpty())
+  {
+    restoredIndex = q->findData(this->DefaultLanguage);
+  }
+  q->setCurrentIndex(restoredIndex);
 
   q->update();
 
@@ -251,7 +256,29 @@ QString ctkLanguageComboBox::defaultLanguage() const
 void ctkLanguageComboBox::setDefaultLanguage(const QString& localeCode)
 {
   Q_D(ctkLanguageComboBox);
-  d->DefaultLanguage = localeCode;
+  if (localeCode.isNull())
+  {
+    d->DefaultLanguage = QString();
+  }
+  else if (localeCode.isEmpty())
+  {
+    d->DefaultLanguage = localeCode;
+  }
+  else
+  {
+    // Normalize the locale code via QLocale. This expands bare language
+    // codes (e.g. "en" → "en_US") and rejects invalid codes.
+    QLocale locale(localeCode);
+    if (locale.name() == "C")
+    {
+      // QLocale returns "C" for unrecognized locale codes
+      d->DefaultLanguage = QString();
+    }
+    else
+    {
+      d->DefaultLanguage = locale.name();
+    }
+  }
   d->updateLanguageItems();
 }
 


### PR DESCRIPTION
## Summary

- `setDefaultLanguage()` stored the raw input string without validation or normalization, causing bare language codes like `"en"` to not be expanded to `"en_US"`, and invalid codes like `"xx"` to be accepted
- Normalize locale codes through `QLocale` — codes that map to `"C"` (unrecognized) are rejected
- Fix `updateLanguageItems()` to fall back to selecting the default language item when no prior selection exists, so `currentLanguage()` returns the correct value after the first `setDefaultLanguage()` call

## Test plan

- [x] ctkLanguageComboBoxTest passes on both Qt5 and Qt6 (all 12 sub-tests)
- [x] Cherry-picks cleanly onto current master

🤖 Generated with [Claude Code](https://claude.com/claude-code)