### PR TITLE
ENH: Add CTK_DEPRECATED_SINCE API deprecation framework

### DIFF
--- a/CMake/LastConfigureStep/CTKGenerateCTKConfig.cmake
+++ b/CMake/LastConfigureStep/CTKGenerateCTKConfig.cmake
@@ -150,6 +150,8 @@ foreach(lib ${CTK_LIBRARIES} CTKTesting)
   list(APPEND _include_dirs ${${lib}_INCLUDE_DIRS})
   set(CTK_CONFIG_CODE "${CTK_CONFIG_CODE}set(${lib}_INCLUDE_DIRS \"${${lib}_INCLUDE_DIRS}\")\n")
 endforeach()
+# ctkDeprecated.h lives directly under Libs/; build-tree consumers need it on the include path.
+list(APPEND _include_dirs ${CTK_SOURCE_DIR}/Libs)
 list(REMOVE_DUPLICATES _include_dirs)
 set(CTK_CONFIG_CODE "${CTK_CONFIG_CODE}set(CTK_INCLUDE_DIRS \"${_include_dirs}\")\n")
 set(CTK_CONFIG_CODE "${CTK_CONFIG_CODE}# CTK library directories that could be used for linking\n")

--- a/CMake/ctkMacroBuildLib.cmake
+++ b/CMake/ctkMacroBuildLib.cmake
@@ -63,6 +63,7 @@ macro(ctkMacroBuildLib)
   set(my_includes
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${CTK_SOURCE_DIR}/Libs            # for ctkDeprecated.h
     )
 
   # Add the include directories from the library dependencies
@@ -111,8 +112,11 @@ ${${MY_EXPORT_CUSTOM_CONTENT_FROM_VARIABLE}}
     ${MY_RESOURCES}
     )
 
