### PR TITLE
STYLE: Replace non-POD ctkLogger globals with Q_GLOBAL_STATIC_WITH_ARGS

### DIFF
--- a/Libs/Core/ctkCorePythonQtDecorators.h
+++ b/Libs/Core/ctkCorePythonQtDecorators.h
@@ -24,6 +24,9 @@
 // PythonQt includes
 #include <PythonQt.h>
 
+// Qt includes
+#include <QGlobalStatic>
+
 // CTK includes
 #include <ctkAbstractJob.h> // For ctkJobDetail
 #include <ctkBooleanMapper.h>
@@ -40,7 +43,7 @@
 // for non-static methods.
 //
 
-static ctkLogger logger("org.commontk.core.ctkCorePythonQtDecorators");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.core.ctkCorePythonQtDecorators"))
 
 /// \ingroup Core
 class ctkCorePythonQtDecorators : public QObject
@@ -250,7 +253,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::setJobClass - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::setJobClass - Invalid ctkJobDetail");
       return;
     }
 
@@ -260,7 +263,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::jobClass - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::jobClass - Invalid ctkJobDetail");
       return "";
     }
 
@@ -271,7 +274,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::setJobUID - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::setJobUID - Invalid ctkJobDetail");
       return;
     }
 
@@ -281,7 +284,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::JobUID - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::JobUID - Invalid ctkJobDetail");
       return "";
     }
 
@@ -292,7 +295,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::setCreationDateTime - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::setCreationDateTime - Invalid ctkJobDetail");
       return;
     }
 
@@ -302,7 +305,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::creationDateTime - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::creationDateTime - Invalid ctkJobDetail");
       return "";
     }
 
@@ -313,7 +316,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::setStartDateTime - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::setStartDateTime - Invalid ctkJobDetail");
       return;
     }
 
@@ -323,7 +326,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::startDateTime - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::startDateTime - Invalid ctkJobDetail");
       return "";
     }
 
@@ -334,7 +337,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::setCompletionDateTime - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::setCompletionDateTime - Invalid ctkJobDetail");
       return;
     }
 
@@ -344,7 +347,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::completionDateTime - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::completionDateTime - Invalid ctkJobDetail");
       return "";
     }
 
@@ -355,7 +358,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::setRunningThreadID - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::setRunningThreadID - Invalid ctkJobDetail");
       return;
     }
 
@@ -365,7 +368,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::runningThreadID - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::runningThreadID - Invalid ctkJobDetail");
       return "";
     }
 
@@ -376,7 +379,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::setLogging - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::setLogging - Invalid ctkJobDetail");
       return;
     }
     td->Logging = logging;
@@ -385,7 +388,7 @@ public Q_SLOTS:
   {
     if (td == nullptr)
     {
-      logger.error("ctkJobDetail::logging - Invalid ctkJobDetail");
+      logger->error("ctkJobDetail::logging - Invalid ctkJobDetail");
       return "";
     }
 

--- a/Libs/Core/ctkJobScheduler.cpp
+++ b/Libs/Core/ctkJobScheduler.cpp
@@ -35,8 +35,9 @@
 #include "ctkJobScheduler.h"
 #include "ctkAbstractWorker.h"
 #include "ctkLogger.h"
+#include <QGlobalStatic>
 
-static ctkLogger logger("org.commontk.core.AbstractScheduler");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.core.AbstractScheduler"))
 
 // --------------------------------------------------------------------------
 // ctkJobSchedulerPrivate methods
@@ -114,7 +115,7 @@ void ctkJobSchedulerPrivate::queueJobsInThreadPool()
           return;
         }
 
-        logger.debug(QString("ctkDICOMScheduler: creating worker for job %1 in thread %2.\n")
+        logger->debug(QString("ctkDICOMScheduler: creating worker for job %1 in thread %2.\n")
                    .arg(job->jobUID())
                    .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId())), 16));
 
@@ -143,15 +144,16 @@ bool ctkJobSchedulerPrivate::insertJob(QSharedPointer<ctkAbstractJob> job)
 
   if (this->FreezeJobsScheduling)
   {
-    logger.debug(QString("ctkJobScheduler: job object %1 of type %2 in thread %3 "
+    logger->debug(QString("ctkJobScheduler: job object %1 of type %2 in thread %3 "
                          "not added to the job list since jobs are being stopped.\n")
       .arg(job->jobUID(), job->className())
       .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId())), 16));
     return false;
   }
 
-  logger.debug(QString("ctkJobScheduler: creating job object %1 of type %2 in thread %3.\n")
-    .arg(job->jobUID(), job->className())
+  logger->debug(QString("ctkJobScheduler: creating job object %1 of type %2 in thread %3.\n")
+    .arg(job->jobUID())
+    .arg(job->className())
     .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId())), 16));
 
   QMetaObject::Connection startedConnection = QObject::connect(job.data(), &ctkAbstractJob::started, q, [q, job](){
@@ -185,7 +187,7 @@ bool ctkJobSchedulerPrivate::insertJob(QSharedPointer<ctkAbstractJob> job)
 
   emit q->jobInitialized(job->toVariant());
 
-  logger.debug(QString("ctkDICOMScheduler: creating worker for job %1 in thread %2.\n")
+  logger->debug(QString("ctkDICOMScheduler: creating worker for job %1 in thread %2.\n")
                      .arg(job->jobUID())
                      .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId())), 16));
 
@@ -203,7 +205,7 @@ bool ctkJobSchedulerPrivate::insertJob(QSharedPointer<ctkAbstractJob> job)
       return false;
     }
 
-    logger.debug(QString("ctkDICOMScheduler: creating worker for job %1 in thread %2.\n")
+    logger->debug(QString("ctkDICOMScheduler: creating worker for job %1 in thread %2.\n")
                    .arg(job->jobUID())
                    .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId())), 16));
 
@@ -223,8 +225,9 @@ bool ctkJobSchedulerPrivate::insertJob(QSharedPointer<ctkAbstractJob> job)
 //------------------------------------------------------------------------------
 bool ctkJobSchedulerPrivate::cleanJob(const QString &jobUID)
 {
-  logger.debug(QString("ctkJobScheduler: deleting job object %1 in thread %2.\n")
-    .arg(jobUID, QString::number(reinterpret_cast<quint64>(QThread::currentThreadId()), 16)));
+  logger->debug(QString("ctkJobScheduler: deleting job object %1 in thread %2.\n")
+    .arg(jobUID)
+    .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId()), 16)));
 
   {
     // The QWriteLocker is enclosed within brackets to restrict its scope and
@@ -273,8 +276,9 @@ void ctkJobSchedulerPrivate::cleanJobs(const QStringList &jobUIDs)
 //------------------------------------------------------------------------------
 bool ctkJobSchedulerPrivate::removeJob(const QString& jobUID)
 {
-  logger.debug(QString("ctkJobScheduler: deleting job object %1 in thread %2.\n")
-    .arg(jobUID, QString::number(reinterpret_cast<quint64>(QThread::currentThreadId()), 16)));
+  logger->debug(QString("ctkJobScheduler: deleting job object %1 in thread %2.\n")
+    .arg(jobUID)
+    .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId()), 16)));
 
   {
     // The QWriteLocker is enclosed within brackets to restrict its scope and
@@ -806,7 +810,7 @@ void ctkJobScheduler::onJobStarted(ctkAbstractJob* job)
     return;
   }
 
-  logger.debug(job->loggerReport(tr("started")));
+  logger->debug(job->loggerReport(tr("started")));
 
   d->BatchedJobsStarted.append(job->toVariant());
   if (!d->ThrottleTimer->isActive())
@@ -824,7 +828,7 @@ void ctkJobScheduler::onJobUserStopped(ctkAbstractJob* job)
     return;
   }
 
-  logger.debug(job->loggerReport(tr("user stopped")));
+  logger->debug(job->loggerReport(tr("user stopped")));
 
   QString jobUID = job->jobUID();
   this->deleteWorker(jobUID);
@@ -853,7 +857,7 @@ void ctkJobScheduler::onJobFinished(ctkAbstractJob* job)
     return;
   }
 
-  logger.debug(job->loggerReport(tr("finished")));
+  logger->debug(job->loggerReport(tr("finished")));
 
   QString jobUID = job->jobUID();
   this->deleteWorker(jobUID);
@@ -882,7 +886,7 @@ void ctkJobScheduler::onJobAttemptFailed(ctkAbstractJob* job)
     return;
   }
 
-  logger.debug(job->loggerReport(tr("attempt failed")));
+  logger->debug(job->loggerReport(tr("attempt failed")));
 
   QString jobUID = job->jobUID();
   this->deleteWorker(jobUID);
@@ -911,7 +915,7 @@ void ctkJobScheduler::onJobFailed(ctkAbstractJob* job)
     return;
   }
 
-  logger.debug(job->loggerReport(tr("failed")));
+  logger->debug(job->loggerReport(tr("failed")));
 
   QString jobUID = job->jobUID();
   this->deleteWorker(jobUID);

--- a/Libs/DICOM/Core/ctkDICOMAbstractThumbnailGenerator.cpp
+++ b/Libs/DICOM/Core/ctkDICOMAbstractThumbnailGenerator.cpp
@@ -22,8 +22,9 @@
 // ctkDICOMCore includes
 #include "ctkDICOMAbstractThumbnailGenerator.h"
 #include "ctkLogger.h"
+#include <QGlobalStatic>
 
-static ctkLogger logger ( "org.commontk.dicom.DICOMAbstractThumbnailGenerator" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMAbstractThumbnailGenerator"))
 struct Node;
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Core/ctkDICOMCorePythonQtDecorators.h
+++ b/Libs/DICOM/Core/ctkDICOMCorePythonQtDecorators.h
@@ -24,6 +24,9 @@
 // PythonQt includes
 #include <PythonQt.h>
 
+// Qt includes
+#include <QGlobalStatic>
+
 // CTK Core includes
 #include <ctkLogger.h>
 
@@ -40,7 +43,7 @@
 // for non-static methods.
 //
 
-static ctkLogger logger("org.commontk.core.ctkDICOMCorePythonQtDecorators");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.core.ctkDICOMCorePythonQtDecorators"))
 
 /// \ingroup DICOM_Core
 class ctkDICOMCorePythonQtDecorators : public QObject
@@ -69,7 +72,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setPatientID - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setPatientID - Invalid ctkJobDetail");
       return;
     }
 
@@ -79,7 +82,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::patientID - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::patientID - Invalid ctkJobDetail");
       return "";
     }
 
@@ -90,7 +93,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setStudyInstanceUID - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setStudyInstanceUID - Invalid ctkJobDetail");
       return;
     }
 
@@ -100,7 +103,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::studyInstanceUID - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::studyInstanceUID - Invalid ctkJobDetail");
       return "";
     }
 
@@ -111,7 +114,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setSeriesInstanceUID - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setSeriesInstanceUID - Invalid ctkJobDetail");
       return;
     }
 
@@ -121,7 +124,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::seriesInstanceUID - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::seriesInstanceUID - Invalid ctkJobDetail");
       return "";
     }
 
@@ -132,7 +135,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setSOPInstanceUID - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setSOPInstanceUID - Invalid ctkJobDetail");
       return;
     }
 
@@ -142,7 +145,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::sopInstanceUID - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::sopInstanceUID - Invalid ctkJobDetail");
       return "";
     }
 
@@ -153,7 +156,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setReferenceInserterJobUID - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setReferenceInserterJobUID - Invalid ctkJobDetail");
       return;
     }
 
@@ -163,7 +166,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::referenceInserterJobUID - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::referenceInserterJobUID - Invalid ctkJobDetail");
       return "";
     }
 
@@ -174,7 +177,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setQueriedPatientIDs - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setQueriedPatientIDs - Invalid ctkJobDetail");
       return;
     }
 
@@ -184,7 +187,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::queriedPatientIDs - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::queriedPatientIDs - Invalid ctkJobDetail");
       return QStringList();
     }
 
@@ -195,7 +198,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setQueriedStudyInstanceUIDs - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setQueriedStudyInstanceUIDs - Invalid ctkJobDetail");
       return;
     }
 
@@ -205,7 +208,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::queriedStudyInstanceUIDs - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::queriedStudyInstanceUIDs - Invalid ctkJobDetail");
       return QStringList();
     }
 
@@ -216,7 +219,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setQueriedSeriesInstanceUIDs - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setQueriedSeriesInstanceUIDs - Invalid ctkJobDetail");
       return;
     }
 
@@ -226,7 +229,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::queriedSeriesInstanceUIDs - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::queriedSeriesInstanceUIDs - Invalid ctkJobDetail");
       return QStringList();
     }
 
@@ -237,7 +240,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setQueriedSOPInstanceUIDs - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setQueriedSOPInstanceUIDs - Invalid ctkJobDetail");
       return;
     }
 
@@ -247,7 +250,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::queriedSOPInstanceUIDs - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::queriedSOPInstanceUIDs - Invalid ctkJobDetail");
       return QStringList();
     }
 
@@ -258,7 +261,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setConnectionName - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setConnectionName - Invalid ctkJobDetail");
       return;
     }
 
@@ -268,7 +271,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::connectionName - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::connectionName - Invalid ctkJobDetail");
       return "";
     }
 
@@ -279,7 +282,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setDICOMLevel - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setDICOMLevel - Invalid ctkJobDetail");
       return;
     }
 
@@ -289,7 +292,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::DICOMLevel - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::DICOMLevel - Invalid ctkJobDetail");
       return ctkDICOMJob::DICOMLevels::None;
     }
 
@@ -300,7 +303,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setJobType - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setJobType - Invalid ctkJobDetail");
       return;
     }
 
@@ -310,7 +313,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::jobType - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::jobType - Invalid ctkJobDetail");
       return ctkDICOMJobResponseSet::JobType::None;
     }
 
@@ -321,7 +324,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::setNumberOfDataSets - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::setNumberOfDataSets - Invalid ctkJobDetail");
       return;
     }
 
@@ -331,7 +334,7 @@ public slots:
   {
     if (td == nullptr)
     {
-      logger.error("ctkDICOMJobDetail::numberOfDataSets - Invalid ctkJobDetail");
+      logger->error("ctkDICOMJobDetail::numberOfDataSets - Invalid ctkJobDetail");
       return -1;
     }
 

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -40,6 +40,7 @@
 
 #include "ctkLogger.h"
 #include "ctkUtils.h"
+#include <QGlobalStatic>
 
 // DCMTK includes
 #include <dcmtk/dcmdata/dcfilefo.h>
@@ -58,17 +59,17 @@
 #include <dcmtk/dcmdata/dcrleerg.h>  /* for DcmRLEEncoderRegistration */
 
 //------------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.dicom.DICOMDatabase" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMDatabase"))
 //------------------------------------------------------------------------------
 
 /// Flag for tag cache to avoid repeated searches for tags that do no exist
-static QString TagNotInInstance("__TAG_NOT_IN_INSTANCE__");
+static constexpr QLatin1String TagNotInInstance{"__TAG_NOT_IN_INSTANCE__", static_cast<int>(sizeof("__TAG_NOT_IN_INSTANCE__") - 1)};
 /// Flag for tag cache indicating that the value really is the empty string
-static QString ValueIsEmptyString("__VALUE_IS_EMPTY_STRING__");
+static constexpr QLatin1String ValueIsEmptyString{"__VALUE_IS_EMPTY_STRING__", static_cast<int>(sizeof("__VALUE_IS_EMPTY_STRING__") - 1)};
 /// Tag exists in the instance and non-empty but its value is not stored (e.g., because it is too long)
-static QString ValueIsNotStored("__VALUE_IS_NOT_STORED__");
+static constexpr QLatin1String ValueIsNotStored{"__VALUE_IS_NOT_STORED__", static_cast<int>(sizeof("__VALUE_IS_NOT_STORED__") - 1)};
 /// Separator character for table and field names to be used in display rules manager
-static QString TableFieldSeparator(":");
+static constexpr QLatin1String TableFieldSeparator{":", static_cast<int>(sizeof(":") - 1)};
 
 //------------------------------------------------------------------------------
 // ctkDICOMDatabasePrivate methods
@@ -137,7 +138,7 @@ int ctkDICOMDatabasePrivate::rowCount(const QString& tableName)
   }
   else
   {
-    logger.error("SQLITE ERROR: " + numberOfItemsQuery.lastError().driverText());
+    logger->error("SQLITE ERROR: " + numberOfItemsQuery.lastError().driverText());
   }
   return numberOfItems;
 }
