### PR TITLE
COMP: Update PythonQt to fix crash when delegate subclass implements displayText

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -91,7 +91,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
 
   ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
 
-  set(revision_tag ec7e1416e17fae645f3b99a8df4533719e17cbf6) # patched-v3.6.1-2025-12-22-469f01f6a
+  set(revision_tag 7ef4c5ee066b8ef1e7dc609b14071d504f59d4ba) # patched-v4.0.1-2026-03-16-5cd9b581f
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()


### PR DESCRIPTION
re https://github.com/commontk/PythonQt/issues/68

```
List of changes from the updated MeVisLab/PythonQt upstream: 
$ git shortlog 469f01f6a..5cd9b581f
James Butler (1):
      Adjustments for Qt 6.10

Jan Plath (1):
      Fix invalid handling of alreadyAllocatedCPPObject in PythonQtConv::ConvertPythonToQt

Julien (1):
      Register QObjectList type conditionally (# 339)

Uwe Siems (2):
      I turns out that the syncqt tool does not create a correct hex version
      Minor generation fixes for Qt 6.10

dependabot[bot] (2):
      chore(deps): bump actions/upload-artifact from 5 to 6
      chore(deps): bump actions/upload-artifact from 6 to 7

pre-commit-ci[bot] (2):
      [pre-commit.ci] pre-commit autoupdate
      [pre-commit.ci] pre-commit autoupdate
```