-  target_compile_definitions(${lib_name} PRIVATE
-    HAVE_QT${CTK_QT_VERSION}
+  target_compile_definitions(${lib_name}
+    PUBLIC
+      CTK_DISABLE_DEPRECATED_BEFORE=${CTK_DISABLE_DEPRECATED_BEFORE}
+    PRIVATE
+      HAVE_QT${CTK_QT_VERSION}
     )
 
   # Configure CMake Qt automatic code generation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,14 @@ set(CTK_PATCH_VERSION 0)
 set(CTK_VERSION
     "${CTK_MAJOR_VERSION}.${CTK_MINOR_VERSION}.${CTK_PATCH_VERSION}")
 
+# CTK_DISABLE_DEPRECATED_BEFORE controls which deprecated CTK APIs are compiled in.
+# Format is the hex encoding 0xMMmmpp (one byte each for major / minor / patch).
+# Example: -DCTK_DISABLE_DEPRECATED_BEFORE=0x000100 hides APIs deprecated in or before 0.1.0.
+# The default 0x000000 keeps all deprecated APIs available.
+# See Libs/ctkDeprecated.h for the CTK_DEPRECATED_SINCE() helper macro.
+set(CTK_DISABLE_DEPRECATED_BEFORE "0x000000" CACHE STRING
+    "Disable CTK APIs deprecated in or before this version (hex: 0xMMmmpp)")
+
 # Append the library version information to the library target
 # properties.  A parent project may set its own properties and/or may
 # block this.
@@ -289,6 +297,10 @@ foreach(file
   )
   install(FILES ${file} DESTINATION ${CTK_INSTALL_CMAKE_DIR} COMPONENT Development)
 endforeach()
+
+# Public CTK headers that are not specific to any single library.
+install(FILES Libs/ctkDeprecated.h
+  DESTINATION ${CTK_INSTALL_INCLUDE_DIR} COMPONENT Development)
 
 install(FILES
   CMake/ctkLinkerAsNeededFlagCheck/CMakeLists.txt

--- a/Libs/ctkDeprecated.h
+++ b/Libs/ctkDeprecated.h
@@ -1,0 +1,56 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+#ifndef __ctkDeprecated_h
+#define __ctkDeprecated_h
+
+// CTK API deprecation framework, modeled after Qt's QT_DEPRECATED_SINCE.
+//
+// Usage in a CTK header:
+//
+//   #include <ctkDeprecated.h>
+//
+//   #if CTK_DEPRECATED_SINCE(0, 1)
+//     CTK_FOO_EXPORT void oldApi();   // deprecated as of CTK 0.1
+//   #endif
+//
+// Downstream projects can hide deprecated APIs by defining
+// CTK_DISABLE_DEPRECATED_BEFORE at compile time, e.g.
+//
+//   -DCTK_DISABLE_DEPRECATED_BEFORE=0x000100   # hide APIs deprecated in or before 0.1.0
+//
+// The CTK build propagates the configured value as a PUBLIC compile
+// definition so consumers automatically inherit the project-wide setting
+// (see CMake/ctkMacroBuildLib.cmake).
+
+// Encode a (major, minor, patch) triple into a comparable hex value.
+#define CTK_VERSION_CHECK(major, minor, patch) (((major) << 16) | ((minor) << 8) | (patch))
+
+// Default: keep all deprecated APIs available.
+#ifndef CTK_DISABLE_DEPRECATED_BEFORE
+#  define CTK_DISABLE_DEPRECATED_BEFORE 0x000000
+#endif
+
+// Evaluates to true when an API deprecated in (major, minor) is still compiled
+// in; APIs deprecated in or before CTK_DISABLE_DEPRECATED_BEFORE are hidden.
+#define CTK_DEPRECATED_SINCE(major, minor) \
+    (CTK_VERSION_CHECK(major, minor, 0) > CTK_DISABLE_DEPRECATED_BEFORE)
+
+#endif


### PR DESCRIPTION
Adds the `CTK_DEPRECATED_SINCE` infrastructure (modeled on `QT_DEPRECATED_SINCE`) so future PRs can evolve CTK public APIs without breaking external projects. **No CTK API is migrated by this PR** — this lands the framework only.

The `ctkDICOMModalities` migration that previously rode on top is moved to a follow-up PR (a refresh of #1411) that will be stacked on this branch.

<details>
<summary>What this PR adds</summary>

**`Libs/ctkDeprecated.h`** (new) — standalone public header:

```cpp
#define CTK_VERSION_CHECK(major, minor, patch) ((major << 16) | (minor << 8) | (patch))

#ifndef CTK_DISABLE_DEPRECATED_BEFORE
#  define CTK_DISABLE_DEPRECATED_BEFORE 0x000000
#endif

#define CTK_DEPRECATED_SINCE(major, minor) \
    (CTK_VERSION_CHECK(major, minor, 0) > CTK_DISABLE_DEPRECATED_BEFORE)
```

**`CMakeLists.txt`** — new cache variable:

```cmake
set(CTK_DISABLE_DEPRECATED_BEFORE "0x000000" CACHE STRING
    "Disable CTK APIs deprecated before this version (hex: 0xMMmmpp)")
```

**`CMake/ctkMacroBuildLib.cmake`** — propagates the value as a PUBLIC compile definition so downstream consumers inherit the setting, and puts `${CTK_SOURCE_DIR}/Libs` on each library's include path so `ctkDeprecated.h` is reachable everywhere.

The header is installed to `${CTK_INSTALL_INCLUDE_DIR}` so installed CTK headers can use the macros.

</details>

<details>
<summary>How a future PR uses this</summary>

```cpp
#include <ctkDeprecated.h>

class CTK_FOO_EXPORT ctkFoo
{
public:
  void newApi();

#if CTK_DEPRECATED_SINCE(0, 1)
  Q_DECL_DEPRECATED_X("Use newApi() instead")
  void oldApi();
#endif
};
```

Consumers who want to verify they have purged all deprecated calls can build with `-DCTK_DISABLE_DEPRECATED_BEFORE=0x000100`.

</details>

<details>
<summary>Why ctkDeprecated.h is its own header (not in ctkExport.h.in)</summary>

`ctkExport.h.in` is configured per-library into `<libname>Export.h`, so putting the macros there would multiply-define them across libraries. A standalone header included once where needed is cleaner. Suggested by @lassoan during review of the original #1411.

</details>

<details>
<summary>Relationship to PR #1411</summary>

This PR is the framework-only split of the original #1411. PR #1411 will be reset to contain only the `ctkDICOMModalities` → `ctkDICOMDatabase` migration commits, stacked on top of this branch. Once this PR merges, #1411 will rebase to a clean three-commit migration series.

</details>

<!--
provenance: claude-code session 2026-05-05, split of #1411 deprecation tooling
related_files:
  - Libs/ctkDeprecated.h            (new)
  - CMakeLists.txt                  (CTK_DISABLE_DEPRECATED_BEFORE cache var)
  - CMake/ctkMacroBuildLib.cmake    (Libs/ on include path; PUBLIC compile def)
post_merge_action: rebase #1411 onto master so it shows only the 3 migration commits
-->
