### PR TITLE
Fix cropped terminal output with special characters

### DIFF
--- a/Libs/Core/ctkErrorLogFDMessageHandler.cpp
+++ b/Libs/Core/ctkErrorLogFDMessageHandler.cpp
@@ -50,7 +50,7 @@ ctkFDHandler::ctkFDHandler(ctkErrorLogFDMessageHandler* messageHandler,
   this->MessageHandler = messageHandler;
   this->LogLevel = logLevel;
   this->TerminalOutput = terminalOutput;
-  this->SavedFDNumber = 0;
+  this->SavedFDNumber = -1;
   this->Pipe[0] = -1;
   this->Pipe[1] = -1;
   this->Enabled = false;
@@ -83,14 +83,15 @@ FILE* ctkFDHandler::terminalOutputFile()
 }
 
 // --------------------------------------------------------------------------
-void ctkFDHandler::setEnabled(bool value)
+void ctkFDHandler::setEnabled(bool enable)
 {
-  if (this->Enabled == value)
+  if (this->Enabled == enable)
   {
     return;
   }
 
-  if (value)
+  int terminalOutputFileDescriptor = -1;
+  if (enable)
   {
     this->setupPipe();
 
@@ -108,6 +109,7 @@ void ctkFDHandler::setEnabled(bool value)
     dup2(this->Pipe[1], fileno(this->terminalOutputFile()));
     close(this->Pipe[1]);
 #endif
+    terminalOutputFileDescriptor = this->SavedFDNumber;
 
     // Start polling thread
     this->Enabled = true;
@@ -132,11 +134,10 @@ void ctkFDHandler::setEnabled(bool value)
       this->Enabled = false;
     }
 
-    QString newline("\n");
 #ifdef Q_OS_WIN32
-    unused = _write(_fileno(this->terminalOutputFile()), qPrintable(newline), newline.size());
+    unused = _write(_fileno(this->terminalOutputFile()), "\n", 1);
 #else
-    unused = write(fileno(this->terminalOutputFile()), qPrintable(newline), newline.size());
+    unused = write(fileno(this->terminalOutputFile()), "\n", 1);
 #endif
     Q_UNUSED(unused);
 
@@ -154,21 +155,25 @@ void ctkFDHandler::setEnabled(bool value)
     clearerr(this->terminalOutputFile());
     fsetpos(this->terminalOutputFile(), &this->SavedFDPos);
 
-
 #ifdef Q_OS_WIN32
     _close(this->Pipe[0]);
 #else
     close(this->Pipe[0]);
 #endif
 
-    this->SavedFDNumber = 0;
+    this->SavedFDNumber = -1;
+#ifdef Q_OS_WIN32
+    terminalOutputFileDescriptor = _fileno(this->terminalOutputFile());
+#else
+    terminalOutputFileDescriptor = fileno(this->terminalOutputFile());
+#endif
   }
 
   ctkErrorLogTerminalOutput * terminalOutput =
       this->MessageHandler->terminalOutput(this->TerminalOutput);
-  if(terminalOutput)
+  if (terminalOutput)
   {
-    terminalOutput->setFileDescriptor(this->SavedFDNumber);
+    terminalOutput->setFileDescriptor(terminalOutputFileDescriptor);
   }
 }
 

--- a/Libs/Core/ctkErrorLogTerminalOutput.cpp
+++ b/Libs/Core/ctkErrorLogTerminalOutput.cpp
@@ -125,11 +125,12 @@ void ctkErrorLogTerminalOutput::output(const QString& text)
 
   {
     QMutexLocker locker(&d->OutputMutex);
-    QString textWithNewLine = text + "\n";
+    QByteArray bytes = text.toUtf8();
+    bytes.append('\n');
 #ifdef _MSC_VER
-    int res = _write(d->FD, qPrintable(textWithNewLine), textWithNewLine.size());
+    int res = _write(d->FD, bytes.constData(), bytes.size());
 #else
-    ssize_t res = write(d->FD, qPrintable(textWithNewLine), textWithNewLine.size());
+    ssize_t res = write(d->FD, bytes.constData(), bytes.size());
 #endif
     if (res == -1)
     {

--- a/Libs/Core/ctkErrorLogTerminalOutput.cpp
+++ b/Libs/Core/ctkErrorLogTerminalOutput.cpp
@@ -29,6 +29,7 @@
 #ifdef _MSC_VER
 # include <io.h> // For _write()
 #else
+# include <cerrno>
 # include <unistd.h>
 #endif
 
@@ -127,14 +128,28 @@ void ctkErrorLogTerminalOutput::output(const QString& text)
     QMutexLocker locker(&d->OutputMutex);
     QByteArray bytes = text.toUtf8();
     bytes.append('\n');
-#ifdef _MSC_VER
-    int res = _write(d->FD, bytes.constData(), bytes.size());
-#else
-    ssize_t res = write(d->FD, bytes.constData(), bytes.size());
-#endif
-    if (res == -1)
+    int offset = 0;
+    while (offset < bytes.size())
     {
-      return;
+#ifdef _MSC_VER
+      int written = _write(d->FD, bytes.constData() + offset, bytes.size() - offset);
+      if (written <= 0)
+      {
+        break;
+      }
+      offset += written;
+#else
+      ssize_t written = write(d->FD, bytes.constData() + offset, bytes.size() - offset);
+      if (written == -1)
+      {
+        if (errno == EINTR)
+        {
+          continue;
+        }
+        break;
+      }
+      offset += static_cast<int>(written);
+#endif
     }
   }
 }

