### PR TITLE
COMP: Update PythonQt to v4.1.0 based branch

### DIFF
--- a/CMakeExternals/PythonQt.cmake
+++ b/CMakeExternals/PythonQt.cmake
@@ -91,7 +91,7 @@ if(NOT DEFINED PYTHONQT_INSTALL_DIR)
 
   ctkFunctionExtractOptimizedLibrary(PYTHON_LIBRARIES PYTHON_LIBRARY)
 
-  set(revision_tag 7ef4c5ee066b8ef1e7dc609b14071d504f59d4ba) # patched-v4.0.1-2026-03-16-5cd9b581f
+  set(revision_tag 74dcd675e1515324cd7467a328d63dd25d263679) # patched-v4.1.0-2026-06-05-9992368e9
   if(${proj}_REVISION_TAG)
     set(revision_tag ${${proj}_REVISION_TAG})
   endif()


### PR DESCRIPTION
This updates the PythonQt forked used based off of PythonQt 4.1.0 which now includes support for Qt 6.11. I have built the 3D Slicer project using Qt 6.11 with this branch successfully. 
```
Upstream changes:
$ git shortlog 5cd9b581f..9992368e9
Uwe Siems (5):
      Fix findChild/findChildren logic:
      Prevent endless recursion if typedef generates same name
      Type system database adaptations for Qt 6.11
      Build against Qt 6.11 for testing
      Restrict MSVC compiler to 2022

dependabot[bot] (3):
      chore(deps): bump hendrikmuhs/ccache-action from 1.2.20 to 1.2.22
      chore(deps): bump egor-tensin/cleanup-path from 4 to 5
      chore(deps): bump hendrikmuhs/ccache-action from 1.2.22 to 1.2.23

pre-commit-ci[bot] (4):
      [pre-commit.ci] pre-commit autoupdate
      [pre-commit.ci] pre-commit autoupdate
      [pre-commit.ci] pre-commit autoupdate
      [pre-commit.ci] pre-commit autoupdate
```