### PR TITLE
BUG: Stop executeFile from leaving its script directory on sys.path

### DIFF
--- a/Libs/Scripting/Python/Core/Testing/Cpp/ctkAbstractPythonManagerTest.cpp
+++ b/Libs/Scripting/Python/Core/Testing/Cpp/ctkAbstractPythonManagerTest.cpp
@@ -51,6 +51,8 @@ private Q_SLOTS:
   void testExecuteFile();
   void testExecuteFile_data();
 
+  void testExecuteFileDoesNotLeakSysPath();
+
   void testPythonAttributes();
   void testPythonAttributes_data();
 
@@ -269,6 +271,38 @@ void ctkAbstractPythonManagerTester::testExecuteFile_data()
 
   QTest::newRow("3-check __file__ attribute") << QString("print('This file is: %s' % __file__)")
                      << false;
+}
+
+// ----------------------------------------------------------------------------
+void ctkAbstractPythonManagerTester::testExecuteFileDoesNotLeakSysPath()
+{
+  QTemporaryFile pythonFile("testExecuteFileLeak-XXXXXX.py");
+  QVERIFY(pythonFile.open());
+  QTextStream out(&pythonFile);
+  out << "pass\n";
+  pythonFile.close();
+
+  const QString scriptDir = QFileInfo(pythonFile.fileName()).absolutePath();
+  const QString inSysPathExpr =
+      QString("%1 in sys.path").arg(ctkAbstractPythonManager::toPythonStringLiteral(scriptDir));
+
+  this->PythonManager.executeString("import sys");
+
+  QVariant beforeContains = this->PythonManager.executeString(
+        inSysPathExpr, ctkAbstractPythonManager::EvalInput);
+  QCOMPARE(beforeContains, QVariant(false));
+
+  this->PythonManager.executeFile(pythonFile.fileName());
+  QCOMPARE(this->PythonManager.pythonErrorOccured(), false);
+
+  QVariant afterContains = this->PythonManager.executeString(
+        inSysPathExpr, ctkAbstractPythonManager::EvalInput);
+  QCOMPARE(afterContains, QVariant(false));
+
+  QVariant helperExists = this->PythonManager.executeString(
+        "'_ctk_executefile_dir' in globals()",
+        ctkAbstractPythonManager::EvalInput);
+  QCOMPARE(helperExists, QVariant(false));
 }
 
 // ----------------------------------------------------------------------------

--- a/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
+++ b/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp
@@ -327,12 +327,21 @@ void ctkAbstractPythonManager::executeFile(const QString& filename)
   if (main)
   {
     QString path = QFileInfo(filename).absolutePath();
+    // try/finally: without it the sys.path prepend would leak for the rest of the process lifetime.
     QStringList code = QStringList()
         << "import sys"
-        << QString("sys.path.insert(0, %1)").arg(ctkAbstractPythonManager::toPythonStringLiteral(path))
-        << "_updated_globals = globals()"
-        << QString("_updated_globals['__file__'] = %1").arg(ctkAbstractPythonManager::toPythonStringLiteral(filename))
-        << QString("exec(open(%1).read(), _updated_globals)").arg(ctkAbstractPythonManager::toPythonStringLiteral(filename));
+        << QString("_ctk_executefile_dir = %1").arg(ctkAbstractPythonManager::toPythonStringLiteral(path))
+        << "sys.path.insert(0, _ctk_executefile_dir)"
+        << "try:"
+        << "    _updated_globals = globals()"
+        << QString("    _updated_globals['__file__'] = %1").arg(ctkAbstractPythonManager::toPythonStringLiteral(filename))
+        << QString("    exec(open(%1).read(), _updated_globals)").arg(ctkAbstractPythonManager::toPythonStringLiteral(filename))
+        << "finally:"
+        << "    try:"
+        << "        sys.path.remove(_ctk_executefile_dir)"
+        << "    except ValueError:"
+        << "        pass"
+        << "    del _ctk_executefile_dir";
     this->executeString(code.join("\n"));
     //PythonQt::self()->handleError(); // Clear errorOccured flag
   }


### PR DESCRIPTION
## Summary

`ctkAbstractPythonManager::executeFile` prepends the executed script's directory to `sys.path` so that the script can import its siblings, mirroring how CPython runs a top-level script. The current implementation never removes that entry, so in long-running CTK-based applications the directory stays on `sys.path` for the rest of the process, and each subsequent `executeFile` call adds another entry.

## Why it matters

Once a directory is permanently on `sys.path`, every file inside it becomes importable as a top-level module — and silently shadows any PyPI package with the same name. The failure mode is invisible until something happens to collide, at which point imports start resolving to the wrong file with no warning.

This was discovered while working on 3D Slicer [PR #9010](https://github.com/Slicer/Slicer/pull/9010). Slicer runs its startup script `slicerqt.py` via `executeFile`, and that script used to live inside the `slicer/` package directory — so `slicer/` was permanently on `sys.path`, and any new file added to that package (for example `slicer/packaging.py`) would have shadowed the corresponding third-party PyPI package. The Slicer PR worked around the symptom by relocating `slicerqt.py`, but every CTK consumer is exposed to the same problem, so the right fix lives here.

## The fix

Wrap the `sys.path.insert(0, ...)` and the `exec()` of the user script in a Python `try`/`finally` block. The directory is added before the script runs (preserving today's behaviour for the script itself) and is removed once the script finishes, regardless of whether it raised. The cleanup uses `sys.path.remove(value)` rather than `pop(0)` so that entries the script itself added cannot corrupt the cleanup, and it tolerates the case where the script already removed the entry.

## Tests

Adds a regression test `testExecuteFileDoesNotLeakSysPath` to `ctkAbstractPythonManagerTest` that calls `executeFile` and verifies `sys.path` is unchanged afterwards. The test was confirmed to fail on the unfixed code and pass with this patch applied.

## Related

- 3D Slicer PR with the original workaround and discussion: https://github.com/Slicer/Slicer/pull/9010