@@ -166,8 +167,8 @@ bool ctkDICOMDatabasePrivate::loggedExec(QSqlQuery& query, const QString& queryS
   {
     QString sqlError = query.lastError().text();
     QString lastQuery = query.lastQuery();
-    logger.error(QString("SQL failed: \n%1 \nError: \n%2")
-      .arg(lastQuery, sqlError));
+    logger->error(QString("SQL failed: \n%1 \nError: \n%2")
+      .arg(lastQuery).arg(sqlError));
   }
 
   return (success);
@@ -182,8 +183,8 @@ bool ctkDICOMDatabasePrivate::loggedExecBatch(QSqlQuery& query)
   {
     QString sqlError = query.lastError().text();
     QString lastQuery = query.lastQuery();
-    logger.error(QString("SQL failed: \n%1 \nError: \n%2")
-      .arg(lastQuery, sqlError));
+    logger->error(QString("SQL failed: \n%1 \nError: \n%2")
+      .arg(lastQuery).arg(sqlError));
   }
   return (success);
 }
@@ -223,7 +224,7 @@ QString ctkDICOMDatabasePrivate::readValueFromFile(const QString& fileName, cons
   dataset.InitializeFromFile(fileName);
   if (!dataset.IsInitialized())
   {
-    logger.error("File " + fileName + " could not be initialized.");
+    logger->error("File " + fileName + " could not be initialized.");
     return "";
   }
 
@@ -332,8 +333,8 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertPatient(
   {
     // patient found
     dbPatientID = checkPatientExistsQuery.value(checkPatientExistsQuery.record().indexOf("UID")).toInt();
-    logger.debug("Found patient in the database as UID: " + QString::number(dbPatientID));
-    logger.debug("New patient ID cache item: " + compositeID + "->" + QString::number(dbPatientID));
+    logger->debug("Found patient in the database as UID: " + QString::number(dbPatientID));
+    logger->debug("New patient ID cache item: " + compositeID + "->" + QString::number(dbPatientID));
   }
   else
   {
@@ -363,7 +364,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertPatient(
     }
     dbPatientID = insertPatientStatement.lastInsertId().toInt();
 
-    logger.debug("New patient inserted: database item ID = " + QString().setNum(dbPatientID));
+    logger->debug("New patient inserted: database item ID = " + QString().setNum(dbPatientID));
   }
 
   this->InsertedPatientsCompositeIDCache[compositeID] = dbPatientID;
@@ -385,8 +386,8 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertConnectionName(
   if (connectionNameFound)
   {
     // connection name found
-    logger.debug("Found connection name in the patient database as UID: " + QString::number(dbPatientID));
-    logger.debug("New connection name ID cache item: " + QString::number(dbPatientID) + "->" + connectionName);
+    logger->debug("Found connection name in the patient database as UID: " + QString::number(dbPatientID));
+    logger->debug("New connection name ID cache item: " + QString::number(dbPatientID) + "->" + connectionName);
   }
   else if (!denyList.contains(connectionName))
   {
@@ -403,7 +404,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertConnectionName(
     {
       return ctkDICOMDatabase::InsertResult::Failed;
     }
-    logger.debug("New connection name inserted: patient database item ID = " + QString().setNum(dbPatientID));
+    logger->debug("New connection name inserted: patient database item ID = " + QString().setNum(dbPatientID));
   }
 
   if (this->InsertedConnectionsIDCache.contains(dbPatientID))
@@ -454,7 +455,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertStudy(
   }
   if (!checkStudyExistsQuery.next())
   {
-    logger.debug("Need to insert new study: " + studyInstanceUID);
+    logger->debug("Need to insert new study: " + studyInstanceUID);
 
     QString studyID(dataset.GetElementAsString(DCM_StudyID) );
     QString studyDate(dataset.GetElementAsString(DCM_StudyDate) );
@@ -485,7 +486,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertStudy(
     insertStudyStatement.addBindValue(QDateTime::currentDateTime());
     if (!insertStudyStatement.exec())
     {
-      logger.error("Error executing statement: " + insertStudyStatement.lastQuery() + " Error: " + insertStudyStatement.lastError().text() );
+      logger->error("Error executing statement: " + insertStudyStatement.lastQuery() + " Error: " + insertStudyStatement.lastError().text() );
       return ctkDICOMDatabase::InsertResult::Failed;
     }
     else
@@ -497,7 +498,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertStudy(
   }
   else
   {
-    logger.debug("Used existing study: " + studyInstanceUID);
+    logger->debug("Used existing study: " + studyInstanceUID);
     this->InsertedStudyUIDsCache.insert(studyInstanceUID);
     return ctkDICOMDatabase::InsertResult::NotInserted;
   }
@@ -511,14 +512,14 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertSeries(
   QSqlQuery checkSeriesExistsQuery(this->Database);
   checkSeriesExistsQuery.prepare( "SELECT * FROM Series WHERE SeriesInstanceUID = ?" );
   checkSeriesExistsQuery.bindValue( 0, seriesInstanceUID );
-  logger.debug("Statement: " + checkSeriesExistsQuery.lastQuery() );
+  logger->debug("Statement: " + checkSeriesExistsQuery.lastQuery() );
   if (!loggedExec(checkSeriesExistsQuery))
   {
     return ctkDICOMDatabase::InsertResult::Failed;
   }
   if (!checkSeriesExistsQuery.next())
   {
-    logger.debug("Need to insert new series: " + seriesInstanceUID);
+    logger->debug("Need to insert new series: " + seriesInstanceUID);
 
     QString seriesDate(dataset.GetElementAsString(DCM_SeriesDate) );
     QString seriesTime(dataset.GetElementAsString(DCM_SeriesTime) );
@@ -555,7 +556,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertSeries(
     insertSeriesStatement.addBindValue(QDateTime::currentDateTime());
     if (!insertSeriesStatement.exec())
     {
-      logger.error("Error executing statement: "
+      logger->error("Error executing statement: "
                      + insertSeriesStatement.lastQuery()
                      + " Error: " + insertSeriesStatement.lastError().text());
       return ctkDICOMDatabase::InsertResult::Failed;
@@ -569,7 +570,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertSeries(
   }
   else
   {
-    logger.debug("Used existing series: " + seriesInstanceUID);
+    logger->debug("Used existing series: " + seriesInstanceUID);
     this->InsertedSeriesUIDsCache.insert(seriesInstanceUID);
     return ctkDICOMDatabase::InsertResult::NotInserted;
   }
@@ -653,7 +654,7 @@ bool ctkDICOMDatabasePrivate::removeImage(const QString& sopInstanceUID)
   bool success = deleteFile.exec();
   if (!success)
   {
-    logger.error("SQLITE ERROR deleting old image row: " + deleteFile.lastError().driverText());
+    logger->error("SQLITE ERROR deleting old image row: " + deleteFile.lastError().driverText());
   }
   return success;
 }
@@ -711,10 +712,10 @@ bool ctkDICOMDatabasePrivate::storeDatasetFile(const ctkDICOMItem& dataset, cons
 
   if (originalFilePath.isEmpty())
   {
-    logger.debug("Saving file: " + storedFilePath);
+    logger->debug("Saving file: " + storedFilePath);
     if (!dataset.SaveToFile(storedFilePath))
     {
-      logger.error("Error saving file: " + storedFilePath);
+      logger->error("Error saving file: " + storedFilePath);
       return false;
     }
   }
@@ -735,7 +736,7 @@ bool ctkDICOMDatabasePrivate::storeDatasetFile(const ctkDICOMItem& dataset, cons
       copySuccess = QFile::copy(originalFilePath, storedFilePath);
       if (!copySuccess)
       {
-        logger.error("Failed to copy file from: " + originalFilePath + " to: " + storedFilePath);
+        logger->error("Failed to copy file from: " + originalFilePath + " to: " + storedFilePath);
         return false;
       }
     }
@@ -749,7 +750,7 @@ bool ctkDICOMDatabasePrivate::storeDatasetFile(const ctkDICOMItem& dataset, cons
 
       if (!sourceFile.open(QIODevice::ReadOnly) || !destFile.open(QIODevice::WriteOnly))
       {
-        logger.error("Failed to copy file from: " + originalFilePath + " to: " + storedFilePath);
+        logger->error("Failed to copy file from: " + originalFilePath + " to: " + storedFilePath);
         return false;
       }
 
@@ -764,7 +765,7 @@ bool ctkDICOMDatabasePrivate::storeDatasetFile(const ctkDICOMItem& dataset, cons
           delete[] buffer;
           sourceFile.close();
           destFile.close();
-          logger.error("Failed to write to: " + storedFilePath);
+          logger->error("Failed to write to: " + storedFilePath);
           return false;
         }
       }
@@ -775,7 +776,7 @@ bool ctkDICOMDatabasePrivate::storeDatasetFile(const ctkDICOMItem& dataset, cons
 
       if (bytesRead < 0)
       {
-        logger.error("Failed to read from: " + originalFilePath);
+        logger->error("Failed to read from: " + originalFilePath);
         return false;
       }
 
@@ -784,7 +785,7 @@ bool ctkDICOMDatabasePrivate::storeDatasetFile(const ctkDICOMItem& dataset, cons
 
     if (copySuccess)
     {
-      logger.debug("Copy file from: " + originalFilePath + " to: " + storedFilePath);
+      logger->debug("Copy file from: " + originalFilePath + " to: " + storedFilePath);
     }
   }
 
@@ -805,7 +806,7 @@ bool ctkDICOMDatabasePrivate::indexingStatusForFile(const QString& filePath, con
   bool success = fileExistsQuery.exec();
   if (!success)
   {
-    logger.error("SQLITE ERROR: " + fileExistsQuery.lastError().driverText());
+    logger->error("SQLITE ERROR: " + fileExistsQuery.lastError().driverText());
     return false;
   }
   bool foundSOPInstanceUID = fileExistsQuery.next();
@@ -862,7 +863,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertPatientStudySeries
   }
   else
   {
-    logger.debug("Insert new patient if not already in database: " + patientID + " " + patientsName);
+    logger->debug("Insert new patient if not already in database: " + patientID + " " + patientsName);
     ctkDICOMDatabase::InsertResult patientMetadataInsertOperationResult =
       this->insertPatient(dataset, patientID, patientsName, dbPatientID);
     if (patientMetadataInsertOperationResult == ctkDICOMDatabase::InsertResult::Inserted)
@@ -885,7 +886,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertPatientStudySeries
   }
   if (connections.count() == 0 || !connections.contains(connectionName))
   {
-    logger.debug("Insert new connection name if not already in database: " + connectionName);
+    logger->debug("Insert new connection name if not already in database: " + connectionName);
     ctkDICOMDatabase::InsertResult connectionMetadataInsertOperationResult =
       this->insertConnectionName(dbPatientID, connectionName);
     if (connectionMetadataInsertOperationResult == ctkDICOMDatabase::InsertResult::Inserted)
@@ -899,7 +900,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertPatientStudySeries
     }
   }
 
-  logger.debug("Going to insert this instance with dbPatientID: " + QString::number(dbPatientID));
+  logger->debug("Going to insert this instance with dbPatientID: " + QString::number(dbPatientID));
 
   // Insert new study if needed
   QString studyInstanceUID(dataset.GetElementAsString(DCM_StudyInstanceUID));
@@ -909,7 +910,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertPatientStudySeries
       this->insertStudy(dataset, dbPatientID);
     if (studyMetadataInsertOperationResult == ctkDICOMDatabase::InsertResult::Inserted)
     {
-      logger.debug("Study Added");
+      logger->debug("Study Added");
       databaseWasChanged = true;
       // let users of this class track when things happen
       emit q->studyAdded(studyInstanceUID);
@@ -927,7 +928,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabasePrivate::insertPatientStudySeries
       this->insertSeries(dataset, studyInstanceUID);
     if (seriesMetadataInsertOperationResult == ctkDICOMDatabase::InsertResult::Inserted)
     {
-      logger.debug("Series Added");
+      logger->debug("Series Added");
       databaseWasChanged = true;
       emit q->seriesAdded(seriesInstanceUID);
     }
@@ -960,7 +961,7 @@ bool ctkDICOMDatabasePrivate::uidsForDataSet(QString& patientsName, QString& pat
   {
     // Use study instance uid as patient id if patient id is empty - can happen on anonymized datasets
     // see: http://www.na-mic.org/Bug/view.php?id=2040
-    logger.warn(QString("Patient ID is empty, using studyInstanceUID (%1) as patient ID").arg(studyInstanceUID));
+    logger->warn(QString("Patient ID is empty, using studyInstanceUID (%1) as patient ID").arg(studyInstanceUID));
     patientID = studyInstanceUID;
   }
   if (patientsName.isEmpty() && !patientID.isEmpty())
@@ -972,7 +973,7 @@ bool ctkDICOMDatabasePrivate::uidsForDataSet(QString& patientsName, QString& pat
   // We accept the dataset without seriesInstanceUID, as query/retrieve result may not contain it
   if (patientsName.isEmpty() || studyInstanceUID.isEmpty() || patientID.isEmpty())
   {
-    logger.error("Required information (patient name, patient ID, study instance UID) is missing from dataset");
+    logger->error("Required information (patient name, patient ID, study instance UID) is missing from dataset");
     return false;
   }
   // Valid data set
@@ -1005,13 +1006,13 @@ void ctkDICOMDatabasePrivate::insert(const ctkDICOMItem& dataset, const QString&
   {
     if (datasetUpToDate)
     {
-      logger.debug("File " + databaseFilename + " already added");
+      logger->debug("File " + databaseFilename + " already added");
       return;
     }
     // File is updated, delete record and re-index
     if (!this->removeImage(sopInstanceUID))
     {
-      logger.debug("File " + filePath + " cannot be added, failed to update existing values in the database");
+      logger->debug("File " + filePath + " cannot be added, failed to update existing values in the database");
       return;
     }
   }
@@ -1030,7 +1031,7 @@ void ctkDICOMDatabasePrivate::insert(const ctkDICOMItem& dataset, const QString&
   {
     if (!this->storeDatasetFile(dataset, filePath, studyInstanceUID, seriesInstanceUID, sopInstanceUID, storedFilePath))
     {
-      logger.error("Error saving file: " + filePath);
+      logger->error("Error saving file: " + filePath);
       return;
     }
   }
@@ -1077,7 +1078,7 @@ void ctkDICOMDatabasePrivate::insert(const ctkDICOMItem& dataset, const QString&
 
       if (!insertImageStatement.exec())
       {
-        logger.error("Error executing statement: "
+        logger->error("Error executing statement: "
                      + insertImageStatement.lastQuery()
                      + " Error: " + insertImageStatement.lastError().text());
       }
@@ -1123,12 +1124,12 @@ QString ctkDICOMDatabasePrivate::getDisplayPatientFieldsKey(const QString& patie
   displayPatientsQuery.bindValue(":patientsName", patientsName);
   if (!displayPatientsQuery.exec())
   {
-    logger.error("SQLITE ERROR: " + displayPatientsQuery.lastError().driverText());
+    logger->error("SQLITE ERROR: " + displayPatientsQuery.lastError().driverText());
     return QString();
   }
   if (displayPatientsQuery.size() > 1)
   {
-    logger.warn("Multiple patients found with PatientsName=" + patientsName + " and PatientID=" + patientID);
+    logger->warn("Multiple patients found with PatientsName=" + patientsName + " and PatientID=" + patientID);
   }
   if (displayPatientsQuery.next())
   {
@@ -1142,7 +1143,7 @@ QString ctkDICOMDatabasePrivate::getDisplayPatientFieldsKey(const QString& patie
     return compositeID;
   }
 
-  logger.error("Failed to find patient with PatientsName=" + patientsName + " and PatientID=" + patientID);
+  logger->error("Failed to find patient with PatientsName=" + patientsName + " and PatientID=" + patientID);
   return QString();
 }
 
@@ -1164,12 +1165,12 @@ QString ctkDICOMDatabasePrivate::getDisplayStudyFieldsKey(QString studyInstanceU
   displayStudiesQuery.bindValue(":studyInstanceUID", studyInstanceUID);
   if (!displayStudiesQuery.exec())
   {
-    logger.error("SQLITE ERROR: " + displayStudiesQuery.lastError().driverText());
+    logger->error("SQLITE ERROR: " + displayStudiesQuery.lastError().driverText());
     return QString();
   }
   if (displayStudiesQuery.size() > 1)
   {
-    logger.warn("Multiple studies found with StudyInstanceUID=" + studyInstanceUID);
+    logger->warn("Multiple studies found with StudyInstanceUID=" + studyInstanceUID);
   }
   if (displayStudiesQuery.next())
   {
@@ -1183,7 +1184,7 @@ QString ctkDICOMDatabasePrivate::getDisplayStudyFieldsKey(QString studyInstanceU
     return studyInstanceUID;
   }
 
-  logger.error("Failed to find study with StudyInstanceUID=" + studyInstanceUID);
+  logger->error("Failed to find study with StudyInstanceUID=" + studyInstanceUID);
   return QString();
 }
 
@@ -1205,12 +1206,12 @@ QString ctkDICOMDatabasePrivate::getDisplaySeriesFieldsKey(QString seriesInstanc
   displaySeriesQuery.bindValue(":seriesInstanceUID", seriesInstanceUID);
   if (!displaySeriesQuery.exec())
   {
-    logger.error("SQLITE ERROR: " + displaySeriesQuery.lastError().driverText());
+    logger->error("SQLITE ERROR: " + displaySeriesQuery.lastError().driverText());
     return QString();
   }
   if (displaySeriesQuery.size() > 1)
   {
-    logger.warn("Multiple series found with SeriesInstanceUID=" + seriesInstanceUID);
+    logger->warn("Multiple series found with SeriesInstanceUID=" + seriesInstanceUID);
   }
   if (displaySeriesQuery.next())
   {
@@ -1224,7 +1225,7 @@ QString ctkDICOMDatabasePrivate::getDisplaySeriesFieldsKey(QString seriesInstanc
     return seriesInstanceUID;
   }
 
-  logger.error("in getDisplaySeriesFieldsKey: Failed to find series with SeriesInstanceUID=" + seriesInstanceUID);
+  logger->error("in getDisplaySeriesFieldsKey: Failed to find series with SeriesInstanceUID=" + seriesInstanceUID);
   return QString();
 }
 
@@ -1248,7 +1249,7 @@ bool ctkDICOMDatabasePrivate::applyDisplayedFieldsChanges( QMap<QString, QMap<QS
     QMap<QString, QString> currentPatient = it.value();
     if (currentPatient["PatientID"].isEmpty() || currentPatient["PatientsName"].isEmpty())
     {
-      logger.error("Unable to locate the patient due to missing values for PatientsName and/or PatientID. "
+      logger->error("Unable to locate the patient due to missing values for PatientsName and/or PatientID. "
                    "If this error recurs, please manually remove the patient from the database, ensuring to"
                    " address the missing PatientsName/PatientID.");
       continue;
@@ -1260,7 +1261,7 @@ bool ctkDICOMDatabasePrivate::applyDisplayedFieldsChanges( QMap<QString, QMap<QS
     displayPatientsQuery.bindValue(":patientsName", currentPatient["PatientsName"]);
     if (!displayPatientsQuery.exec())
     {
-      logger.error("SQLITE ERROR: " + displayPatientsQuery.lastError().driverText());
+      logger->error("SQLITE ERROR: " + displayPatientsQuery.lastError().driverText());
       return false;
     }
     if (displayPatientsQuery.next())
@@ -1301,7 +1302,7 @@ bool ctkDICOMDatabasePrivate::applyDisplayedFieldsChanges( QMap<QString, QMap<QS
     }
     else
     {
-      logger.error("Failed to find patient with PatientsName=" + currentPatient["PatientsName"] + " and PatientID=" + currentPatient["PatientID"]);
+      logger->error("Failed to find patient with PatientsName=" + currentPatient["PatientsName"] + " and PatientID=" + currentPatient["PatientID"]);
       continue;
     }
   } // For each patient in displayedFieldsVectorPatient
@@ -1320,7 +1321,7 @@ bool ctkDICOMDatabasePrivate::applyDisplayedFieldsChanges( QMap<QString, QMap<QS
     displayStudiesQuery.addBindValue(currentStudyInstanceUid);
     if (!displayStudiesQuery.exec())
     {
-      logger.error("SQLITE ERROR: " + displayStudiesQuery.lastError().driverText());
+      logger->error("SQLITE ERROR: " + displayStudiesQuery.lastError().driverText());
       return false;
     }
     if (displayStudiesQuery.next())
@@ -1360,7 +1361,7 @@ bool ctkDICOMDatabasePrivate::applyDisplayedFieldsChanges( QMap<QString, QMap<QS
     }
     else
     {
-      logger.error("in applyDisplayedFieldsChanges: Failed to find study with StudyInstanceUID=" + currentStudyInstanceUid);
+      logger->error("in applyDisplayedFieldsChanges: Failed to find study with StudyInstanceUID=" + currentStudyInstanceUid);
       continue;
     }
   } // For each study in displayedFieldsMapStudy
@@ -1380,7 +1381,7 @@ bool ctkDICOMDatabasePrivate::applyDisplayedFieldsChanges( QMap<QString, QMap<QS
     displaySeriesQuery.addBindValue(currentSeriesInstanceUid);
     if (!displaySeriesQuery.exec())
     {
-      logger.error("SQLITE ERROR: " + displaySeriesQuery.lastError().driverText());
+      logger->error("SQLITE ERROR: " + displaySeriesQuery.lastError().driverText());
       return false;
     }
     if (displaySeriesQuery.next())
@@ -1411,7 +1412,7 @@ bool ctkDICOMDatabasePrivate::applyDisplayedFieldsChanges( QMap<QString, QMap<QS
     }
     else
     {
-      logger.error("in applyDisplayedFieldsChanges: Failed to find series with SeriesInstanceUID=" + currentSeriesInstanceUid);
+      logger->error("in applyDisplayedFieldsChanges: Failed to find series with SeriesInstanceUID=" + currentSeriesInstanceUid);
       continue;
     }
   } // For each series in displayedFieldsMapSeries
@@ -2495,7 +2496,7 @@ bool ctkDICOMDatabase::storeThumbnailFile(const QString &originalFilePath,
     // The rendering will fail and in addition SEG object can be very large and
     // loading the file can be slow.
     // To Do: refactor ctkDICOMThumbnailGenerator for rendering more modalities.
-    logger.warn(QString("SEG thumbnail generation is not available"));
+    logger->warn(QString("SEG thumbnail generation is not available"));
     return false;
   }
   else
@@ -2909,7 +2910,7 @@ void ctkDICOMDatabase::insert( const QString& filePath, bool storeFile, bool gen
   /// first we check if the file is already in the database
   if (fileExistsAndUpToDate(filePath))
   {
-    logger.debug( "File " + filePath + " already added.");
+    logger->debug( "File " + filePath + " already added.");
     return;
   }
 
@@ -2922,7 +2923,7 @@ void ctkDICOMDatabase::insert( const QString& filePath, bool storeFile, bool gen
   }
   else
   {
-    logger.warn(QString("Could not read DICOM file:") + filePath);
+    logger->warn(QString("Could not read DICOM file:") + filePath);
   }
 }
 
@@ -2974,7 +2975,7 @@ void ctkDICOMDatabase::insert(const QList<ctkDICOMDatabase::IndexingResult>& ind
       // File is updated, delete record and re-index
       if (!d->removeImage(sopInstanceUID))
       {
-        logger.error("Failed to insert file into database (cannot update pre-existing item): " + filePath);
+        logger->error("Failed to insert file into database (cannot update pre-existing item): " + filePath);
         continue;
       }
     }
@@ -2983,7 +2984,7 @@ void ctkDICOMDatabase::insert(const QList<ctkDICOMDatabase::IndexingResult>& ind
     QString patientsName, patientID, studyInstanceUID, seriesInstanceUID;
     if (!d->uidsForDataSet(dataset, patientsName, patientID, studyInstanceUID, seriesInstanceUID))
     {
-      logger.error("Failed to insert file into database (required fields missing): " + filePath);
+      logger->error("Failed to insert file into database (required fields missing): " + filePath);
       continue;
     }
 
@@ -3186,19 +3187,19 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabase::insert(const QList<ctkDICOMJobR
 
       if (patientID.isEmpty())
       {
-        logger.error("ctkDICOMDatabase::insert: dataset has no patientID");
+        logger->error("ctkDICOMDatabase::insert: dataset has no patientID");
         continue;
       }
 
       if (patientName.isEmpty())
       {
-        logger.error("ctkDICOMDatabase::insert: dataset has no patientName");
+        logger->error("ctkDICOMDatabase::insert: dataset has no patientName");
         continue;
       }
 
       if (studyInstanceUID.isEmpty() && jobType != ctkDICOMJobResponseSet::JobType::QueryPatients)
       {
-        logger.error("ctkDICOMDatabase::insert: dataset has no studyInstanceUID");
+        logger->error("ctkDICOMDatabase::insert: dataset has no studyInstanceUID");
         continue;
       }
 
@@ -3249,7 +3250,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabase::insert(const QList<ctkDICOMJobR
         // File is updated, delete record and re-index
         if (!d->removeImage(sopInstanceUID))
         {
-          logger.error("Failed to insert file into database (cannot update pre-existing item): " + filePath);
+          logger->error("Failed to insert file into database (cannot update pre-existing item): " + filePath);
           continue;
         }
       }
@@ -3320,7 +3321,7 @@ ctkDICOMDatabase::InsertResult ctkDICOMDatabase::insert(const QList<ctkDICOMJobR
 
           if (!insertImageStatement.exec())
           {
-            logger.error("Error executing statement: "
+            logger->error("Error executing statement: "
                          + insertImageStatement.lastQuery()
                          + " Error: " + insertImageStatement.lastError().text());
             insertFailed = true;
@@ -3471,7 +3472,7 @@ bool ctkDICOMDatabase::removeSeries(const QString& seriesInstanceUID, bool clear
   bool success = fileExistsQuery.exec();
   if (!success)
   {
-    logger.error("SQLITE ERROR: " + fileExistsQuery.lastError().driverText());
+    logger->error("SQLITE ERROR: " + fileExistsQuery.lastError().driverText());
     return false;
   }
 
@@ -3493,12 +3494,12 @@ bool ctkDICOMDatabase::removeSeries(const QString& seriesInstanceUID, bool clear
   QSqlQuery fileRemove(d->Database);
   fileRemove.prepare("DELETE FROM Images WHERE SeriesInstanceUID == :seriesID");
   fileRemove.bindValue(":seriesID", seriesInstanceUID);
-  logger.debug("SQLITE: removing seriesInstanceUID " + seriesInstanceUID);
+  logger->debug("SQLITE: removing seriesInstanceUID " + seriesInstanceUID);
   success = fileRemove.exec();
   if (!success)
   {
-    logger.error("SQLITE ERROR: could not remove seriesInstanceUID " + seriesInstanceUID);
-    logger.error("SQLITE ERROR: " + fileRemove.lastError().driverText());
+    logger->error("SQLITE ERROR: could not remove seriesInstanceUID " + seriesInstanceUID);
+    logger->error("SQLITE ERROR: " + fileRemove.lastError().driverText());
   }
 
   if (!removeTagCacheSOPInstanceUIDs.isEmpty())
@@ -3536,7 +3537,7 @@ bool ctkDICOMDatabase::removeSeries(const QString& seriesInstanceUID, bool clear
         }
         else
         {
-          logger.warn("Failed to remove file " + absPath);
+          logger->warn("Failed to remove file " + absPath);
         }
       }
     }
@@ -3546,7 +3547,7 @@ bool ctkDICOMDatabase::removeSeries(const QString& seriesInstanceUID, bool clear
     {
       if (!thumbnailFile.remove())
       {
-      logger.warn("Failed to remove thumbnail " + thumbnailFile.fileName());
+      logger->warn("Failed to remove thumbnail " + thumbnailFile.fileName());
       }
       QString fileFolder = QFileInfo(thumbnailFile).absoluteDir().path();
       if (foldersToRemove.isEmpty() || foldersToRemove.last() != fileFolder)
@@ -3604,7 +3605,7 @@ bool ctkDICOMDatabase::removeStudy(const QString& studyInstanceUID, bool cleanup
   bool success = seriesForStudy.exec();
   if (!success)
   {
-    logger.error("SQLITE ERROR: " + seriesForStudy.lastError().driverText());
+    logger->error("SQLITE ERROR: " + seriesForStudy.lastError().driverText());
     return false;
   }
   bool result = true;
@@ -3639,7 +3640,7 @@ bool ctkDICOMDatabase::removePatient(const QString& patientUID, bool cleanup/*=t
   bool success = studiesForPatient.exec();
   if (!success)
   {
-    logger.error("SQLITE ERROR: " + studiesForPatient.lastError().driverText());
+    logger->error("SQLITE ERROR: " + studiesForPatient.lastError().driverText());
     return false;
   }
   bool result = true;
@@ -3803,7 +3804,7 @@ bool ctkDICOMDatabase::cacheTags(const QStringList sopInstanceUIDs, const QStrin
   int itemCount = sopInstanceUIDs.size();
   if (tags.size() != itemCount || values.size() != itemCount)
   {
-    logger.error("Failed to cache tags: number of inputs do not match");
+    logger->error("Failed to cache tags: number of inputs do not match");
     return false;
   }
 
@@ -3865,7 +3866,7 @@ void ctkDICOMDatabase::removeCachedTags(const QString sopInstanceUID)
   bool success = deleteFile.exec();
   if (!success)
   {
-    logger.error("SQLITE ERROR deleting tag cache row: " + deleteFile.lastError().driverText());
+    logger->error("SQLITE ERROR deleting tag cache row: " + deleteFile.lastError().driverText());
   }
 }
 
@@ -3914,7 +3915,7 @@ void ctkDICOMDatabase::updateDisplayedFields()
     QString compositeId = d->getDisplayPatientFieldsKey(patientID, patientsName, patientsBirthDate, displayedFieldsMapPatient);
     if (compositeId.isEmpty())
     {
-      logger.error("Failed to find patient for SOP Instance UID = " + sopInstanceUID);
+      logger->error("Failed to find patient for SOP Instance UID = " + sopInstanceUID);
       continue;
     }
     QMap<QString, QString> displayedFieldsForCurrentPatient = displayedFieldsMapPatient[compositeId];
@@ -3924,7 +3925,7 @@ void ctkDICOMDatabase::updateDisplayedFields()
       cachedTags[ctkDICOMItem::TagKeyStripped(DCM_StudyInstanceUID)], displayedFieldsMapStudy );
     if (displayedFieldsKeyForCurrentStudy.isEmpty())
     {
-      logger.error("Failed to find study for SOP Instance UID = " + sopInstanceUID);
+      logger->error("Failed to find study for SOP Instance UID = " + sopInstanceUID);
       continue;
     }
     QMap<QString, QString> displayedFieldsForCurrentStudy = displayedFieldsMapStudy[ displayedFieldsKeyForCurrentStudy ];
@@ -3934,7 +3935,7 @@ void ctkDICOMDatabase::updateDisplayedFields()
     QString displayedFieldsKeyForCurrentSeries = d->getDisplaySeriesFieldsKey(seriesInstanceUID, displayedFieldsMapSeries);
     if (displayedFieldsKeyForCurrentSeries.isEmpty())
     {
-      logger.error("Failed to find series for SOP Instance UID = " + sopInstanceUID);
+      logger->error("Failed to find series for SOP Instance UID = " + sopInstanceUID);
       continue;
     }
     QMap<QString, QString> displayedFieldsForCurrentSeries = displayedFieldsMapSeries[ displayedFieldsKeyForCurrentSeries ];
@@ -3993,7 +3994,7 @@ QString ctkDICOMDatabase::displayedNameForField(QString table, QString field) co
   query.addBindValue(field);
   if (!query.exec())
   {
-    logger.error("SQLITE ERROR: " + query.lastError().driverText());
+    logger->error("SQLITE ERROR: " + query.lastError().driverText());
     return QString();
   }
 
@@ -4008,7 +4009,7 @@ void ctkDICOMDatabase::setDisplayedNameForField(QString table, QString field, QS
 
   if (!this->isOpen())
   {
-    logger.warn("Database needs to be open to set column display properties");
+    logger->warn("Database needs to be open to set column display properties");
     return;
   }
 
@@ -4019,7 +4020,7 @@ void ctkDICOMDatabase::setDisplayedNameForField(QString table, QString field, QS
   query.addBindValue(field);
   if (!d->loggedExec(query))
   {
-    logger.error("SQLITE ERROR: " + query.lastError().driverText());
+    logger->error("SQLITE ERROR: " + query.lastError().driverText());
     return;
   }
 
@@ -4037,7 +4038,7 @@ bool ctkDICOMDatabase::visibilityForField(QString table, QString field) const
   query.addBindValue(field);
   if (!query.exec())
   {
-    logger.error("SQLITE ERROR: " + query.lastError().driverText());
+    logger->error("SQLITE ERROR: " + query.lastError().driverText());
     return false;
   }
 
@@ -4052,7 +4053,7 @@ void ctkDICOMDatabase::setVisibilityForField(QString table, QString field, bool 
 
   if (!this->isOpen())
   {
-    logger.warn("Database needs to be open to set column display properties");
+    logger->warn("Database needs to be open to set column display properties");
     return;
   }
 
@@ -4063,7 +4064,7 @@ void ctkDICOMDatabase::setVisibilityForField(QString table, QString field, bool 
   query.addBindValue(field);
   if (!d->loggedExec(query))
   {
-    logger.error("SQLITE ERROR: " + query.lastError().driverText());
+    logger->error("SQLITE ERROR: " + query.lastError().driverText());
     return;
   }
 
@@ -4081,7 +4082,7 @@ int ctkDICOMDatabase::weightForField(QString table, QString field) const
   query.addBindValue(field);
   if (!query.exec())
   {
-    logger.error("SQLITE ERROR: " + query.lastError().driverText());
+    logger->error("SQLITE ERROR: " + query.lastError().driverText());
     return INT_MAX;
   }
 
@@ -4096,7 +4097,7 @@ void ctkDICOMDatabase::setWeightForField(QString table, QString field, int weigh
 
   if (!this->isOpen())
   {
-    logger.warn("Database needs to be open to set column display properties");
+    logger->warn("Database needs to be open to set column display properties");
     return;
   }
 
@@ -4107,7 +4108,7 @@ void ctkDICOMDatabase::setWeightForField(QString table, QString field, int weigh
   query.addBindValue(field);
   if (!d->loggedExec(query))
   {
-    logger.error("SQLITE ERROR: " + query.lastError().driverText());
+    logger->error("SQLITE ERROR: " + query.lastError().driverText());
     return;
   }
 
@@ -4125,7 +4126,7 @@ QString ctkDICOMDatabase::formatForField(QString table, QString field) const
   query.addBindValue(field);
   if (!query.exec())
   {
-    logger.error("SQLITE ERROR: " + query.lastError().driverText());
+    logger->error("SQLITE ERROR: " + query.lastError().driverText());
     return QString();
   }
 
@@ -4140,7 +4141,7 @@ void ctkDICOMDatabase::setFormatForField(QString table, QString field, QString f
 
   if (!this->isOpen())
   {
-    logger.warn("Database needs to be open to set column display properties");
+    logger->warn("Database needs to be open to set column display properties");
     return;
   }
 
@@ -4151,7 +4152,7 @@ void ctkDICOMDatabase::setFormatForField(QString table, QString field, QString f
   query.addBindValue(field);
   if (!d->loggedExec(query))
   {
-    logger.error("SQLITE ERROR: " + query.lastError().driverText());
+    logger->error("SQLITE ERROR: " + query.lastError().driverText());
     return;
   }
 

--- a/Libs/DICOM/Core/ctkDICOMDisplayedFieldGenerator.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDisplayedFieldGenerator.cpp
@@ -23,6 +23,7 @@
 
 // ctkDICOM includes
 #include "ctkLogger.h"
+#include <QGlobalStatic>
 #include "ctkDICOMDatabase.h"
 #include "ctkDICOMDisplayedFieldGenerator.h"
 #include "ctkDICOMDisplayedFieldGenerator_p.h"
@@ -30,7 +31,7 @@
 #include "ctkDICOMDisplayedFieldGeneratorRuleFactory.h"
 
 //------------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.dicom.DICOMDisplayedFieldGenerator" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMDisplayedFieldGenerator"))
 //------------------------------------------------------------------------------
 
 

--- a/Libs/DICOM/Core/ctkDICOMEchoJob.cpp
+++ b/Libs/DICOM/Core/ctkDICOMEchoJob.cpp
@@ -23,6 +23,7 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMJobResponseSet.h" // For ctkDICOMJobDetail
@@ -30,7 +31,7 @@
 #include "ctkDICOMEchoWorker.h"
 #include "ctkDICOMServer.h"
 
-static ctkLogger logger ( "org.commontk.dicom.DICOMEchoJob" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMEchoJob"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMEchoJobPrivate methods

--- a/Libs/DICOM/Core/ctkDICOMEchoWorker.cpp
+++ b/Libs/DICOM/Core/ctkDICOMEchoWorker.cpp
@@ -23,6 +23,7 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMEchoWorker_p.h"
@@ -33,7 +34,7 @@
 // DCMTK includes
 #include <dcmtk/oflog/spi/logevent.h>
 
-static ctkLogger logger ("org.commontk.dicom.DICOMRetrieveWorker");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMRetrieveWorker"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMEchoWorkerPrivate methods
@@ -127,7 +128,7 @@ void ctkDICOMEchoWorker::run()
 
   echoJob->setStatus(ctkAbstractJob::JobStatus::Running);
 
-  logger.debug(QString("ctkDICOMEchoWorker : running job %1 in thread %2.\n")
+  logger->debug(QString("ctkDICOMEchoWorker : running job %1 in thread %2.\n")
                        .arg(echoJob->jobUID())
                        .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId())), 16));
 

--- a/Libs/DICOM/Core/ctkDICOMFilterProxyModel.cpp
+++ b/Libs/DICOM/Core/ctkDICOMFilterProxyModel.cpp
@@ -27,7 +27,8 @@
 
 //logger
 #include <ctkLogger.h>
-static ctkLogger logger("org.commontk.DICOM.Core.ctkDICOMFilterProxyModel");
+#include <QGlobalStatic>
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Core.ctkDICOMFilterProxyModel"))
 
 
 //----------------------------------------------------------------------------

--- a/Libs/DICOM/Core/ctkDICOMIndexer.cpp
+++ b/Libs/DICOM/Core/ctkDICOMIndexer.cpp
@@ -40,6 +40,8 @@
 #include "ctkDICOMIndexer_p.h"
 #include "ctkDICOMDatabase.h"
 
+#include <QGlobalStatic>
+
 // DCMTK includes
 #include <dcmtk/dcmdata/dcfilefo.h>
 #include <dcmtk/dcmdata/dcfilefo.h>
@@ -54,7 +56,7 @@
 
 
 //------------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.dicom.DICOMIndexer" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMIndexer"))
 
 /// How many files to parse before inserting results into the database.
 /// Increasing cache size increases maximum memory usage, very low cache size
@@ -139,7 +141,7 @@ void ctkDICOMIndexerPrivateWorker::start()
     imagesCountAfter = database.imagesCount();
 
     double elapsedTimeInSeconds = timeProbe.elapsed() / 1000.0;
-    logger.info(QString("DICOM indexer has updated display fields for %1 files [%2s]")
+    logger->info(QString("DICOM indexer has updated display fields for %1 files [%2s]")
                 .arg(imagesCountAfter-imagesCountBefore).arg(QString::number(elapsedTimeInSeconds, 'f', 2)));
 
   // restart if new requests has been queued during displayed fields update
@@ -225,7 +227,7 @@ void ctkDICOMIndexerPrivateWorker::processIndexingRequest(DICOMIndexingQueue::In
     }
     else
     {
-      logger.warn(QString("Could not read DICOM file:") + filePath);
+      logger->warn(QString("Could not read DICOM file:") + filePath);
     }
 
     if (this->RequestQueue->isStopRequested())
@@ -236,7 +238,7 @@ void ctkDICOMIndexerPrivateWorker::processIndexingRequest(DICOMIndexingQueue::In
 
   if (alreadyAddedFileCount > 0)
   {
-    logger.debug(
+    logger->debug(
       QString("Skipped %1 files that were already in the database: %2...")
       .arg(alreadyAddedFileCount)
       .arg(alreadyAddedFiles.join(", "))
@@ -251,7 +253,7 @@ void ctkDICOMIndexerPrivateWorker::processIndexingRequest(DICOMIndexingQueue::In
   }
 
   float elapsedTimeInSeconds = timeProbe.elapsed() / 1000.0;
-  logger.info(QString("DICOM indexer has successfully processed %1 files [%2s]")
+  logger->info(QString("DICOM indexer has successfully processed %1 files [%2s]")
               .arg(currentFileIndex).arg(QString::number(elapsedTimeInSeconds, 'f', 2)));
 }
 
@@ -280,7 +282,7 @@ void ctkDICOMIndexerPrivateWorker::writeIndexingResultsToDatabase(ctkDICOMDataba
   this->NumberOfInstancesInserted = 0;
 
   float elapsedTimeInSeconds = timeProbe.elapsed() / 1000.0;
-  logger.info(QString("DICOM indexer has successfully inserted %1 files [%2s]")
+  logger->info(QString("DICOM indexer has successfully inserted %1 files [%2s]")
               .arg(indexingResults.count()).arg(QString::number(elapsedTimeInSeconds, 'f', 2)));
 
 }
@@ -566,10 +568,10 @@ bool ctkDICOMIndexer::addDicomdir(const QString& directoryName, bool copyFile/*=
   {
     while ((patientRecord = rootRecord->nextSub(patientRecord)) != NULL)
     {
-      logger.debug( "Reading new Patient:" );
+      logger->debug( "Reading new Patient:" );
       if (patientRecord->findAndGetOFString(DCM_PatientName, patientsName).bad())
       {
-        logger.warn(
+        logger->warn(
           QString("DICOMDIR file at %1 is invalid: patient name not found. "
              "All records belonging to this patient will be ignored.")
           .arg(directoryName)
@@ -577,13 +579,13 @@ bool ctkDICOMIndexer::addDicomdir(const QString& directoryName, bool copyFile/*=
         success = false;
         continue;
       }
-      logger.debug( "Patient's Name: " + QString(patientsName.c_str()) );
+      logger->debug( "Patient's Name: " + QString(patientsName.c_str()) );
       while ((studyRecord = patientRecord->nextSub(studyRecord)) != NULL)
       {
-        logger.debug( "Reading new Study:" );
+        logger->debug( "Reading new Study:" );
         if (studyRecord->findAndGetOFString(DCM_StudyInstanceUID, studyInstanceUID).bad())
         {
-          logger.warn(
+          logger->warn(
             QString("DICOMDIR file at %1 is invalid: study instance UID not found for patient %2. "
                "All records belonging to this study will be ignored.")
             .arg(directoryName)
@@ -592,14 +594,14 @@ bool ctkDICOMIndexer::addDicomdir(const QString& directoryName, bool copyFile/*=
           success = false;
           continue;
         }
-        logger.debug( "Study instance UID: " + QString(studyInstanceUID.c_str()) );
+        logger->debug( "Study instance UID: " + QString(studyInstanceUID.c_str()) );
 
         while ((seriesRecord = studyRecord->nextSub(seriesRecord)) != NULL)
         {
-          logger.debug( "Reading new Series:" );
+          logger->debug( "Reading new Series:" );
           if (seriesRecord->findAndGetOFString(DCM_SeriesInstanceUID, seriesInstanceUID).bad())
           {
-            logger.warn(
+            logger->warn(
               QString("DICOMDIR file at %1 is invalid: series instance UID not found for patient %2, study %3. "
                  "All records belonging to this series will be ignored.")
               .arg(directoryName)
@@ -609,14 +611,14 @@ bool ctkDICOMIndexer::addDicomdir(const QString& directoryName, bool copyFile/*=
             success = false;
             continue;
           }
-          logger.debug( "Series instance UID: " + QString(seriesInstanceUID.c_str()) );
+          logger->debug( "Series instance UID: " + QString(seriesInstanceUID.c_str()) );
 
           while ((fileRecord = seriesRecord->nextSub(fileRecord)) != NULL)
           {
             if (fileRecord->findAndGetOFStringArray(DCM_ReferencedSOPInstanceUIDInFile, sopInstanceUID).bad()
               || fileRecord->findAndGetOFStringArray(DCM_ReferencedFileID,referencedFileName).bad())
             {
-              logger.warn(
+              logger->warn(
                 QString("DICOMDIR file at %1 is invalid: "
                    "referenced SOP instance UID or file name is invalid for patient %2, study %3, series %4. "
                    "This file will be ignored.")
@@ -640,8 +642,9 @@ bool ctkDICOMIndexer::addDicomdir(const QString& directoryName, bool copyFile/*=
       }
     }
     float elapsedTimeInSeconds = timeProbe.elapsed() / 1000.0;
-    logger.info(QString("DICOM indexer has successfully processed DICOMDIR in %1 [%2s]")
-                .arg(directoryName, QString::number(elapsedTimeInSeconds,'f', 2)));
+    logger->info(QString("DICOM indexer has successfully processed DICOMDIR in %1 [%2s]")
+                .arg(directoryName)
+                .arg(QString::number(elapsedTimeInSeconds,'f', 2)));
     this->addListOfFiles(listOfInstances, copyFile);
   }
   return success;

--- a/Libs/DICOM/Core/ctkDICOMInserterJob.cpp
+++ b/Libs/DICOM/Core/ctkDICOMInserterJob.cpp
@@ -25,8 +25,9 @@
 #include "ctkDICOMInserterJob.h"
 #include "ctkDICOMInserterWorker.h"
 #include "ctkLogger.h"
+#include <QGlobalStatic>
 
-static ctkLogger logger ("org.commontk.dicom.DICOMInserterJob");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMInserterJob"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMInserterJob methods

--- a/Libs/DICOM/Core/ctkDICOMInserterWorker.cpp
+++ b/Libs/DICOM/Core/ctkDICOMInserterWorker.cpp
@@ -26,6 +26,7 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMInserterJob.h"
@@ -35,7 +36,7 @@
 // DCMTK includes
 #include <dcmtk/oflog/spi/logevent.h>
 
-static ctkLogger logger ("org.commontk.dicom.DICOMInserterWorker");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMInserterWorker"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMInserterWorkerPrivate methods
@@ -114,7 +115,7 @@ void ctkDICOMInserterWorker::run()
 
   inserterJob->setStatus(ctkAbstractJob::JobStatus::Running);
 
-  logger.debug(QString("ctkDICOMInserterWorker : running job %1 in thread %2.\n")
+  logger->debug(QString("ctkDICOMInserterWorker : running job %1 in thread %2.\n")
                        .arg(inserterJob->jobUID())
                        .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId())), 16));
 

--- a/Libs/DICOM/Core/ctkDICOMJob.cpp
+++ b/Libs/DICOM/Core/ctkDICOMJob.cpp
@@ -23,12 +23,13 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMJob.h"
 #include "ctkDICOMJobResponseSet.h"
 
-static ctkLogger logger ("org.commontk.dicom.DICOMJob");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMJob"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMJob methods

--- a/Libs/DICOM/Core/ctkDICOMJobResponseSet.cpp
+++ b/Libs/DICOM/Core/ctkDICOMJobResponseSet.cpp
@@ -23,6 +23,7 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMItem.h"
@@ -32,7 +33,7 @@
 // DCMTK includes
 #include <dcmtk/dcmdata/dcdeftag.h>
 
-static ctkLogger logger("org.commontk.dicom.DICOMJobResponseSet");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMJobResponseSet"))
 
 //------------------------------------------------------------------------------
 class ctkDICOMJobResponseSetPrivate : public QObject {

--- a/Libs/DICOM/Core/ctkDICOMModel.cpp
+++ b/Libs/DICOM/Core/ctkDICOMModel.cpp
@@ -38,8 +38,9 @@
 // ctkDICOMCore includes
 #include "ctkDICOMModel.h"
 #include "ctkLogger.h"
+#include <QGlobalStatic>
 
-static ctkLogger logger ( "org.commontk.dicom.DICOMModel" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMModel"))
 struct Node;
 
 Q_DECLARE_METATYPE(Qt::CheckState);
@@ -303,7 +304,7 @@ QString ctkDICOMModelPrivate::generateQuery(const QString& fields, const QString
   {
     res += QString(" ORDER BY ") + this->Sort;
   }
-  logger.debug ( "ctkDICOMModelPrivate::generateQuery: query is: " + res );
+  logger->debug ( "ctkDICOMModelPrivate::generateQuery: query is: " + res );
   return res;
 }
 
@@ -324,7 +325,7 @@ void ctkDICOMModelPrivate::updateQueries(Node* node)const
         condition.append("PatientsName LIKE \"%" + this->SearchParameters["Name"].toString() + "%\"");
       }
       query = this->generateQuery("UID as UID, PatientsName as Name, PatientsAge as Age, PatientsBirthDate as Date, PatientID as \"Subject ID\"","Patients", condition);
-      logger.debug ( "ctkDICOMModelPrivate::updateQueries for Root: query is: " + query );
+      logger->debug ( "ctkDICOMModelPrivate::updateQueries for Root: query is: " + query );
       break;
     case ctkDICOMModel::PatientType:
       //query = QString("SELECT  FROM Studies WHERE PatientsUID='%1'").arg(node->UID);
@@ -343,7 +344,7 @@ void ctkDICOMModelPrivate::updateQueries(Node* node)const
                            + "\' AND \'" + QDate::fromString(this->SearchParameters["EndDate"].toString(), "yyyyMMdd").toString("yyyy-MM-dd") + "\' ) AND ");
       }
       query = this->generateQuery("StudyInstanceUID as UID, StudyDescription as Name, ModalitiesInStudy as Scan, StudyDate as Date, AccessionNumber as Number, InstitutionName as Institution, ReferringPhysician as Referrer, PerformingPhysiciansName as Performer", "Studies", condition + QString("PatientsUID='%1'").arg(node->UID));
-      logger.debug ( "ctkDICOMModelPrivate::updateQueries for Patient: query is: " + query );
+      logger->debug ( "ctkDICOMModelPrivate::updateQueries for Patient: query is: " + query );
       break;
     case ctkDICOMModel::StudyType:
       //query = QString("SELECT SeriesInstanceUID as UID, SeriesDescription as Name, BodyPartExamined as Scan, SeriesDate as Date, AcquisitionNumber as Number FROM Series WHERE StudyInstanceUID='%1'").arg(node->UID);
@@ -352,7 +353,7 @@ void ctkDICOMModelPrivate::updateQueries(Node* node)const
         condition.append("SeriesDescription LIKE \"%" + this->SearchParameters["Series"].toString() + "%\"" + " AND ");
       }
       query = this->generateQuery("SeriesInstanceUID as UID, SeriesDescription as Name, Modality as Age, SeriesNumber as Scan, BodyPartExamined as \"Subject ID\", SeriesDate as Date, AcquisitionNumber as Number","Series",condition + QString("StudyInstanceUID='%1'").arg(node->UID));
-      logger.debug ( "ctkDICOMModelPrivate::updateQueries for Study: query is: " + query );
+      logger->debug ( "ctkDICOMModelPrivate::updateQueries for Study: query is: " + query );
       break;
     case ctkDICOMModel::SeriesType:
       if(this->SearchParameters["ID"].toString() != "")
@@ -361,7 +362,7 @@ void ctkDICOMModelPrivate::updateQueries(Node* node)const
       }
       //query = QString("SELECT Filename as UID, Filename as Name, SeriesInstanceUID as Date FROM Images WHERE SeriesInstanceUID='%1'").arg(node->UID);
       query = this->generateQuery("SOPInstanceUID as UID, Filename as Name, SeriesInstanceUID as Date", "Images", condition + QString("SeriesInstanceUID='%1'").arg(node->UID));
-      logger.debug ( "ctkDICOMModelPrivate::updateQueries for Series: query is: " + query );
+      logger->debug ( "ctkDICOMModelPrivate::updateQueries for Series: query is: " + query );
       break;
     case ctkDICOMModel::ImageType:
       break;

--- a/Libs/DICOM/Core/ctkDICOMPatientModel.cpp
+++ b/Libs/DICOM/Core/ctkDICOMPatientModel.cpp
@@ -28,6 +28,7 @@
 
 // CTK includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMPatientModel.h"
@@ -41,7 +42,7 @@
 #include "ctkDICOMJobResponseSet.h"
 #include "ctkDICOMJob.h"
 
-static ctkLogger logger("org.commontk.DICOM.Core.ctkDICOMPatientModel");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Core.ctkDICOMPatientModel"))
 
 //------------------------------------------------------------------------------
 // Helper function for setDicomDatabase/setScheduler
@@ -193,7 +194,7 @@ void ctkDICOMPatientModelPrivate::populatePatients()
 
   if (!this->DicomDatabase)
   {
-    logger.error("populatePatients: No database set");
+    logger->error("populatePatients: No database set");
     return;
   }
 
@@ -500,7 +501,7 @@ ctkDICOMStudyModel* ctkDICOMPatientModelPrivate::createStudyModel(const QString&
 
   if (!this->DicomDatabase)
   {
-    logger.warn("createStudyModel: No database set");
+    logger->warn("createStudyModel: No database set");
     return nullptr;
   }
 
@@ -1540,7 +1541,7 @@ bool ctkDICOMPatientModel::queryStudies(const QString &patientID)
   Q_D(ctkDICOMPatientModel);
   if (!d->Scheduler)
   {
-    logger.warn("queryStudies: No scheduler set");
+    logger->warn("queryStudies: No scheduler set");
     return false;
   }
   QString patientUID;
@@ -1760,20 +1761,20 @@ void ctkDICOMPatientModel::updateAllowedServersFromDB(const QString& patientUID)
 
   if (!d->DicomDatabase)
   {
-    logger.error("updateAllowedServersFromDB: No database set");
+    logger->error("updateAllowedServersFromDB: No database set");
     return;
   }
 
   if (!d->Scheduler)
   {
-    logger.error("updateAllowedServersFromDB: No scheduler set");
+    logger->error("updateAllowedServersFromDB: No scheduler set");
     return;
   }
 
   int patientIndex = d->PatientUIDToIndex.value(patientUID, -1);
   if (patientIndex < 0 || patientIndex >= d->Patients.count())
   {
-    logger.error("updateAllowedServersFromDB: Invalid patient item");
+    logger->error("updateAllowedServersFromDB: Invalid patient item");
     return;
   }
 
@@ -1829,20 +1830,20 @@ void ctkDICOMPatientModel::saveAllowedServersToDB(const QString& patientUID, con
 
   if (!d->DicomDatabase)
   {
-    logger.error("saveAllowedServersToDB: No database set");
+    logger->error("saveAllowedServersToDB: No database set");
     return;
   }
 
   if (!d->Scheduler)
   {
-    logger.error("saveAllowedServersToDB: No scheduler set");
+    logger->error("saveAllowedServersToDB: No scheduler set");
     return;
   }
 
   int patientIndex = d->PatientUIDToIndex.value(patientUID, -1);
   if (patientIndex < 0 || patientIndex >= d->Patients.count())
   {
-    logger.error("saveAllowedServersToDB: Invalid patient item");
+    logger->error("saveAllowedServersToDB: Invalid patient item");
     return;
   }
 

--- a/Libs/DICOM/Core/ctkDICOMQueryJob.cpp
+++ b/Libs/DICOM/Core/ctkDICOMQueryJob.cpp
@@ -23,6 +23,7 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMJobResponseSet.h" // For ctkDICOMJobDetail
@@ -30,7 +31,7 @@
 #include "ctkDICOMQueryWorker.h"
 #include "ctkDICOMServer.h"
 
-static ctkLogger logger ( "org.commontk.dicom.DICOMQueryJob" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMQueryJob"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMQueryJobPrivate methods

--- a/Libs/DICOM/Core/ctkDICOMQueryWorker.cpp
+++ b/Libs/DICOM/Core/ctkDICOMQueryWorker.cpp
@@ -23,6 +23,7 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMQueryWorker_p.h"
@@ -33,7 +34,7 @@
 // DCMTK includes
 #include <dcmtk/oflog/spi/logevent.h>
 
-static ctkLogger logger ("org.commontk.dicom.DICOMQueryWorker");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMQueryWorker"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMQueryWorkerPrivate methods
@@ -126,14 +127,14 @@ void ctkDICOMQueryWorker::run()
 
   queryJob->setStatus(ctkAbstractJob::JobStatus::Running);
 
-  logger.debug(QString("ctkDICOMQueryWorker : running job %1 in thread %2.\n")
+  logger->debug(QString("ctkDICOMQueryWorker : running job %1 in thread %2.\n")
                        .arg(queryJob->jobUID())
                        .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId())), 16));
 
   switch (queryJob->dicomLevel())
   {
     case ctkDICOMJob::DICOMLevels::None:
-      logger.warn("ctkDICOMQueryWorker : DICOMLevels was not set.");
+      logger->warn("ctkDICOMQueryWorker : DICOMLevels was not set.");
       this->Job->setStatus(ctkAbstractJob::JobStatus::Finished);
       return;
     case ctkDICOMJob::DICOMLevels::Patients:

--- a/Libs/DICOM/Core/ctkDICOMRetrieveJob.cpp
+++ b/Libs/DICOM/Core/ctkDICOMRetrieveJob.cpp
@@ -23,6 +23,7 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMJobResponseSet.h" // For ctkDICOMJobDetail
@@ -30,7 +31,7 @@
 #include "ctkDICOMRetrieveWorker.h"
 #include "ctkDICOMServer.h"
 
-static ctkLogger logger ( "org.commontk.dicom.DICOMRetrieveJob" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMRetrieveJob"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMRetrieveJobPrivate methods

--- a/Libs/DICOM/Core/ctkDICOMRetrieveWorker.cpp
+++ b/Libs/DICOM/Core/ctkDICOMRetrieveWorker.cpp
@@ -23,6 +23,7 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMJobResponseSet.h"
@@ -34,7 +35,7 @@
 // DCMTK includes
 #include <dcmtk/oflog/spi/logevent.h>
 
-static ctkLogger logger ("org.commontk.dicom.DICOMRetrieveWorker");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMRetrieveWorker"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMRetrieveWorkerPrivate methods
@@ -148,7 +149,7 @@ void ctkDICOMRetrieveWorker::run()
 
   retrieveJob->setStatus(ctkAbstractJob::JobStatus::Running);
 
-  logger.debug(QString("ctkDICOMRetrieveWorker : running job %1 in thread %2.\n")
+  logger->debug(QString("ctkDICOMRetrieveWorker : running job %1 in thread %2.\n")
                        .arg(retrieveJob->jobUID())
                        .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId())), 16));
 
@@ -158,11 +159,11 @@ void ctkDICOMRetrieveWorker::run()
       switch(retrieveJob->dicomLevel())
       {
         case ctkDICOMJob::DICOMLevels::None:
-          logger.warn("ctkDICOMRetrieveWorker : DICOMLevels was not set.");
+          logger->warn("ctkDICOMRetrieveWorker : DICOMLevels was not set.");
           this->Job->setStatus(ctkAbstractJob::JobStatus::Finished);
           return;
         case ctkDICOMJob::DICOMLevels::Patients:
-          logger.warn("ctkDICOMRetrieveWorker : get operation for a full patient is not implemented.");
+          logger->warn("ctkDICOMRetrieveWorker : get operation for a full patient is not implemented.");
           this->Job->setStatus(ctkAbstractJob::JobStatus::Finished);
           return;
         case ctkDICOMJob::DICOMLevels::Studies:
@@ -198,11 +199,11 @@ void ctkDICOMRetrieveWorker::run()
       switch(retrieveJob->dicomLevel())
       {
         case ctkDICOMJob::DICOMLevels::None:
-          logger.warn("ctkDICOMRetrieveWorker : DICOMLevels was not set.");
+          logger->warn("ctkDICOMRetrieveWorker : DICOMLevels was not set.");
           this->Job->setStatus(ctkAbstractJob::JobStatus::Finished);
           return;
         case ctkDICOMJob::DICOMLevels::Patients:
-          logger.warn("ctkDICOMRetrieveTask : move operation for a full patient is not implemented.");
+          logger->warn("ctkDICOMRetrieveTask : move operation for a full patient is not implemented.");
           retrieveJob->setStatus(ctkAbstractJob::JobStatus::Finished);
           return;
         case ctkDICOMJob::DICOMLevels::Studies:

--- a/Libs/DICOM/Core/ctkDICOMScheduler.cpp
+++ b/Libs/DICOM/Core/ctkDICOMScheduler.cpp
@@ -24,7 +24,6 @@
 // ctkCore includes
 #include <ctkLogger.h>
 #include <QGlobalStatic>
-#include <ctkJobScheduler_p.h>
 #include <ctkAbstractWorker.h>
 
 // ctkDICOMCore includes

--- a/Libs/DICOM/Core/ctkDICOMScheduler.cpp
+++ b/Libs/DICOM/Core/ctkDICOMScheduler.cpp
@@ -23,6 +23,8 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
+#include <ctkJobScheduler_p.h>
 #include <ctkAbstractWorker.h>
 
 // ctkDICOMCore includes
@@ -44,7 +46,7 @@
 #include <dcmtk/oflog/oflog.h>
 #include "dcmtk/oflog/spi/logevent.h"
 
-static ctkLogger logger ( "org.commontk.dicom.DICOMScheduler" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMScheduler"))
 
 //------------------------------------------------------------------------------
 // JobAppender class (custom DCMTK Appender)
@@ -824,7 +826,7 @@ void ctkDICOMScheduler::waitForFinishByDICOMUIDs(const QStringList& patientIDs,
 
   if (numberOfInputLists == 0)
   {
-    logger.warn("ctkDICOMScheduler::waitForFinishByDICOMUIDs failed: all the provided lists with UIDs are empty.");
+    logger->warn("ctkDICOMScheduler::waitForFinishByDICOMUIDs failed: all the provided lists with UIDs are empty.");
     return;
   }
 
@@ -900,7 +902,7 @@ QList<QSharedPointer<ctkAbstractJob>> ctkDICOMScheduler::getJobsByDICOMUIDs(cons
 
   if (numberOfInputLists == 0)
   {
-    logger.warn("ctkDICOMScheduler::getJobsByDICOMUIDs failed: all the provided lists with UIDs are empty.");
+    logger->warn("ctkDICOMScheduler::getJobsByDICOMUIDs failed: all the provided lists with UIDs are empty.");
     return jobs;
   }
 
@@ -918,7 +920,7 @@ QList<QSharedPointer<ctkAbstractJob>> ctkDICOMScheduler::getJobsByDICOMUIDs(cons
       ctkDICOMJob* dicomJob = qobject_cast<ctkDICOMJob*>(job.data());
       if (!dicomJob)
       {
-        logger.debug("ctkDICOMScheduler::getJobsByDICOMUIDs: unexpected type of job.");
+        logger->debug("ctkDICOMScheduler::getJobsByDICOMUIDs: unexpected type of job.");
         continue;
       }
 
@@ -965,7 +967,7 @@ void ctkDICOMScheduler::stopJobsByDICOMUIDs(const QStringList& patientIDs,
 
   if (numberOfInputLists == 0)
   {
-    logger.debug("ctkDICOMScheduler::stopJobsByDICOMUIDs: all the provided lists with UIDs are empty.");
+    logger->debug("ctkDICOMScheduler::stopJobsByDICOMUIDs: all the provided lists with UIDs are empty.");
     return;
   }
 
@@ -985,7 +987,7 @@ void ctkDICOMScheduler::stopJobsByDICOMUIDs(const QStringList& patientIDs,
       ctkDICOMJob* dicomJob = qobject_cast<ctkDICOMJob*>(job.data());
       if (!dicomJob)
       {
-        logger.debug("ctkDICOMScheduler::stopJobsByDICOMUIDs: unexpected type of job.");
+        logger->debug("ctkDICOMScheduler::stopJobsByDICOMUIDs: unexpected type of job.");
         continue;
       }
 
@@ -1027,7 +1029,7 @@ void ctkDICOMScheduler::raiseJobsPriorityForSeries(const QStringList& selectedSe
       ctkDICOMJob* dicomJob = qobject_cast<ctkDICOMJob*>(job.data());
       if (!dicomJob)
       {
-        logger.debug("ctkDICOMScheduler::raiseJobsPriorityForSeries: unexpected type of job.");
+        logger->debug("ctkDICOMScheduler::raiseJobsPriorityForSeries: unexpected type of job.");
         continue;
       }
 

--- a/Libs/DICOM/Core/ctkDICOMSeriesModel.cpp
+++ b/Libs/DICOM/Core/ctkDICOMSeriesModel.cpp
@@ -30,6 +30,7 @@
 
 // CTK includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMModalities.h"
@@ -39,7 +40,7 @@
 #include "ctkDICOMJobResponseSet.h"
 #include "ctkDICOMJob.h"
 
-static ctkLogger logger("org.commontk.DICOM.Core.DICOMSeriesModel");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Core.DICOMSeriesModel"))
 
 //----------------------------------------------------------------------------
 static void skipDelete(QObject* obj)
@@ -163,7 +164,7 @@ void ctkDICOMSeriesModelPrivate::populateSeriesData()
 
   if (!this->DicomDatabase)
   {
-    logger.error("populateSeriesData: No database set");
+    logger->error("populateSeriesData: No database set");
     return;
   }
 
@@ -594,7 +595,7 @@ void ctkDICOMSeriesModel::setDicomDatabase(QSharedPointer<ctkDICOMDatabase> data
   Q_D(ctkDICOMSeriesModel);
   if (!database.data())
   {
-    logger.error("setDicomDatabase: Invalid (null) database pointer");
+    logger->error("setDicomDatabase: Invalid (null) database pointer");
     return;
   }
   if (d->DicomDatabase == database)
@@ -1045,7 +1046,7 @@ void ctkDICOMSeriesModel::forceRetrieveSeries(const QString &seriesInstanceUID)
   ctkDICOMSeriesModelPrivate::SeriesData& seriesData = d->SeriesList[linearIndex];
   if (d->AllowedServers.isEmpty())
   {
-    logger.warn("ctkDICOMSeriesModel::forceRetrieveSeries: No allowed servers specified, cannot retrieve series.");
+    logger->warn("ctkDICOMSeriesModel::forceRetrieveSeries: No allowed servers specified, cannot retrieve series.");
     seriesData.operationStatus = ctkDICOMSeriesModel::Failed;
   }
   else

--- a/Libs/DICOM/Core/ctkDICOMServer.cpp
+++ b/Libs/DICOM/Core/ctkDICOMServer.cpp
@@ -27,11 +27,12 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMServer.h"
 
-static ctkLogger logger("org.commontk.dicom.DICOMServer");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMServer"))
 
 //------------------------------------------------------------------------------
 class ctkDICOMServerPrivate : public QObject

--- a/Libs/DICOM/Core/ctkDICOMStorageListenerJob.cpp
+++ b/Libs/DICOM/Core/ctkDICOMStorageListenerJob.cpp
@@ -23,12 +23,13 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMStorageListenerJob_p.h"
 #include "ctkDICOMStorageListenerWorker.h"
 
-static ctkLogger logger ( "org.commontk.dicom.DICOMStorageListenerJob" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMStorageListenerJob"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMStorageListenerJobPrivate methods

--- a/Libs/DICOM/Core/ctkDICOMStorageListenerWorker.cpp
+++ b/Libs/DICOM/Core/ctkDICOMStorageListenerWorker.cpp
@@ -26,6 +26,7 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMJobResponseSet.h"
@@ -36,7 +37,7 @@
 // DCMTK includes
 #include <dcmtk/oflog/spi/logevent.h>
 
-static ctkLogger logger ("org.commontk.dicom.DICOMStorageListenerWorker");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMStorageListenerWorker"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMStorageListenerWorkerPrivate methods
@@ -141,7 +142,7 @@ void ctkDICOMStorageListenerWorker::run()
   storageListenerJob->setStatus(ctkAbstractJob::JobStatus::Running);
   emit storageListenerJob->started();
 
-  logger.debug(QString("ctkDICOMStorageListenerWorker : running job %1 in thread %2.\n")
+  logger->debug(QString("ctkDICOMStorageListenerWorker : running job %1 in thread %2.\n")
                        .arg(storageListenerJob->jobUID())
                        .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId())), 16));
 

--- a/Libs/DICOM/Core/ctkDICOMStudyModel.cpp
+++ b/Libs/DICOM/Core/ctkDICOMStudyModel.cpp
@@ -28,6 +28,7 @@
 
 // CTK includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMStudyModel.h"
@@ -39,7 +40,7 @@
 #include "ctkDICOMJobResponseSet.h"
 #include "ctkDICOMJob.h"
 
-static ctkLogger logger("org.commontk.DICOM.Core.ctkDICOMStudyModel");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Core.ctkDICOMStudyModel"))
 
 //------------------------------------------------------------------------------
 // Helper function for setDicomDatabase/setScheduler
@@ -198,7 +199,7 @@ void ctkDICOMStudyModelPrivate::populateStudies()
 
   if (!this->DicomDatabase)
   {
-    logger.error("populateStudies: No database set");
+    logger->error("populateStudies: No database set");
     return;
   }
 
@@ -604,7 +605,7 @@ ctkDICOMSeriesModel* ctkDICOMStudyModelPrivate::createSeriesModel(const QString&
 
   if (!this->DicomDatabase)
   {
-    logger.warn("createSeriesModel: No database set");
+    logger->warn("createSeriesModel: No database set");
     return nullptr;
   }
 

--- a/Libs/DICOM/Core/ctkDICOMTester.cpp
+++ b/Libs/DICOM/Core/ctkDICOMTester.cpp
@@ -28,9 +28,10 @@
 // ctkDICOM includes
 #include "ctkDICOMTester.h"
 #include "ctkLogger.h"
+#include <QGlobalStatic>
 
 //------------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.dicom.DICOMTester" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMTester"))
 //------------------------------------------------------------------------------
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Core/ctkDICOMThumbnailGeneratorJob.cpp
+++ b/Libs/DICOM/Core/ctkDICOMThumbnailGeneratorJob.cpp
@@ -23,13 +23,14 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMJobResponseSet.h" // For ctkDICOMJobDetail
 #include "ctkDICOMThumbnailGeneratorJob_p.h"
 #include "ctkDICOMThumbnailGeneratorWorker.h"
 
-static ctkLogger logger ( "org.commontk.dicom.DICOMThumbnailGeneratorJob" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMThumbnailGeneratorJob"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMThumbnailGeneratorJobPrivate methods

--- a/Libs/DICOM/Core/ctkDICOMThumbnailGeneratorWorker.cpp
+++ b/Libs/DICOM/Core/ctkDICOMThumbnailGeneratorWorker.cpp
@@ -23,6 +23,7 @@
 
 // ctkCore includes
 #include <ctkLogger.h>
+#include <QGlobalStatic>
 
 // ctkDICOMCore includes
 #include "ctkDICOMThumbnailGenerator.h"
@@ -30,7 +31,7 @@
 #include "ctkDICOMThumbnailGeneratorJob.h"
 #include "ctkDICOMScheduler.h"
 
-static ctkLogger logger ("org.commontk.dicom.DICOMRetrieveWorker");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMRetrieveWorker"))
 
 //------------------------------------------------------------------------------
 // ctkDICOMThumbnailGeneratorWorkerPrivate methods
@@ -97,7 +98,7 @@ void ctkDICOMThumbnailGeneratorWorker::run()
 
   thumbnailGeneratorJob->setStatus(ctkAbstractJob::JobStatus::Running);
 
-  logger.debug(QString("ctkDICOMThumbnailGeneratorWorker : running job %1 in thread %2.\n")
+  logger->debug(QString("ctkDICOMThumbnailGeneratorWorker : running job %1 in thread %2.\n")
                        .arg(thumbnailGeneratorJob->jobUID())
                        .arg(QString::number(reinterpret_cast<quint64>(QThread::currentThreadId())), 16));
 

--- a/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMAppWidget.cpp
@@ -61,7 +61,7 @@
 
 //logger
 #include <ctkLogger.h>
-static ctkLogger logger("org.commontk.DICOM.Widgets.ctkDICOMAppWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Widgets.ctkDICOMAppWidget"))
 
 Q_DECLARE_METATYPE(QPersistentModelIndex);
 

--- a/Libs/DICOM/Widgets/ctkDICOMImage.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMImage.cpp
@@ -31,7 +31,7 @@
 #include <dcmtk/dcmimgle/dcmimage.h>
 #include <dcmtk/ofstd/ofbmanip.h>
 
-static ctkLogger logger ( "org.commontk.dicom.DICOMImage" );
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMImage"))
 struct Node;
 
 //------------------------------------------------------------------------------
@@ -129,7 +129,7 @@ QImage ctkDICOMImage::frame(int frame) const
 
       if (!image.loadFromData( buffer ))
       {
-        logger.error("QImage couldn't created");
+        logger->error("QImage couldn't created");
       }
     }
   }

--- a/Libs/DICOM/Widgets/ctkDICOMItemView.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMItemView.cpp
@@ -47,7 +47,7 @@
 #include <QPainter>
 #include <QResizeEvent>
 
-static ctkLogger logger("org.commontk.DICOM.Widgets.ctkDICOMItemView");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Widgets.ctkDICOMItemView"))
 
 //--------------------------------------------------------------------------
 class ctkDICOMItemViewPrivate
@@ -272,7 +272,7 @@ void ctkDICOMItemView::addImage( DicomImage & dcmImage, bool defaultIntensity )
     EI_Status result = dcmImage.getStatus();
     if (result != EIS_Normal)
     {
-      logger.error(QString("Rendering of DICOM image failed for thumbnail failed: ") + DicomImage::getString(result));
+      logger->error(QString("Rendering of DICOM image failed for thumbnail failed: ") + DicomImage::getString(result));
       return;
     }
     // Select first window defined in image. If none, compute min/max window as best guess.
@@ -328,7 +328,7 @@ void ctkDICOMItemView::addImage( DicomImage & dcmImage, bool defaultIntensity )
     {
       if (!image.loadFromData( buffer ))
       {
-            logger.error("QImage couldn't created");
+            logger->error("QImage couldn't created");
       }
     }
     this->addImage(image);
@@ -424,7 +424,7 @@ void ctkDICOMItemView::displayImage(int imageIndex){
           }
           else
           {
-            logger.debug("out of index");
+            logger->debug("out of index");
           }
       }
   }

--- a/Libs/DICOM/Widgets/ctkDICOMJobListWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMJobListWidget.cpp
@@ -37,7 +37,7 @@
 #include "ctkDICOMJobListWidget.h"
 #include "ui_ctkDICOMJobListWidget.h"
 
-static ctkLogger logger("org.commontk.DICOM.Widgets.DICOMJobListWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Widgets.DICOMJobListWidget"))
 
 //----------------------------------------------------------------------------
 class ProgressBarDelegate : public QStyledItemDelegate {
@@ -151,7 +151,7 @@ QString QCenteredItemModel::getJobTypeAsString(QString jobClass, ctkDICOMJob::DI
     switch (dicomLevel)
     {
       case ctkDICOMJob::DICOMLevels::None:
-        logger.warn("ctkDICOMScheduler : DICOMLevels was not set.");
+        logger->warn("ctkDICOMScheduler : DICOMLevels was not set.");
         return "";
       case ctkDICOMJob::DICOMLevels::Patients:
         return ctkDICOMJobListWidget::tr("Query patients");
@@ -168,7 +168,7 @@ QString QCenteredItemModel::getJobTypeAsString(QString jobClass, ctkDICOMJob::DI
     switch (dicomLevel)
     {
       case ctkDICOMJob::DICOMLevels::None:
-        logger.warn("ctkDICOMScheduler : DICOMLevels was not set.");
+        logger->warn("ctkDICOMScheduler : DICOMLevels was not set.");
         return "";
       case ctkDICOMJob::DICOMLevels::Patients:
         return ctkDICOMJobListWidget::tr("Retrieve patients");

--- a/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMObjectListWidget.cpp
@@ -36,7 +36,7 @@
 //CTK includes
 #include <ctkDICOMObjectModel.h>
 #include <ctkLogger.h>
-static ctkLogger logger("org.commontk.DICOM.Widgets.ctkDICOMObjectListWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Widgets.ctkDICOMObjectListWidget"))
 
 class qRecursiveTreeProxyFilter : public QSortFilterProxyModel {
   Q_OBJECT

--- a/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
@@ -44,7 +44,7 @@
 #include "ctkDICOMQueryRetrieveWidget.h"
 #include "ui_ctkDICOMQueryRetrieveWidget.h"
 
-static ctkLogger logger("org.commontk.DICOM.Widgets.ctkDICOMQueryRetrieveWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Widgets.ctkDICOMQueryRetrieveWidget"))
 
 //----------------------------------------------------------------------------
 class ctkDICOMQueryRetrieveWidgetPrivate: public Ui_ctkDICOMQueryRetrieveWidget
@@ -188,7 +188,7 @@ void ctkDICOMQueryRetrieveWidget::query()
     catch (const std::exception& e)
     {
       Q_UNUSED(e);
-      logger.error("Database error: " + d->QueryResultDatabase.lastError());
+      logger->error("Database error: " + d->QueryResultDatabase.lastError());
       d->QueryResultDatabase.closeDatabase();
       return;
     }
@@ -258,7 +258,7 @@ void ctkDICOMQueryRetrieveWidget::query()
     catch (const std::exception& e)
     {
       Q_UNUSED(e);
-      logger.error ( "Query error: " + parameters["Name"].toString() );
+      logger->error ( "Query error: " + parameters["Name"].toString() );
       progress.setLabelText("Query error: " + parameters["Name"].toString());
       delete query;
     }
@@ -354,7 +354,7 @@ void ctkDICOMQueryRetrieveWidget::retrieve()
     ctkDICOMQuery* currentQuery = (queryIt == d->QueriesByStudyUID.end() ? nullptr : *queryIt);
     if (!currentQuery)
     {
-      logger.warn("Retrieve of series " + seriesUID + " failed. No query found for study " + studyUID + ".");
+      logger->warn("Retrieve of series " + seriesUID + " failed. No query found for study " + studyUID + ".");
       continue;
     }
 
@@ -365,8 +365,8 @@ void ctkDICOMQueryRetrieveWidget::retrieve()
     retrieve->setHost( currentQuery->host() );
     // TODO: check the model item to see if it is checked
     // for now, assume all studies queried and shown to the user will be retrieved
-    logger.debug("About to retrieve " + seriesUID + " from " + currentQuery->host());
-    logger.info ( "Starting to retrieve" );
+    logger->debug("About to retrieve " + seriesUID + " from " + currentQuery->host());
+    logger->info ( "Starting to retrieve" );
 
     if(d->UseProgressDialog)
     {
@@ -402,7 +402,7 @@ void ctkDICOMQueryRetrieveWidget::retrieve()
     catch (const std::exception& e)
     {
       Q_UNUSED(e);
-      logger.error ( "Retrieve failed" );
+      logger->error ( "Retrieve failed" );
       if(d->UseProgressDialog)
       {
         if ( QMessageBox::question ( this,
@@ -426,7 +426,7 @@ void ctkDICOMQueryRetrieveWidget::retrieve()
               this, SLOT(updateRetrieveProgress(int)));
       disconnect(&progress, SIGNAL(canceled()), retrieve, SLOT(cancel()));
     }
-    logger.info ( "Retrieve success" );
+    logger->info ( "Retrieve success" );
   }
 
   if (retrieve->dicomDatabase())
@@ -505,7 +505,7 @@ void ctkDICOMQueryRetrieveWidget::updateRetrieveProgress(int value)
     d->ProgressDialog->resize(targetWidth, d->ProgressDialog->height());
   }
   d->ProgressDialog->setValue( value );
-  logger.error(QString("setting value to %1").arg(value) );
+  logger->error(QString("setting value to %1").arg(value) );
   QApplication::processEvents();
 }
 

--- a/Libs/DICOM/Widgets/ctkDICOMQueryWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMQueryWidget.cpp
@@ -30,7 +30,7 @@
 
 //logger
 #include <ctkLogger.h>
-static ctkLogger logger("org.commontk.DICOM.Widgets.ctkDICOMQueryWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Widgets.ctkDICOMQueryWidget"))
 
 
 //----------------------------------------------------------------------------

--- a/Libs/DICOM/Widgets/ctkDICOMServerNodeWidget2.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMServerNodeWidget2.cpp
@@ -54,7 +54,7 @@
 #include "ctkDICOMServerNodeWidget2.h"
 #include "ui_ctkDICOMServerNodeWidget2.h"
 
-static ctkLogger logger("org.commontk.DICOM.Widgets.DICOMServerNodeWidget2");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Widgets.DICOMServerNodeWidget2"))
 QColor ctkDICOMServerNodeWidget2DefaultColor(Qt::white);
 QColor ctkDICOMServerNodeWidget2DarkModeDefaultColor(50, 50, 50);
 QColor ctkDICOMServerNodeWidget2ModifiedColor(Qt::darkYellow);
@@ -579,7 +579,7 @@ int ctkDICOMServerNodeWidget2Private::addServerNode(const QMap<QString, QVariant
 
   if (this->getServerNodeRowFromConnectionName(node["Name"].toString()) != -1)
   {
-    logger.warn("addServerNode failed: the server has a duplicate. The connection name has to be unique \n");
+    logger->warn("addServerNode failed: the server has a duplicate. The connection name has to be unique \n");
     return -1;
   }
 
@@ -699,7 +699,7 @@ int ctkDICOMServerNodeWidget2Private::addServerNode(ctkDICOMServer* server)
 
   if (this->getServerNodeRowFromConnectionName(server->connectionName()) != -1)
   {
-    logger.debug("addServerNode failed: the server has a duplicate. The connection name has to be unique \n");
+    logger->debug("addServerNode failed: the server has a duplicate. The connection name has to be unique \n");
     return -1;
   }
 
@@ -1665,7 +1665,7 @@ int ctkDICOMServerNodeWidget2::serversCount()
   Q_D(ctkDICOMServerNodeWidget2);
   if (!d->Scheduler)
   {
-    logger.error("serversCount failed, no task pool has been set. \n");
+    logger->error("serversCount failed, no task pool has been set. \n");
     return -1;
   }
 
@@ -1678,7 +1678,7 @@ ctkDICOMServer* ctkDICOMServerNodeWidget2::server(int id)
   Q_D(ctkDICOMServerNodeWidget2);
   if (!d->Scheduler)
   {
-    logger.error("server failed, no task pool has been set. \n");
+    logger->error("server failed, no task pool has been set. \n");
     return nullptr;
   }
 
@@ -1691,7 +1691,7 @@ ctkDICOMServer* ctkDICOMServerNodeWidget2::server(const QString& connectionName)
   Q_D(ctkDICOMServerNodeWidget2);
   if (!d->Scheduler)
   {
-    logger.error("server failed, no task pool has been set. \n");
+    logger->error("server failed, no task pool has been set. \n");
     return nullptr;
   }
 
@@ -1704,7 +1704,7 @@ int ctkDICOMServerNodeWidget2::addServer(ctkDICOMServer* server)
   Q_D(ctkDICOMServerNodeWidget2);
   if (!d->Scheduler)
   {
-    logger.error("addServer failed, no task pool has been set. \n");
+    logger->error("addServer failed, no task pool has been set. \n");
     return -1;
   }
 
@@ -1719,7 +1719,7 @@ void ctkDICOMServerNodeWidget2::removeServer(const QString& connectionName)
   Q_D(ctkDICOMServerNodeWidget2);
   if (!d->Scheduler)
   {
-    logger.error("removeServer failed, no task pool has been set. \n");
+    logger->error("removeServer failed, no task pool has been set. \n");
     return;
   }
 
@@ -1732,7 +1732,7 @@ void ctkDICOMServerNodeWidget2::removeServer(int id)
   Q_D(ctkDICOMServerNodeWidget2);
   if (!d->Scheduler)
   {
-    logger.error("removeServer failed, no task pool has been set. \n");
+    logger->error("removeServer failed, no task pool has been set. \n");
     return;
   }
 
@@ -1748,7 +1748,7 @@ void ctkDICOMServerNodeWidget2::removeAllServers()
   Q_D(ctkDICOMServerNodeWidget2);
   if (!d->Scheduler)
   {
-    logger.error("removeAllServers failed, no task pool has been set. \n");
+    logger->error("removeAllServers failed, no task pool has been set. \n");
     return;
   }
 
@@ -1763,7 +1763,7 @@ QString ctkDICOMServerNodeWidget2::getServerNameFromIndex(int id)
   Q_D(ctkDICOMServerNodeWidget2);
   if (!d->Scheduler)
   {
-    logger.error("getServerNameFromIndex failed, no task pool has been set. \n");
+    logger->error("getServerNameFromIndex failed, no task pool has been set. \n");
     return "";
   }
 
@@ -1776,7 +1776,7 @@ int ctkDICOMServerNodeWidget2::getServerIndexFromName(const QString& connectionN
   Q_D(ctkDICOMServerNodeWidget2);
   if (!d->Scheduler)
   {
-    logger.error("getServerIndexFromName failed, no task pool has been set. \n");
+    logger->error("getServerIndexFromName failed, no task pool has been set. \n");
     return -1;
   }
 

--- a/Libs/DICOM/Widgets/ctkDICOMThumbnailListWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMThumbnailListWidget.cpp
@@ -53,7 +53,7 @@
 // DCMTK includes
 #include <dcmtk/dcmimgle/dcmimage.h>
 
-static ctkLogger logger("org.commontk.DICOM.Widgets.DICOMThumbnailListWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Widgets.DICOMThumbnailListWidget"))
 
 Q_DECLARE_METATYPE(QPersistentModelIndex);
 
@@ -157,7 +157,7 @@ void ctkDICOMThumbnailListWidgetPrivate
   model->fetchMore(seriesIndex);
 
   const int imageCount = model->rowCount(seriesIndex);
-  logger.debug(QString("Thumbs: %1").arg(imageCount));
+  logger->debug(QString("Thumbs: %1").arg(imageCount));
   for (int i = 0 ; i < imageCount ; i++ )
   {
     QModelIndex imageIndex = ctk::modelChildIndex(model, seriesIndex, i, 0);
@@ -195,7 +195,7 @@ void ctkDICOMThumbnailListWidgetPrivate
   QString widgetLabel = text;
   widget->setText( widgetLabel );
   QPixmap pix(thumbnailPath);
-  logger.debug("Setting pixmap to " + thumbnailPath);
+  logger->debug("Setting pixmap to " + thumbnailPath);
   if(this->ThumbnailSize.isValid())
   {
     widget->setFixedSize(this->ThumbnailSize);

--- a/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
@@ -76,7 +76,7 @@
 #include "ctkDICOMVisualBrowserWidget.h"
 #include "ui_ctkDICOMVisualBrowserWidget.h"
 
-static ctkLogger logger("org.commontk.DICOM.Widgets.DICOMVisualBrowserWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.DICOM.Widgets.DICOMVisualBrowserWidget"))
 
 QColor ctkDICOMVisualBrowserWidgetDefaultColor(Qt::white);
 QColor ctkDICOMVisualBrowserWidgetDarkModeDefaultColor(50, 50, 50);
@@ -574,19 +574,19 @@ void ctkDICOMVisualBrowserWidgetPrivate::importDirectory(QString directory, ctkD
 {
   if (!this->DicomDatabase)
   {
-    logger.error("importDirectory failed, no DICOM Database has been set. \n");
+    logger->error("importDirectory failed, no DICOM Database has been set. \n");
     return;
   }
 
   if (!this->Scheduler || !this->Indexer)
   {
-    logger.error("importDirectory failed, no task pool has been set. \n");
+    logger->error("importDirectory failed, no task pool has been set. \n");
     return;
   }
 
   if (!QDir(directory).exists())
   {
-    logger.error(QString("importDirectory failed, input directory %1 does not exist. \n").arg(directory));
+    logger->error(QString("importDirectory failed, input directory %1 does not exist. \n").arg(directory));
     return;
   }
   // Start background indexing
@@ -598,13 +598,13 @@ void ctkDICOMVisualBrowserWidgetPrivate::importFiles(const QStringList& files, c
 {
   if (!this->DicomDatabase)
   {
-    logger.error("importFiles failed, no DICOM Database has been set. \n");
+    logger->error("importFiles failed, no DICOM Database has been set. \n");
     return;
   }
 
   if (!this->Scheduler || !this->Indexer)
   {
-    logger.error("importFiles failed, no task pool has been set. \n");
+    logger->error("importFiles failed, no task pool has been set. \n");
     return;
   }
 
@@ -764,13 +764,13 @@ QString ctkDICOMVisualBrowserWidgetPrivate::createPatients(bool queryRetrieve,
 
   if (!this->DicomDatabase)
   {
-    logger.error("createPatients failed, no DICOM database has been set. \n");
+    logger->error("createPatients failed, no DICOM database has been set. \n");
     return QString();
   }
 
   if (!this->PatientModel)
   {
-    logger.error("createPatients failed, no PatientModel has been set. \n");
+    logger->error("createPatients failed, no PatientModel has been set. \n");
     return QString();
   }
 
@@ -885,7 +885,7 @@ QString ctkDICOMVisualBrowserWidgetPrivate::createPatients(bool queryRetrieve,
         "The server settings section is below.\n"
         "Check also the allowed servers at patient level."
       );
-      logger.warn(warningText);
+      logger->warn(warningText);
       this->WarningPushButton->setText(warningText);
       this->WarningPushButton->show();
       q->openServerSettingsSection();
@@ -950,13 +950,13 @@ void ctkDICOMVisualBrowserWidgetPrivate::updateFiltersWarnings()
 {
   if (!this->DicomDatabase)
   {
-    logger.error("updateFiltersWarnings failed, no DICOM database has been set. \n");
+    logger->error("updateFiltersWarnings failed, no DICOM database has been set. \n");
     return;
   }
 
   if (!this->PatientModel)
   {
-    logger.error("updateFiltersWarnings failed, no PatientModel has been set. \n");
+    logger->error("updateFiltersWarnings failed, no PatientModel has been set. \n");
     return;
   }
 
@@ -1234,7 +1234,7 @@ QStringList ctkDICOMVisualBrowserWidgetPrivate::filterPatientList(const QStringL
   QStringList filteredPatientList;
   if (!this->DicomDatabase)
   {
-    logger.error("filterPatientList failed, no DICOM Database has been set. \n");
+    logger->error("filterPatientList failed, no DICOM Database has been set. \n");
     return filteredPatientList;
   }
 
@@ -1270,7 +1270,7 @@ QStringList ctkDICOMVisualBrowserWidgetPrivate::filterStudyList(const QStringLis
   QStringList filteredStudyList;
   if (!this->DicomDatabase)
   {
-    logger.error("filterStudyList failed, no DICOM Database has been set. \n");
+    logger->error("filterStudyList failed, no DICOM Database has been set. \n");
     return filteredStudyList;
   }
 
@@ -1322,7 +1322,7 @@ QStringList ctkDICOMVisualBrowserWidgetPrivate::filterSeriesList(const QStringLi
   QStringList filteredSeriesList;
   if (!this->DicomDatabase)
   {
-    logger.error("filterSeriesList failed, no DICOM Database has been set. \n");
+    logger->error("filterSeriesList failed, no DICOM Database has been set. \n");
     return filteredSeriesList;
   }
 
@@ -1609,7 +1609,7 @@ void ctkDICOMVisualBrowserWidget::setTagsToPrecache(const QStringList& tags)
   Q_D(ctkDICOMVisualBrowserWidget);
   if (!d->DicomDatabase)
   {
-    logger.error("setTagsToPrecache failed, no DICOM Database has been set. \n");
+    logger->error("setTagsToPrecache failed, no DICOM Database has been set. \n");
     return;
   }
 
@@ -1622,7 +1622,7 @@ const QStringList ctkDICOMVisualBrowserWidget::tagsToPrecache()
   Q_D(ctkDICOMVisualBrowserWidget);
   if (!d->DicomDatabase)
   {
-    logger.error("Get tagsToPrecache failed, no DICOM Database has been set. \n");
+    logger->error("Get tagsToPrecache failed, no DICOM Database has been set. \n");
     return QStringList();
   }
 
@@ -1926,7 +1926,7 @@ void ctkDICOMVisualBrowserWidget::setDatabaseDirectory(const QString& directory)
   Q_D(ctkDICOMVisualBrowserWidget);
   if (!d->DicomDatabase)
   {
-    logger.error("setDatabaseDirectory failed, no DICOM database has been set. \n");
+    logger->error("setDatabaseDirectory failed, no DICOM database has been set. \n");
     return;
   }
 
@@ -1942,7 +1942,7 @@ void ctkDICOMVisualBrowserWidget::setDatabaseDirectory(const QString& directory)
   if (!QDir(absDirectory).exists()
     || (!ctk::isDirEmpty(QDir(absDirectory)) && !QFile(databaseFileName).exists()))
   {
-    logger.warn("Database folder does not contain ctkDICOM.sql file: " + absDirectory + "\n");
+    logger->warn("Database folder does not contain ctkDICOM.sql file: " + absDirectory + "\n");
     d->DatabaseDirectoryProblemFrame->show();
     d->DatabaseDirectoryProblemLabel->setText(
       //: %1 is the folder path
@@ -1969,7 +1969,7 @@ void ctkDICOMVisualBrowserWidget::setDatabaseDirectory(const QString& directory)
     }
     if (!databaseOpenSuccess || d->DicomDatabase->schemaVersionLoaded().isEmpty())
     {
-      logger.warn(tr("Database error: %1 \n").arg(d->DicomDatabase->lastError()));
+      logger->warn(tr("Database error: %1 \n").arg(d->DicomDatabase->lastError()));
       d->DicomDatabase->closeDatabase();
       d->DatabaseDirectoryProblemFrame->show();
       d->DatabaseDirectoryProblemLabel->setText(
@@ -1987,8 +1987,8 @@ void ctkDICOMVisualBrowserWidget::setDatabaseDirectory(const QString& directory)
   {
     if (d->DicomDatabase->schemaVersionLoaded() != d->DicomDatabase->schemaVersion())
     {
-      logger.warn(QString("Database version mismatch: version of selected database = %1, version required = %2 \n")
-        .arg(d->DicomDatabase->schemaVersionLoaded(), d->DicomDatabase->schemaVersion()));
+      logger->warn(QString("Database version mismatch: version of selected database = %1, version required = %2 \n")
+        .arg(d->DicomDatabase->schemaVersionLoaded()).arg(d->DicomDatabase->schemaVersion()));
       d->DicomDatabase->closeDatabase();
       d->DatabaseDirectoryProblemFrame->show();
       d->DatabaseDirectoryProblemLabel->setText(
@@ -2069,7 +2069,7 @@ void ctkDICOMVisualBrowserWidget::waitForImportFinished()
   Q_D(ctkDICOMVisualBrowserWidget);
   if (!d->Scheduler || !d->Indexer)
   {
-    logger.error("waitForImportFinished failed, no task pool has been set. \n");
+    logger->error("waitForImportFinished failed, no task pool has been set. \n");
     return;
   }
   d->Indexer->waitForImportFinished();
@@ -2457,7 +2457,7 @@ void ctkDICOMVisualBrowserWidget::onQueryPatients()
 
   if (!d->DicomDatabase)
   {
-    logger.error("onQueryPatients failed, no DICOM database has been set. \n");
+    logger->error("onQueryPatients failed, no DICOM database has been set. \n");
     return;
   }
 
@@ -2480,7 +2480,7 @@ void ctkDICOMVisualBrowserWidget::onQueryPatients()
     d->SearchPushButton->setIcon(QIcon(":/Icons/query_failed.svg"));
     QString warningText = tr("No server is configured for query/retrieve operations.\n"
                               "The server settings section is below.");
-    logger.warn(warningText);
+    logger->warn(warningText);
     d->WarningPushButton->setText(warningText);
     d->WarningPushButton->show();
     this->openServerSettingsSection();
@@ -2493,7 +2493,7 @@ void ctkDICOMVisualBrowserWidget::onQueryPatients()
     d->SearchPushButton->setIcon(QIcon(":/Icons/query_failed.svg"));
     QString warningText = tr("No filters are set and no patients are found in the local database.\n"
                               "Please specify at least one filter to query the servers.");
-    logger.warn(warningText);
+    logger->warn(warningText);
     d->WarningPushButton->setText(warningText);
     d->WarningPushButton->show();
     return;
@@ -3551,13 +3551,13 @@ void ctkDICOMVisualBrowserWidget::onLoadSeries(const QStringList& seriesInstance
 
   if (!d->Scheduler)
   {
-    logger.error("onLoadSeries failed, no scheduler has been set. \n");
+    logger->error("onLoadSeries failed, no scheduler has been set. \n");
     return;
   }
 
   if (!d->DicomDatabase)
   {
-    logger.error("onLoadSeries failed, no DicomDatabase has been set. \n");
+    logger->error("onLoadSeries failed, no DicomDatabase has been set. \n");
     return;
   }
 
@@ -3769,13 +3769,13 @@ void ctkDICOMVisualBrowserWidget::forceRetrieveSeries(const QStringList& seriesI
 
   if (!d->Scheduler)
   {
-    logger.error("forceRetrieveSeries failed, no scheduler has been set. \n");
+    logger->error("forceRetrieveSeries failed, no scheduler has been set. \n");
     return;
   }
 
   if (!d->DicomDatabase)
   {
-    logger.error("forceRetrieveSeries failed, no DicomDatabase has been set. \n");
+    logger->error("forceRetrieveSeries failed, no DicomDatabase has been set. \n");
     return;
   }
 
@@ -3966,7 +3966,7 @@ void ctkDICOMVisualBrowserWidget::exportSeriesToDirectory(const QString& dirPath
   Q_D(ctkDICOMVisualBrowserWidget);
   if (!d->DicomDatabase)
   {
-    logger.error("exportSeries failed, no DICOM database has been set. \n");
+    logger->error("exportSeries failed, no DICOM database has been set. \n");
     return;
   }
 
@@ -4265,7 +4265,7 @@ bool ctkDICOMVisualBrowserWidget::confirmDeleteSelectedUIDs(const QStringList& u
   Q_D(ctkDICOMVisualBrowserWidget);
   if (!d->DicomDatabase)
   {
-    logger.error("confirmDeleteSelectedUIDs failed, no DICOM database has been set. \n");
+    logger->error("confirmDeleteSelectedUIDs failed, no DICOM database has been set. \n");
     return false;
   }
 

--- a/Libs/Visualization/VTK/Core/ctkVTKScalarsToColorsUtils.cpp
+++ b/Libs/Visualization/VTK/Core/ctkVTKScalarsToColorsUtils.cpp
@@ -28,8 +28,7 @@
 #include <vtkScalarsToColors.h>
 
 // ----------------------------------------------------------------------------
-static ctkLogger logger(
-  "org.commontk.visualization.vtk.core.ctkVTKScalarsToColorsUtils");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.visualization.vtk.core.ctkVTKScalarsToColorsUtils"))
 
 // ----------------------------------------------------------------------------
 void ctk::remapColorScale(

--- a/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKAbstractView.cpp
@@ -37,7 +37,7 @@
 #include <vtkVersion.h>
 
 //--------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkVTKAbstractView");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.visualization.vtk.widgets.ctkVTKAbstractView"))
 //--------------------------------------------------------------------------
 int ctkVTKAbstractViewPrivate::MultiSamples = 0;  // Default for static var
 //--------------------------------------------------------------------------
@@ -179,7 +179,7 @@ void ctkVTKAbstractView::scheduleRender()
 {
   Q_D(ctkVTKAbstractView);
 
-  //logger.trace(QString("scheduleRender - RenderEnabled: %1 - Request render elapsed: %2ms").
+  //logger->trace(QString("scheduleRender - RenderEnabled: %1 - Request render elapsed: %2ms").
   //             arg(d->RenderEnabled ? "true" : "false")
   //             .arg(d->RequestTime.elapsed()));
 
@@ -250,7 +250,7 @@ void ctkVTKAbstractView::forceRender()
   d->RequestTime = QTime();
 #endif
 
-  //logger.trace(QString("forceRender - RenderEnabled: %1")
+  //logger->trace(QString("forceRender - RenderEnabled: %1")
   //             .arg(d->RenderEnabled ? "true" : "false"));
 
   if (!d->RenderEnabled || !this->isVisible())

--- a/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKChartView.cpp
@@ -41,7 +41,7 @@
 #include <vtkVersion.h>
 
 //----------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkVTKChartView");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.visualization.vtk.widgets.ctkVTKChartView"))
 //----------------------------------------------------------------------------
 
 class ctkVTKChartViewPrivate

--- a/Libs/Visualization/VTK/Widgets/ctkVTKColorTransferFunction.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKColorTransferFunction.cpp
@@ -31,7 +31,7 @@
 #include <vtkSmartPointer.h>
 
 //--------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.libs.visualization.core.ctkVTKColorTransferFunction");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.libs.visualization.core.ctkVTKColorTransferFunction"))
 //--------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------
@@ -92,7 +92,7 @@ void ctkVTKColorTransferFunction::range(qreal& minRange, qreal& maxRange)const
   if (d->ColorTransferFunction.GetPointer() == 0)
   {
     //Q_ASSERT(d->ColorTransferFunction.GetPointer());
-    logger.warn("no ColorTransferFunction");
+    logger->warn("no ColorTransferFunction");
     minRange = 1.;
     maxRange = 0.;
     return;
@@ -110,7 +110,7 @@ QVariant ctkVTKColorTransferFunction::minValue()const
   if (d->ColorTransferFunction.GetPointer() == 0)
   {
     //Q_ASSERT(d->ColorTransferFunction.GetPointer());
-    logger.warn("no ColorTransferFunction");
+    logger->warn("no ColorTransferFunction");
     return -1;
   }
   double rgb[3];
@@ -138,7 +138,7 @@ QVariant ctkVTKColorTransferFunction::maxValue()const
   if (d->ColorTransferFunction.GetPointer() == 0)
   {
     //Q_ASSERT(d->ColorTransferFunction.GetPointer());
-    logger.warn("no ColorTransferFunction");
+    logger->warn("no ColorTransferFunction");
     return -1;
   }
   double rgb[3];

--- a/Libs/Visualization/VTK/Widgets/ctkVTKHistogram.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKHistogram.cpp
@@ -36,7 +36,7 @@
 #include <limits>
 
 //--------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.libs.visualization.core.ctkVTKHistogram");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.libs.visualization.core.ctkVTKHistogram"))
 //--------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------
@@ -116,14 +116,14 @@ void ctkVTKHistogram::setRange(qreal minRange, qreal maxRange)
   Q_D(const ctkVTKHistogram);
   if (d->DataArray.GetPointer() == 0)
   {
-    logger.warn("no data array. range will be reset when setting array.");
+    logger->warn("no data array. range will be reset when setting array.");
     minRange = 1.; // set incorrect values
     maxRange = 0.;
     return;
   }
   if (minRange >= maxRange)
   {
-    logger.warn("minRange >= maxRange");
+    logger->warn("minRange >= maxRange");
     qreal pivot = minRange;
     minRange = maxRange;
     maxRange = pivot;
@@ -144,7 +144,7 @@ void ctkVTKHistogram::range(qreal& minRange, qreal& maxRange)const
   Q_D(const ctkVTKHistogram);
   if (d->DataArray.GetPointer() == 0)
   {
-    logger.warn("no dataArray");
+    logger->warn("no dataArray");
     minRange = 1.; // set incorrect values
     maxRange = 0.;
     return;

--- a/Libs/Visualization/VTK/Widgets/ctkVTKMagnifyView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKMagnifyView.cpp
@@ -40,7 +40,7 @@
 #include <cmath>
 
 //--------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkVTKMagnifyView");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.visualization.vtk.widgets.ctkVTKMagnifyView"))
 //--------------------------------------------------------------------------
 
 // --------------------------------------------------------------------------

--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsView.cpp
@@ -44,7 +44,7 @@
 #include <vtkVersionMacros.h> // For VTK_VERSION_CHECK
 
 //----------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkVTKScalarsToColorsView");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.visualization.vtk.widgets.ctkVTKScalarsToColorsView"))
 //----------------------------------------------------------------------------
 
 class ctkVTKScalarsToColorsViewPrivate

--- a/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKScalarsToColorsWidget.cpp
@@ -45,7 +45,7 @@
 #include <vtkPiecewiseFunctionItem.h>
 
 //----------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkVTKScalarsToColorsWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.visualization.vtk.widgets.ctkVTKScalarsToColorsWidget"))
 //----------------------------------------------------------------------------
 
 class ctkVTKScalarsToColorsWidgetPrivate:

--- a/Libs/Visualization/VTK/Widgets/ctkVTKThresholdWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKThresholdWidget.cpp
@@ -34,7 +34,7 @@
 #include <cmath> // for pow
 
 //----------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkVTKThresholdWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.visualization.vtk.widgets.ctkVTKThresholdWidget"))
 //----------------------------------------------------------------------------
 
 class ctkVTKThresholdWidgetPrivate:

--- a/Libs/Visualization/VTK/Widgets/ctkVTKThumbnailView.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKThumbnailView.cpp
@@ -41,7 +41,7 @@
 #include <vtkWeakPointer.h>
 
 //--------------------------------------------------------------------------
-static ctkLogger logger("org.slicer.libs.qmrmlwidgets.ctkVTKThumbnailView");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.slicer.libs.qmrmlwidgets.ctkVTKThumbnailView"))
 //--------------------------------------------------------------------------
 
 #define DEGREES2RADIANS 0.0174532925
@@ -340,7 +340,7 @@ void ctkVTKThumbnailViewPrivate::resetCamera()
 
   if (!ren || !cam)
   {
-    logger.error("Trying to reset non-existent camera");
+    logger->error("Trying to reset non-existent camera");
     return;
   }
 
@@ -349,7 +349,7 @@ void ctkVTKThumbnailViewPrivate::resetCamera()
 
   if (!vtkMath::AreBoundsInitialized(bounds))
   {
-    logger.error("Cannot reset camera!");
+    logger->error("Cannot reset camera!");
     return;
   }
   ren->InvokeEvent(vtkCommand::ResetCameraEvent, ren);
@@ -395,7 +395,7 @@ void ctkVTKThumbnailViewPrivate::resetCamera()
   double* vup = cam->GetViewUp();
   if ( fabs(vtkMath::Dot(vup,vn)) > 0.999 )
   {
-    logger.warn("Resetting view-up since view plane normal is parallel");
+    logger->warn("Resetting view-up since view plane normal is parallel");
     cam->SetViewUp(-vup[2], vup[0], vup[1]);
   }
 

--- a/Libs/Visualization/VTK/Widgets/ctkVTKVolumePropertyWidget.cpp
+++ b/Libs/Visualization/VTK/Widgets/ctkVTKVolumePropertyWidget.cpp
@@ -44,7 +44,7 @@
 #include <vtkVolumeProperty.h>
 
 //----------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkVTKVolumePropertyWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.visualization.vtk.widgets.ctkVTKVolumePropertyWidget"))
 //----------------------------------------------------------------------------
 
 class ctkVTKVolumePropertyWidgetPrivate:

--- a/Libs/Widgets/ctkCrosshairLabel.cpp
+++ b/Libs/Widgets/ctkCrosshairLabel.cpp
@@ -33,7 +33,7 @@
 #include <math.h>
 
 //--------------------------------------------------------------------------
-static ctkLogger logger("org.commontk.visualization.vtk.widgets.ctkCrosshairLabel");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.visualization.vtk.widgets.ctkCrosshairLabel"))
 //--------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------

--- a/Libs/Widgets/ctkFlowLayout.cpp
+++ b/Libs/Widgets/ctkFlowLayout.cpp
@@ -30,7 +30,7 @@
 // STD includes
 #include <cmath>
 
-static ctkLogger logger("org.commontk.libs.widgets.ctkFlowLayout");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.libs.widgets.ctkFlowLayout"))
 
 //-----------------------------------------------------------------------------
 class ctkFlowLayoutPrivate

--- a/Libs/Widgets/ctkMaterialPropertyWidget.cpp
+++ b/Libs/Widgets/ctkMaterialPropertyWidget.cpp
@@ -29,7 +29,7 @@
 #include "ui_ctkMaterialPropertyWidget.h"
 #include "ctkLogger.h"
 
-static ctkLogger logger("org.commontk.libs.widgets.ctkMaterialPropertyWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.libs.widgets.ctkMaterialPropertyWidget"))
 
 //-----------------------------------------------------------------------------
 class ctkMaterialPropertyWidgetPrivate: public Ui_ctkMaterialPropertyWidget

--- a/Libs/Widgets/ctkModalityWidget.cpp
+++ b/Libs/Widgets/ctkModalityWidget.cpp
@@ -31,7 +31,7 @@
 // STD includes
 #include <cmath>
 
-static ctkLogger logger("org.commontk.libs.widgets.ctkModalityWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.libs.widgets.ctkModalityWidget"))
 
 namespace
 {

--- a/Libs/Widgets/ctkSettingsDialog.cpp
+++ b/Libs/Widgets/ctkSettingsDialog.cpp
@@ -31,7 +31,7 @@
 #include "ui_ctkSettingsDialog.h"
 #include "ctkLogger.h"
 
-static ctkLogger logger("org.commontk.libs.widgets.ctkSettingsDialog");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.libs.widgets.ctkSettingsDialog"))
 
 //-----------------------------------------------------------------------------
 class ctkSettingsDialogPrivate: public Ui_ctkSettingsDialog

--- a/Libs/Widgets/ctkSettingsPanel.cpp
+++ b/Libs/Widgets/ctkSettingsPanel.cpp
@@ -28,7 +28,7 @@
 #include "ctkSettingsPanel.h"
 #include "ctkLogger.h"
 
-static ctkLogger logger("org.commontk.libs.widgets.ctkSettingsPanel");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.libs.widgets.ctkSettingsPanel"))
 
 namespace
 {
@@ -281,7 +281,7 @@ void ctkSettingsPanel::setSetting(const QString& key, const QVariant& newVal)
   d->Properties[key].setValue(newVal);
   if (settings->status() != QSettings::NoError)
   {
-    logger.warn( QString("Error #%1 while writing setting \"%2\"")
+    logger->warn( QString("Error #%1 while writing setting \"%2\"")
       .arg(static_cast<int>(settings->status()))
       .arg(key));
   }

--- a/Libs/Widgets/ctkTemplateWidget.cpp
+++ b/Libs/Widgets/ctkTemplateWidget.cpp
@@ -26,7 +26,9 @@
 #include "ui_ctkTemplateWidget.h"
 #include "ctkLogger.h"
 
-static ctkLogger logger("org.commontk.libs.widgets.ctkTemplateWidget");
+#include <QGlobalStatic>
+
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.libs.widgets.ctkTemplateWidget"))
 
 //-----------------------------------------------------------------------------
 class ctkTemplateWidgetPrivate: public Ui_ctkTemplateWidget

--- a/Libs/Widgets/ctkThumbnailLabel.cpp
+++ b/Libs/Widgets/ctkThumbnailLabel.cpp
@@ -25,7 +25,7 @@
 
 // ctkCore includes
 #include "ctkLogger.h"
-static ctkLogger logger("org.commontk.Widgets.ctkThumbnailLabel");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.Widgets.ctkThumbnailLabel"))
 
 // ctkWidgets includes
 #include "ctkThumbnailLabel.h"

--- a/Libs/Widgets/ctkThumbnailListWidget.cpp
+++ b/Libs/Widgets/ctkThumbnailListWidget.cpp
@@ -45,7 +45,7 @@
 // STD includes
 #include <iostream>
 
-static ctkLogger logger("org.commontk.Widgets.ctkThumbnailListWidget");
+Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.Widgets.ctkThumbnailListWidget"))
 
 //----------------------------------------------------------------------------
 // ctkThumbnailListWidgetPrivate methods
@@ -209,7 +209,7 @@ void ctkThumbnailListWidget::setCurrentThumbnail(int index)
 
   int count = d->ScrollAreaContentWidget->layout()->count();
 
-  logger.debug("Select thumbnail " + QVariant(index).toString() + " of " + QVariant(count).toString());
+  logger->debug("Select thumbnail " + QVariant(index).toString() + " of " + QVariant(count).toString());
 
   if(index >= count)return;
 


### PR DESCRIPTION
## Summary

Fixes `clazy:non-pod-global-static` warnings on file-scope `ctkLogger` globals by converting them to `Q_GLOBAL_STATIC_WITH_ARGS`.

This is one of two PRs split from a combined approach (the companion PR #1410 handles string constants via `constexpr QLatin1String`).

## Problem

`static ctkLogger logger("name")` at file scope has a non-trivial constructor and destructor (it connects to the logging framework at startup), triggering the `non-pod-global-static` clazy warning. This is a real SIOF risk: if another file-scope static calls the logger during its own initialization, the logger may not be constructed yet.

## Approach

`Q_GLOBAL_STATIC_WITH_ARGS` is a Qt macro that wraps the object in a function-local static with a thread-safe once-guard. The object is constructed lazily on first access and destroyed in reverse order at shutdown — SIOF-safe.

```cpp
// Before (triggers non-pod-global-static, SIOF risk):
static ctkLogger logger("org.commontk.dicom.DICOMDatabase");

// After (lazy, thread-safe, SIOF-safe):
Q_GLOBAL_STATIC_WITH_ARGS(ctkLogger, logger, ("org.commontk.dicom.DICOMDatabase"))
```

The macro returns a pointer-like proxy, so all `logger.method()` call sites become `logger->method()`.

## Public Header Notice

Two public headers were also updated:
- `Libs/Core/ctkCorePythonQtDecorators.h`
- `Libs/DICOM/Core/ctkDICOMCorePythonQtDecorators.h`

These headers each declared `static ctkLogger logger(...)` at file scope, visible to any translation unit that includes them. Although `logger` has internal linkage (per-TU, not exported), the type changes from `ctkLogger` to the `QGlobalStatic<ctkLogger>` proxy.

**Impact on downstream code**: Any external code that directly referenced `logger` by name after including these headers (via `logger.method()`) would need to update to `logger->method()`. In practice this is extremely unlikely — `logger` is an internal implementation detail of the decorator methods defined in these headers, not part of any public class interface.

Note: `Q_GLOBAL_STATIC_WITH_ARGS` in a header gives each including TU its own instance (Qt wraps the declaration in an anonymous namespace), preserving the same per-TU isolation as the original `static`.

## Comparison with PR #1398

| Aspect | PR #1398 | This PR |
|--------|----------|---------|
| Logger globals | `Q_GLOBAL_STATIC_WITH_ARGS` | Same |
| String constants | Meyers' singleton | `constexpr QLatin1String` (PR #1410) |
| QStringList | Meyers' singleton | Deferred with deprecation strategy (PR #1411) |

## Files Changed

59 files across:
- `Libs/DICOM/Core/` — ctkDICOMDatabase, ctkDICOMIndexer, all DICOM job/worker files, `ctkDICOMCorePythonQtDecorators.h`
- `Libs/DICOM/Widgets/` — 9 widget files
- `Libs/Core/ctkJobScheduler.cpp`, `ctkCorePythonQtDecorators.h`
- `Libs/Widgets/` — 4 widget files
- `Libs/Visualization/VTK/Core/` and `Widgets/` — 8 files

## Testing

Built successfully against Qt5 (`cmake-build-clazy-qt5`, Apple clang) and Qt6 (`cmake-build-clazy-qt6`) on macOS ARM64.

Part of the fix for #1407. See also companion PR #1410 for `constexpr QLatin1String` string constant fixes, and draft PR #1411 for the `ctkDICOMModalities` API deprecation strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)