### PR TITLE
COMP: Add dependabot workflow for updating GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "COMP: "
+      prefix: "COMP"


### PR DESCRIPTION
I've observed some warnings in the GitHub actions runs due to some outdated github actions tools. Adding a dependabot workflow here will help keep things up-to-date with a easy to review and merge automatic PRs.