### PR TITLE
COMP: Fix Windows dllimport build error

### DIFF
--- a/CMakeExternals/QtTesting.cmake
+++ b/CMakeExternals/QtTesting.cmake
@@ -27,7 +27,7 @@ if(NOT DEFINED QtTesting_DIR)
   if("${CMAKE_CXX_STANDARD}" STREQUAL "98")
     set(revision_tag c44b32fdea827be737e8c2f5608ffbc2e3bd08b2)
   else()
-    set(revision_tag cf5fa4156734edb9c3515c7104c19783b17ed0c1) # ctk-2026-03-27 Qt5+Qt6 support
+    set(revision_tag 6d1531564ae61f702fdd0d63f573fef08853460f) # ctk-2026-02-09-4e0a3eb
   endif()
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})


### PR DESCRIPTION
This uses an updated branch of QtTesting (https://github.com/commontk/QtTesting/commits/ctk-2026-02-09-4e0a3eb/) based on a newer upstream of https://github.com/Kitware/QtTesting. Existing usage has been using https://github.com/commontk/QtTesting/commit/cf5fa4156734edb9c3515c7104c19783b17ed0c1 of https://github.com/commontk/QtTesting/commits/ctk-2025-07-17-4bdc580.
```
Commontk/QtTesting:
$ git shortlog cf5fa41..6d15315 --no-merges
Ben Boeckel (14):
      cmake: check if the export variable is defined
      cmake: integrate into ParaView's build system
      cmake: add include directory usage requirements
      pqObjectNaming: ensure horizontal alignment when printing object names
      cmake: compile with `QT_NO_KEYWORDS`
      qt: remove use of deprecated `null` sentinel
      gitattributes: use clang-format-9
      clang-format: sync with ParaView
      qt6: adapt for deprecation of `QMouseEvent` ctor without globalPos
      qt6: adapt for `Q*Event::pos` deprecation
      qt6: adapt for `QMouseEvent::globalPos` deprecation
      pqEventTranslator: fix typos in comments
      cmake: don't make an export at all if it isn't being installed
      cmake: use VTK module CMake APIs

Cory Quammen (1):
      cmake: get QtTesting example to work

Dan Lipsa (1):
      Use keyword signature for target_link_libraries

Hans J. Johnson (1):
      [commontk] COMP: Set C++ standard to 17 in CMakeLists.txt

Hans Johnson (1):
      [commontk] STYLE: Update cmake style with linter

James Butler (1):
      [commontk] BUG: Fix dllimport error in MOC-generated files on Windows

Julien Schueller (2):
      Qt6 port
      Drop remaining qt4 paths

Kitware Robot (1):
      clang-format: apply clang-format-9's formatting to the repository

Louis Gombert (1):
      Fix for Qt6.10.1: Explicitly cast unscoped enums to int

Mathieu Westphal (20):
      cmake: use autogen instead of manual wrapping calls
      Use last suffix for xml test file extension when recording
      pqAbstractItemViewEventPlayerBase: add support for labels.
      qt: remove usage of `signals`, `slots`, `foreach`, and `emit`
      Add context for play error messages
      Fix some emit keywords
      Support building QtTesting as a separate lib
      Fixup cmake
      Fix some C++17 code
      Adding doc
      Fix a small issue with QRegularExpression
      Adding logic for dashboard mode
      Fixup dashboard mode to update correctly
      Increase cmake min ver to avoid warnings
      Fix a few warnings
      Update Copyright.txt
      Update license headers
      Update license
```