### PR TITLE
ENH: Migrate ctkDICOMModalities to ctkDICOMDatabase accessors (stacked on #1418)

### DIFF
--- a/CMake/ctkMacroBuildLib.cmake
+++ b/CMake/ctkMacroBuildLib.cmake
@@ -63,6 +63,7 @@ macro(ctkMacroBuildLib)
   set(my_includes
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${CTK_SOURCE_DIR}/Libs            # for ctkDeprecated.h
     )
 
   # Add the include directories from the library dependencies
@@ -111,8 +112,11 @@ ${${MY_EXPORT_CUSTOM_CONTENT_FROM_VARIABLE}}
     ${MY_RESOURCES}
     )
 
-  target_compile_definitions(${lib_name} PRIVATE
-    HAVE_QT${CTK_QT_VERSION}
+  target_compile_definitions(${lib_name}
+    PUBLIC
+      CTK_DISABLE_DEPRECATED_BEFORE=${CTK_DISABLE_DEPRECATED_BEFORE}
+    PRIVATE
+      HAVE_QT${CTK_QT_VERSION}
     )
 
   # Configure CMake Qt automatic code generation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,14 @@ set(CTK_PATCH_VERSION 0)
 set(CTK_VERSION
     "${CTK_MAJOR_VERSION}.${CTK_MINOR_VERSION}.${CTK_PATCH_VERSION}")
 
+# CTK_DISABLE_DEPRECATED_BEFORE controls which deprecated CTK APIs are compiled in.
+# Format is the hex encoding 0xMMmmpp (one byte each for major / minor / patch).
+# Example: -DCTK_DISABLE_DEPRECATED_BEFORE=0x000100 hides APIs deprecated since 0.1.x.
+# The default 0x000000 keeps all deprecated APIs available.
+# See Libs/ctkDeprecated.h for the CTK_DEPRECATED_SINCE() helper macro.
+set(CTK_DISABLE_DEPRECATED_BEFORE "0x000000" CACHE STRING
+    "Disable CTK APIs deprecated before this version (hex: 0xMMmmpp)")
+
 # Append the library version information to the library target
 # properties.  A parent project may set its own properties and/or may
 # block this.
@@ -289,6 +297,10 @@ foreach(file
   )
   install(FILES ${file} DESTINATION ${CTK_INSTALL_CMAKE_DIR} COMPONENT Development)
 endforeach()
+
+# Public CTK headers that are not specific to any single library.
+install(FILES Libs/ctkDeprecated.h
+  DESTINATION ${CTK_INSTALL_INCLUDE_DIR} COMPONENT Development)
 
 install(FILES
   CMake/ctkLinkerAsNeededFlagCheck/CMakeLists.txt

--- a/Libs/DICOM/Core/CMakeLists.txt
+++ b/Libs/DICOM/Core/CMakeLists.txt
@@ -42,6 +42,8 @@ set(KIT_SRCS
   ctkDICOMJob.h
   ctkDICOMJobResponseSet.cpp
   ctkDICOMJobResponseSet.h
+  ctkDICOMModalities.cpp
+  ctkDICOMModalities.h
   ctkDICOMModel.cpp
   ctkDICOMModel.h
   ctkDICOMPatientFilterProxyModel.cpp

--- a/Libs/DICOM/Core/ctkDICOMDatabase.cpp
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.cpp
@@ -37,6 +37,7 @@
 #include "ctkDICOMAbstractThumbnailGenerator.h"
 #include "ctkDICOMItem.h"
 #include "ctkDICOMJobResponseSet.h"
+#include "ctkDICOMModalities.h"
 
 #include "ctkLogger.h"
 #include "ctkUtils.h"
@@ -85,6 +86,14 @@ ctkDICOMDatabasePrivate::ctkDICOMDatabasePrivate(ctkDICOMDatabase& o)
 {
   this->resetLastInsertedValues();
   this->DisplayedFieldGenerator = new ctkDICOMDisplayedFieldGenerator(q_ptr);
+
+  // Seed application-configurable modality lists with the historical defaults
+  // from ctkDICOMModalities. Applications can override via the corresponding
+  // setters / Q_PROPERTY bindings.
+  this->SupportedModalities = ctkDICOMModalities::AllModalities;
+  this->DefaultModalities = ctkDICOMModalities::CommonImagingModalities;
+  this->ModalitiesExcludedFromThumbnailGeneration =
+    ctkDICOMModalities::ExcludedFromThumbnailGeneration;
 }
 
 //------------------------------------------------------------------------------
@@ -3403,6 +3412,63 @@ const QStringList ctkDICOMDatabase::tagsToExcludeFromStorage()
 {
   Q_D(ctkDICOMDatabase);
   return d->TagsToExcludeFromStorage;
+}
+
+//------------------------------------------------------------------------------
+QStringList ctkDICOMDatabase::supportedModalities() const
+{
+  Q_D(const ctkDICOMDatabase);
+  return d->SupportedModalities;
+}
+
+//------------------------------------------------------------------------------
+void ctkDICOMDatabase::setSupportedModalities(const QStringList& modalities)
+{
+  Q_D(ctkDICOMDatabase);
+  if (d->SupportedModalities == modalities)
+  {
+    return;
+  }
+  d->SupportedModalities = modalities;
+  emit supportedModalitiesChanged();
+}
+
+//------------------------------------------------------------------------------
+QStringList ctkDICOMDatabase::defaultModalities() const
+{
+  Q_D(const ctkDICOMDatabase);
+  return d->DefaultModalities;
+}
+
+//------------------------------------------------------------------------------
+void ctkDICOMDatabase::setDefaultModalities(const QStringList& modalities)
+{
+  Q_D(ctkDICOMDatabase);
+  if (d->DefaultModalities == modalities)
+  {
+    return;
+  }
+  d->DefaultModalities = modalities;
+  emit defaultModalitiesChanged();
+}
+
+//------------------------------------------------------------------------------
+QStringList ctkDICOMDatabase::modalitiesExcludedFromThumbnailGeneration() const
+{
+  Q_D(const ctkDICOMDatabase);
+  return d->ModalitiesExcludedFromThumbnailGeneration;
+}
+
+//------------------------------------------------------------------------------
+void ctkDICOMDatabase::setModalitiesExcludedFromThumbnailGeneration(const QStringList& modalities)
+{
+  Q_D(ctkDICOMDatabase);
+  if (d->ModalitiesExcludedFromThumbnailGeneration == modalities)
+  {
+    return;
+  }
+  d->ModalitiesExcludedFromThumbnailGeneration = modalities;
+  emit modalitiesExcludedFromThumbnailGenerationChanged();
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Core/ctkDICOMDatabase.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase.h
@@ -72,6 +72,12 @@ class CTK_DICOM_CORE_EXPORT ctkDICOMDatabase : public QObject
   Q_PROPERTY(QStringList loadedSeriesInstanceUIDs READ loadedSeriesInstanceUIDs WRITE setLoadedSeriesInstanceUIDs NOTIFY loadedSeriesInstanceUIDsChanged)
   Q_PROPERTY(bool useShortStoragePath READ useShortStoragePath WRITE setUseShortStoragePath)
   Q_PROPERTY(bool useSystemFileCopy READ useSystemFileCopy WRITE setUseSystemFileCopy)
+  Q_PROPERTY(QStringList supportedModalities READ supportedModalities WRITE setSupportedModalities NOTIFY supportedModalitiesChanged)
+  Q_PROPERTY(QStringList defaultModalities READ defaultModalities WRITE setDefaultModalities NOTIFY defaultModalitiesChanged)
+  Q_PROPERTY(QStringList modalitiesExcludedFromThumbnailGeneration
+             READ modalitiesExcludedFromThumbnailGeneration
+             WRITE setModalitiesExcludedFromThumbnailGeneration
+             NOTIFY modalitiesExcludedFromThumbnailGenerationChanged)
 
 public:
   struct IndexingResult
@@ -260,6 +266,28 @@ public:
   /// By default, only PixelData tag is excluded from storage.
   void setTagsToExcludeFromStorage(const QStringList tags);
   const QStringList tagsToExcludeFromStorage();
+
+  /// \brief List of all DICOM modality codes the application knows about.
+  ///
+  /// Defaults to the full set of non-retired DICOM modality codes (DICOM PS3.16
+  /// Annex D). Applications can override this list to restrict the modalities
+  /// shown in the UI or to extend it with custom values.
+  Q_INVOKABLE QStringList supportedModalities() const;
+  Q_INVOKABLE void setSupportedModalities(const QStringList& modalities);
+
+  /// \brief List of modalities that are checked by default in modality filter UI.
+  ///
+  /// Defaults to a curated subset of common imaging modalities (CR, CT, DX,
+  /// MG, MR, NM, PT, RF, SEG, SR, US, XA).
+  Q_INVOKABLE QStringList defaultModalities() const;
+  Q_INVOKABLE void setDefaultModalities(const QStringList& modalities);
+
+  /// \brief List of modalities for which thumbnail generation should be skipped.
+  ///
+  /// Defaults to non-pixel data modalities (SEG, SR, RT*, PR, DOC, REG, ...)
+  /// that have no meaningful image preview.
+  Q_INVOKABLE QStringList modalitiesExcludedFromThumbnailGeneration() const;
+  Q_INVOKABLE void setModalitiesExcludedFromThumbnailGeneration(const QStringList& modalities);
 
   /// Insert into the database if not already existing.
   /// @param dataset The dataset to store into the database. Usually, this is
@@ -533,6 +561,13 @@ Q_SIGNALS:
 
   /// Indicate that the list of loaded seriesInstanceUIDs changed
   void loadedSeriesInstanceUIDsChanged(const QStringList&);
+
+  /// Indicate that the list of supported modalities changed
+  void supportedModalitiesChanged();
+  /// Indicate that the list of default (UI-checked) modalities changed
+  void defaultModalitiesChanged();
+  /// Indicate that the list of modalities excluded from thumbnail generation changed
+  void modalitiesExcludedFromThumbnailGenerationChanged();
 
 protected:
   QScopedPointer<ctkDICOMDatabasePrivate> d_ptr;

--- a/Libs/DICOM/Core/ctkDICOMDatabase_p.h
+++ b/Libs/DICOM/Core/ctkDICOMDatabase_p.h
@@ -173,6 +173,9 @@ public:
   QString TagCacheDatabaseFilename;
   QStringList TagsToPrecache;
   QStringList TagsToExcludeFromStorage;
+  QStringList SupportedModalities;
+  QStringList DefaultModalities;
+  QStringList ModalitiesExcludedFromThumbnailGeneration;
   bool openTagCacheDatabase();
   void precacheTags(const ctkDICOMItem& dataset, const QString sopInstanceUID);
 

--- a/Libs/DICOM/Core/ctkDICOMModalities.cpp
+++ b/Libs/DICOM/Core/ctkDICOMModalities.cpp
@@ -1,0 +1,155 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+// CTK includes
+#include "ctkDICOMModalities.h"
+
+#if CTK_DEPRECATED_SINCE(0, 1)
+
+namespace
+{
+  // Meyers' singletons. Defining the lists in a single translation unit and
+  // exposing them through references prevents the per-TU heap allocation that
+  // the previous in-header `static const QStringList` definitions caused, and
+  // sidesteps clazy's non-pod-global-static warning because a reference to a
+  // function-local static has trivial construction at namespace scope.
+  const QStringList& allModalitiesSingleton()
+  {
+    static const QStringList list = {
+      "Any",      // Special filter value for "all modalities"
+      "AR",       // Autorefraction
+      "ASMT",     // Content Assessment Results
+      "AU",       // Audio
+      "BDUS",     // Bone Densitometry (ultrasound)
+      "BI",       // Biomagnetic imaging
+      "BMD",      // Bone Densitometry (X-Ray)
+      "CR",       // Computed Radiography
+      "CT",       // Computed Tomography
+      "DG",       // Diaphanography
+      "DOC",      // Document
+      "DX",       // Digital Radiography
+      "ECG",      // Electrocardiography
+      "EPS",      // Cardiac Electrophysiology
+      "ES",       // Endoscopy
+      "FID",      // Fiducials
+      "GM",       // General Microscopy
+      "HC",       // Hard Copy
+      "HD",       // Hemodynamic Waveform
+      "IO",       // Intra-Oral Radiography
+      "IOL",      // Intraocular Lens Data
+      "IVOCT",    // Intravascular Optical Coherence Tomography
+      "IVUS",     // Intravascular Ultrasound
+      "KER",      // Keratometry
+      "KO",       // Key Object Selection
+      "LEN",      // Lensometry
+      "LS",       // Laser surface scan
+      "MG",       // Mammography
+      "MR",       // Magnetic Resonance
+      "NM",       // Nuclear Medicine
+      "OAM",      // Ophthalmic Axial Measurements
+      "OCT",      // Optical Coherence Tomography (non-Ophthalmic)
+      "OP",       // Ophthalmic Photography
+      "OPM",      // Ophthalmic Mapping
+      "OPT",      // Ophthalmic Tomography
+      "OPV",      // Ophthalmic Visual Field
+      "OSS",      // Optical Surface Scan
+      "OT",       // Other
+      "PLAN",     // Plan
+      "PR",       // Presentation State
+      "PT",       // Positron emission tomography (PET)
+      "PX",       // Panoramic X-Ray
+      "REG",      // Registration
+      "RESP",     // Respiratory Waveform
+      "RF",       // Radio Fluoroscopy
+      "RG",       // Radiographic imaging (conventional film/screen)
+      "RTDOSE",   // Radiotherapy Dose
+      "RTIMAGE",  // Radiotherapy Image
+      "RTPLAN",   // Radiotherapy Plan
+      "RTRECORD", // RT Treatment Record
+      "RTSTRUCT", // Radiotherapy Structure Set
+      "RWV",      // Real World Value Map
+      "SEG",      // Segmentation
+      "SM",       // Slide Microscopy
+      "SMR",      // Stereometric Relationship
+      "SR",       // SR Document
+      "SRF",      // Subjective Refraction
+      "STAIN",    // Automated Slide Stainer
+      "TG",       // Thermography
+      "US",       // Ultrasound
+      "VA",       // Visual Acuity
+      "XA",       // X-Ray Angiography
+      "XC"        // External-camera Photography
+    };
+    return list;
+  }
+
+  const QStringList& excludedFromThumbnailGenerationSingleton()
+  {
+    static const QStringList list = {
+      "SEG",      // Segmentation
+      "SR",       // Structured Report
+      "RTSTRUCT", // Radiotherapy Structure Set
+      "RTPLAN",   // Radiotherapy Plan
+      "RTDOSE",   // Radiotherapy Dose
+      "RTRECORD", // RT Treatment Record
+      "PR",       // Presentation State
+      "DOC",      // Document
+      "REG",      // Registration
+      "PLAN",     // Plan
+      "FID",      // Fiducials
+      "KO",       // Key Object Selection
+      "RWV",      // Real World Value Map
+      "AU",       // Audio
+      "ECG",      // Electrocardiography
+      "EPS",      // Cardiac Electrophysiology
+      "HD",       // Hemodynamic Waveform
+      "RESP"      // Respiratory Waveform
+    };
+    return list;
+  }
+
+  const QStringList& commonImagingModalitiesSingleton()
+  {
+    static const QStringList list = {
+      "CR",       // Computed Radiography
+      "CT",       // Computed Tomography
+      "DX",       // Digital Radiography
+      "MG",       // Mammography
+      "MR",       // Magnetic Resonance
+      "NM",       // Nuclear Medicine
+      "PT",       // Positron emission tomography
+      "RF",       // Radio Fluoroscopy
+      "SEG",      // Segmentation
+      "SR",       // Structured Report
+      "US",       // Ultrasound
+      "XA"        // X-Ray Angiography
+    };
+    return list;
+  }
+}
+
+namespace ctkDICOMModalities
+{
+  const QStringList& AllModalities = allModalitiesSingleton();
+  const QStringList& ExcludedFromThumbnailGeneration = excludedFromThumbnailGenerationSingleton();
+  const QStringList& CommonImagingModalities = commonImagingModalitiesSingleton();
+}
+
+#endif // CTK_DEPRECATED_SINCE(0, 1)

--- a/Libs/DICOM/Core/ctkDICOMModalities.h
+++ b/Libs/DICOM/Core/ctkDICOMModalities.h
@@ -23,8 +23,10 @@
 
 // Qt includes
 #include <QStringList>
+#include <QtGlobal>
 
 // CTK includes
+#include "ctkDeprecated.h"
 #include "ctkDICOMCoreExport.h"
 
 /// \ingroup DICOM_Core
@@ -35,113 +37,41 @@
 /// as defined in DICOM PS3.16 Annex D - DICOM Controlled Terminology Definitions.
 /// Reference: https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_D.html
 ///
+/// \deprecated These lists are deprecated as of CTK 0.1. Applications should
+/// query the attached ctkDICOMDatabase instance instead, which exposes
+/// configurable equivalents:
+///
+///   ctkDICOMModalities::AllModalities                    ->
+///       ctkDICOMDatabase::supportedModalities()
+///   ctkDICOMModalities::CommonImagingModalities          ->
+///       ctkDICOMDatabase::defaultModalities()
+///   ctkDICOMModalities::ExcludedFromThumbnailGeneration  ->
+///       ctkDICOMDatabase::modalitiesExcludedFromThumbnailGeneration()
+///
+/// The deprecated aliases below are defined as references to Meyers'
+/// singletons in ctkDICOMModalities.cpp, which fixes the clazy
+/// non-pod-global-static warning that the previous in-header
+/// `static const QStringList` definitions produced (one heap-allocated
+/// copy per translation unit, plus static-initialization-order risk).
+///
 namespace ctkDICOMModalities
 {
-  /// Complete list of all current (non-retired) DICOM modality codes
-  static const QStringList AllModalities = {
-    "Any",      // Special filter value for "all modalities"
-    "AR",       // Autorefraction
-    "ASMT",     // Content Assessment Results
-    "AU",       // Audio
-    "BDUS",     // Bone Densitometry (ultrasound)
-    "BI",       // Biomagnetic imaging
-    "BMD",      // Bone Densitometry (X-Ray)
-    "CR",       // Computed Radiography
-    "CT",       // Computed Tomography
-    "DG",       // Diaphanography
-    "DOC",      // Document
-    "DX",       // Digital Radiography
-    "ECG",      // Electrocardiography
-    "EPS",      // Cardiac Electrophysiology
-    "ES",       // Endoscopy
-    "FID",      // Fiducials
-    "GM",       // General Microscopy
-    "HC",       // Hard Copy
-    "HD",       // Hemodynamic Waveform
-    "IO",       // Intra-Oral Radiography
-    "IOL",      // Intraocular Lens Data
-    "IVOCT",    // Intravascular Optical Coherence Tomography
-    "IVUS",     // Intravascular Ultrasound
-    "KER",      // Keratometry
-    "KO",       // Key Object Selection
-    "LEN",      // Lensometry
-    "LS",       // Laser surface scan
-    "MG",       // Mammography
-    "MR",       // Magnetic Resonance
-    "NM",       // Nuclear Medicine
-    "OAM",      // Ophthalmic Axial Measurements
-    "OCT",      // Optical Coherence Tomography (non-Ophthalmic)
-    "OP",       // Ophthalmic Photography
-    "OPM",      // Ophthalmic Mapping
-    "OPT",      // Ophthalmic Tomography
-    "OPV",      // Ophthalmic Visual Field
-    "OSS",      // Optical Surface Scan
-    "OT",       // Other
-    "PLAN",     // Plan
-    "PR",       // Presentation State
-    "PT",       // Positron emission tomography (PET)
-    "PX",       // Panoramic X-Ray
-    "REG",      // Registration
-    "RESP",     // Respiratory Waveform
-    "RF",       // Radio Fluoroscopy
-    "RG",       // Radiographic imaging (conventional film/screen)
-    "RTDOSE",   // Radiotherapy Dose
-    "RTIMAGE",  // Radiotherapy Image
-    "RTPLAN",   // Radiotherapy Plan
-    "RTRECORD", // RT Treatment Record
-    "RTSTRUCT", // Radiotherapy Structure Set
-    "RWV",      // Real World Value Map
-    "SEG",      // Segmentation
-    "SM",       // Slide Microscopy
-    "SMR",      // Stereometric Relationship
-    "SR",       // SR Document
-    "SRF",      // Subjective Refraction
-    "STAIN",    // Automated Slide Stainer
-    "TG",       // Thermography
-    "US",       // Ultrasound
-    "VA",       // Visual Acuity
-    "XA",       // X-Ray Angiography
-    "XC"        // External-camera Photography
-  };
+#if CTK_DEPRECATED_SINCE(0, 1)
 
-  /// Modalities that should be excluded from thumbnail generation
-  /// because they do not have meaningful image thumbnails
-  static const QStringList ExcludedFromThumbnailGeneration = {
-    "SEG",      // Segmentation
-    "SR",       // Structured Report
-    "RTSTRUCT", // Radiotherapy Structure Set
-    "RTPLAN",   // Radiotherapy Plan
-    "RTDOSE",   // Radiotherapy Dose
-    "RTRECORD", // RT Treatment Record
-    "PR",       // Presentation State
-    "DOC",      // Document
-    "REG",      // Registration
-    "PLAN",     // Plan
-    "FID",      // Fiducials
-    "KO",       // Key Object Selection
-    "RWV",      // Real World Value Map
-    "AU",       // Audio
-    "ECG",      // Electrocardiography
-    "EPS",      // Cardiac Electrophysiology
-    "HD",       // Hemodynamic Waveform
-    "RESP"      // Respiratory Waveform
-  };
+  /// \deprecated Use ctkDICOMDatabase::supportedModalities() instead.
+  /// Complete list of all current (non-retired) DICOM modality codes.
+  CTK_DICOM_CORE_EXPORT extern const QStringList& AllModalities;
 
-  /// Common imaging modalities typically used for filtering in UI
-  static const QStringList CommonImagingModalities = {
-    "CR",       // Computed Radiography
-    "CT",       // Computed Tomography
-    "DX",       // Digital Radiography
-    "MG",       // Mammography
-    "MR",       // Magnetic Resonance
-    "NM",       // Nuclear Medicine
-    "PT",       // Positron emission tomography
-    "RF",       // Radio Fluoroscopy
-    "SEG",      // Segmentation
-    "SR",       // Structured Report
-    "US",       // Ultrasound
-    "XA"        // X-Ray Angiography
-  };
+  /// \deprecated Use ctkDICOMDatabase::modalitiesExcludedFromThumbnailGeneration()
+  /// instead. Modalities that should be excluded from thumbnail generation
+  /// because they do not have meaningful image thumbnails.
+  CTK_DICOM_CORE_EXPORT extern const QStringList& ExcludedFromThumbnailGeneration;
+
+  /// \deprecated Use ctkDICOMDatabase::defaultModalities() instead.
+  /// Common imaging modalities typically used for filtering in UI.
+  CTK_DICOM_CORE_EXPORT extern const QStringList& CommonImagingModalities;
+
+#endif
 }
 
 #endif // __ctkDICOMModalities_h

--- a/Libs/DICOM/Core/ctkDICOMPatientModel.cpp
+++ b/Libs/DICOM/Core/ctkDICOMPatientModel.cpp
@@ -143,7 +143,10 @@ ctkDICOMPatientModelPrivate::ctkDICOMPatientModelPrivate(ctkDICOMPatientModel& o
   this->IsUpdating = false;
   this->QueryInProgress = false;
 
-  this->ModalityFilter = ctkDICOMModalities::AllModalities;
+  // Fallback to ctkDICOMModalities::AllModalities until a database is attached.
+  this->ModalityFilter = this->DicomDatabase
+    ? this->DicomDatabase->supportedModalities()
+    : ctkDICOMModalities::AllModalities;
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Core/ctkDICOMScheduler.cpp
+++ b/Libs/DICOM/Core/ctkDICOMScheduler.cpp
@@ -478,8 +478,13 @@ void ctkDICOMScheduler::generateThumbnail(const QString &originalFilePath,
 {
   Q_D(ctkDICOMScheduler);
 
-  // Do not generate thumbnails for modalities that do not have meaningful image thumbnails
-  if (ctkDICOMModalities::ExcludedFromThumbnailGeneration.contains(modality))
+  // Do not generate thumbnails for modalities that do not have meaningful image thumbnails.
+  // Prefer the database's configured exclusion list when a database is attached;
+  // otherwise fall back to ctkDICOMModalities::ExcludedFromThumbnailGeneration.
+  const QStringList excludedModalities = d->DicomDatabase
+    ? d->DicomDatabase->modalitiesExcludedFromThumbnailGeneration()
+    : ctkDICOMModalities::ExcludedFromThumbnailGeneration;
+  if (excludedModalities.contains(modality))
   {
     // Do not generate thumbnails for excluded modalities
     // To Do: refactor the ctkDICOMThumbnailGenerator to handle properly these cases

--- a/Libs/DICOM/Core/ctkDICOMSeriesModel.cpp
+++ b/Libs/DICOM/Core/ctkDICOMSeriesModel.cpp
@@ -132,7 +132,12 @@ ctkDICOMSeriesModelPrivate::ctkDICOMSeriesModelPrivate(ctkDICOMSeriesModel& obj)
   this->Scheduler = nullptr;
   this->PatientID = "";
   this->StudyFilter = "";
-  this->ModalityFilter = ctkDICOMModalities::AllModalities;
+  // Fallback to ctkDICOMModalities::AllModalities until a database is attached
+  // via setDicomDatabase(); once attached, callers may opt in to the database's
+  // configured supportedModalities() via setModalityFilter().
+  this->ModalityFilter = this->DicomDatabase
+    ? this->DicomDatabase->supportedModalities()
+    : ctkDICOMModalities::AllModalities;
   this->SeriesDescriptionFilter = "";
 }
 

--- a/Libs/DICOM/Core/ctkDICOMStudyModel.cpp
+++ b/Libs/DICOM/Core/ctkDICOMStudyModel.cpp
@@ -141,7 +141,10 @@ ctkDICOMStudyModelPrivate::ctkDICOMStudyModelPrivate(ctkDICOMStudyModel& obj)
   this->NumberOfOpenedStudies = 2;
   this->ThumbnailSize = 128;
   this->IsUpdating = false;
-  this->ModalityFilter = ctkDICOMModalities::AllModalities;
+  // Fallback to ctkDICOMModalities::AllModalities until a database is attached.
+  this->ModalityFilter = this->DicomDatabase
+    ? this->DicomDatabase->supportedModalities()
+    : ctkDICOMModalities::AllModalities;
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
@@ -235,7 +235,11 @@ ctkDICOMVisualBrowserWidgetPrivate::ctkDICOMVisualBrowserWidgetPrivate(ctkDICOMV
   this->CustomDateRangeWidget = nullptr;
   this->FilteringStartDateEdit = nullptr;
   this->FilteringEndDateEdit = nullptr;
-  this->FilteringModalities = ctkDICOMModalities::AllModalities;
+  // The DicomDatabase was just constructed above; prefer its configured list,
+  // and fall back to ctkDICOMModalities::AllModalities if it is somehow unset.
+  this->FilteringModalities = this->DicomDatabase
+    ? this->DicomDatabase->supportedModalities()
+    : ctkDICOMModalities::AllModalities;
 
   this->PatientsAddedDuringImport = 0;
   this->StudiesAddedDuringImport = 0;
@@ -324,8 +328,13 @@ void ctkDICOMVisualBrowserWidgetPrivate::init()
   // To Do: add an option to disable styling
   this->FilteringModalityCheckableComboBox->setStyleSheet("combobox-popup: 0;");
 
-  QStringList allModalities = ctkDICOMModalities::AllModalities;
-  QStringList commonModalities = ctkDICOMModalities::CommonImagingModalities;
+  // Prefer the database's configured lists; fall back to ctkDICOMModalities defaults.
+  QStringList allModalities = this->DicomDatabase
+    ? this->DicomDatabase->supportedModalities()
+    : ctkDICOMModalities::AllModalities;
+  QStringList commonModalities = this->DicomDatabase
+    ? this->DicomDatabase->defaultModalities()
+    : ctkDICOMModalities::CommonImagingModalities;
 
   QSet<QString> otherModalitiesSet = QSet<QString>(allModalities.begin(), allModalities.end());
   otherModalitiesSet.subtract(QSet<QString>(commonModalities.begin(), commonModalities.end()));
@@ -666,7 +675,10 @@ void ctkDICOMVisualBrowserWidgetPrivate::updateModalityCheckableComboBox()
 
   bool shouldCheckAllCommon = this->PreviousFilteringModalities.contains("Any") &&
                               !this->FilteringModalities.contains("Any");
-  bool shouldUncheckAll = this->PreviousFilteringModalities == ctkDICOMModalities::CommonImagingModalities;
+  const QStringList commonImagingModalitiesRef = this->DicomDatabase
+    ? this->DicomDatabase->defaultModalities()
+    : ctkDICOMModalities::CommonImagingModalities;
+  bool shouldUncheckAll = this->PreviousFilteringModalities == commonImagingModalitiesRef;
   bool shouldCheckAll = !this->PreviousFilteringModalities.contains("Any") &&
                          this->FilteringModalities.contains("Any");
   if (shouldUncheckAll)
@@ -692,7 +704,7 @@ void ctkDICOMVisualBrowserWidgetPrivate::updateModalityCheckableComboBox()
   }
   else if (shouldCheckAllCommon)
   {
-    this->FilteringModalities = ctkDICOMModalities::CommonImagingModalities;
+    this->FilteringModalities = commonImagingModalitiesRef;
   }
 
   // First, uncheck all items
@@ -921,8 +933,11 @@ void ctkDICOMVisualBrowserWidgetPrivate::resetFilters()
   this->FilteringDate = ctkDICOMVisualBrowserWidget::Any;
   this->FilteringDateComboBox->setCurrentIndex(static_cast<int>(this->FilteringDate));
   this->PatientModel->setDateFilter(static_cast<ctkDICOMPatientModel::DateType>(this->FilteringDate));
-  this->PreviousFilteringModalities = ctkDICOMModalities::AllModalities;
-  this->FilteringModalities = ctkDICOMModalities::AllModalities;
+  const QStringList allSupportedModalities = this->DicomDatabase
+    ? this->DicomDatabase->supportedModalities()
+    : ctkDICOMModalities::AllModalities;
+  this->PreviousFilteringModalities = allSupportedModalities;
+  this->FilteringModalities = allSupportedModalities;
 
   this->updateModalityCheckableComboBox();
 

--- a/Libs/ctkDeprecated.h
+++ b/Libs/ctkDeprecated.h
@@ -1,0 +1,56 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+#ifndef __ctkDeprecated_h
+#define __ctkDeprecated_h
+
+// CTK API deprecation framework, modeled after Qt's QT_DEPRECATED_SINCE.
+//
+// Usage in a CTK header:
+//
+//   #include <ctkDeprecated.h>
+//
+//   #if CTK_DEPRECATED_SINCE(0, 1)
+//     CTK_FOO_EXPORT void oldApi();   // deprecated as of CTK 0.1
+//   #endif
+//
+// Downstream projects can hide deprecated APIs by defining
+// CTK_DISABLE_DEPRECATED_BEFORE at compile time, e.g.
+//
+//   -DCTK_DISABLE_DEPRECATED_BEFORE=0x000100   # hide APIs deprecated since 0.1.x
+//
+// The CTK build propagates the configured value as a PUBLIC compile
+// definition so consumers automatically inherit the project-wide setting
+// (see CMake/ctkMacroBuildLib.cmake).
+
+// Encode a (major, minor, patch) triple into a comparable hex value.
+#define CTK_VERSION_CHECK(major, minor, patch) ((major << 16) | (minor << 8) | (patch))
+
+// Default: keep all deprecated APIs available.
+#ifndef CTK_DISABLE_DEPRECATED_BEFORE
+#  define CTK_DISABLE_DEPRECATED_BEFORE 0x000000
+#endif
+
+// Evaluates to true when an API deprecated in (major, minor) should still
+// be compiled in (i.e. has not been hidden by CTK_DISABLE_DEPRECATED_BEFORE).
+#define CTK_DEPRECATED_SINCE(major, minor) \
+    (CTK_VERSION_CHECK(major, minor, 0) > CTK_DISABLE_DEPRECATED_BEFORE)
+
+#endif


### PR DESCRIPTION
Migrates the `ctkDICOMModalities` namespace from a header-only definition to deprecated free functions, with the supported-modality lists moved onto `ctkDICOMDatabase` as the new home. **Stacked on #1418** (the `CTK_DEPRECATED_SINCE` framework).

This PR was previously the four-commit "framework + migration" series. The framework commit has been split out to #1418 to make review easier; this PR now contains only the three migration commits and will rebase to a clean series once #1418 merges.

<details>
<summary>What this PR changes</summary>

1. **`ENH: Add modality list accessors to ctkDICOMDatabase`** — adds `supportedModalities()`, `defaultModalities()`, and `modalitiesExcludedFromThumbnailGeneration()` as the new authoritative home for the lists, per @lassoan's review on the original draft of #1411 ([comment](https://github.com/commontk/CTK/pull/1411#issuecomment-2780896127)).
2. **`ENH: Migrate DICOM modality call sites to ctkDICOMDatabase accessors`** — switches every in-tree caller to the new `ctkDICOMDatabase` accessors.
3. **`ENH: Deprecate ctkDICOMModalities namespace and move definitions out-of-line`** — wraps the legacy free functions in `#if CTK_DEPRECATED_SINCE(0, 1)` and moves their bodies to a `.cpp` so they no longer pollute the header. External consumers continue to compile until they raise `CTK_DISABLE_DEPRECATED_BEFORE`.

</details>

<details>
<summary>Stacking / merge order</summary>

| PR | Scope | Status |
|----|-------|--------|
| #1418 | `CTK_DEPRECATED_SINCE` framework only | depends on nothing; merge first |
| **this PR (#1411)** | `ctkDICOMModalities` → `ctkDICOMDatabase` migration | depends on #1418 |

Both PRs target `master`. While #1418 is open, the framework commit appears in both PRs' commit lists; once #1418 merges, GitHub will rebase this branch and only the three migration commits will remain.

</details>

<!--
provenance: claude-code session 2026-05-05, refresh of #1411 after framework split into #1418
depends_on: #1418
related_files:
  - Libs/DICOM/Core/ctkDICOMDatabase.{h,cpp}
  - Libs/DICOM/Core/ctkDICOMModalities.{h,cpp}
post_merge_action: none -- closes the multi-year ctkDICOMModalities cleanup
-->