--- a/Libs/Widgets/Testing/Cpp/ctkErrorLogModelTerminalOutputTest1.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkErrorLogModelTerminalOutputTest1.cpp
@@ -70,8 +70,16 @@ bool checkTerminalOutput(const QStringList& expectedMessages)
     process.setProcessChannelMode(QProcess::MergedChannels);
     process.start(testLauncher, QStringList() << QCoreApplication::arguments().at(0));
     process.waitForFinished(1000);
-    QString output = process.readAll();
-    QString errorMsg = checkTextMessages(__LINE__, output.split("\n"), expectedMessages);
+    QStringList lines;
+    for (const QString& line : QString::fromUtf8(process.readAll()).split('\n'))
+    {
+      const QString trimmed = line.trimmed();
+      if (!trimmed.isEmpty())
+      {
+        lines << trimmed;
+      }
+    }
+    QString errorMsg = checkTextMessages(__LINE__, lines, expectedMessages);
     if (!errorMsg.isEmpty())
     {
       printErrorMessage(errorMsg);
@@ -94,12 +102,15 @@ int ctkErrorLogModelTerminalOutputTest1(int argc, char * argv [])
   QString qtMessage0("This is a qDebug message");
   QString qtMessage1("This is a qWarning message");
   QString qtMessage2("This is a qCritical message");
+  // e with acute (U+00E9) is 1 UTF-16 unit but 2 UTF-8 bytes; size() != toUtf8().size() for this string.
+  // This guards against regressions where output() used QString::size() as the write byte count.
+  QString qtMessageUtf8 = QString::fromUtf8("caf\xc3\xa9 r\xc3\xa9sum\xc3\xa9"); // "café résumé"
   QString stdMessage0("This is a std::cerr message");
   QString stdMessage1("This is a std::cout message");
 
   QStringList expectedMessages;
   expectedMessages << fdMessage0 << fdMessage1
-                   << qtMessage0 << qtMessage1 << qtMessage2
+                   << qtMessage0 << qtMessage1 << qtMessage2 << qtMessageUtf8
                    << stdMessage0 << stdMessage1;
 
   // Since the order of the messages outputted on the terminal is not deterministic,
@@ -171,6 +182,8 @@ int ctkErrorLogModelTerminalOutputTest1(int argc, char * argv [])
     std::cout << qPrintable(stdMessage1) << std::endl;
 
     qCritical().nospace() << qUtf8Printable(qtMessage2);
+
+    qDebug().nospace() << qUtf8Printable(qtMessageUtf8);
 
     // Give enough time to the ErrorLogModel to consider the queued messages.
     processEvents(1000);

--- a/Libs/Widgets/Testing/Cpp/ctkErrorLogModelTestHelper.cpp
+++ b/Libs/Widgets/Testing/Cpp/ctkErrorLogModelTestHelper.cpp
@@ -66,8 +66,9 @@ QString checkTextMessages(int line, const QStringList& currentMessages, const QS
     if (!expectedMessages.contains(currentMessages.at(i)))
     {
       QString errorMsg("Line %1 - Problem with logged messages !\n"
-                       "\tMessage [%2] hasn't been logged !\n");
-      return errorMsg.arg(line).arg(expectedMessages.value(i));
+                       "\tMessage [%2] hasn't been logged !\n"
+                       "Current messages:\n%3");
+      return errorMsg.arg(line).arg(expectedMessages.value(i)).arg(currentMessages.join("\n"));
     }
   }
   return QString();


### PR DESCRIPTION

When string with special characters were printed to the output then the length of the buffer was not computed correctly and the end of the string was not written out. Fixed by replacing qPrintable()/QString::size() writes with toUtf8()/QByteArray::size() so the byte count matches the encoded data.

fixes https://github.com/Slicer/Slicer/issues/8708

Also fix disabling of terminal redirection. It is a rarely used feature, the error was discovered by accident while reviewing console output writing.
