### PR TITLE
BUG: Fix crash exporting series with no local files

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMBrowser.cpp
@@ -1358,6 +1358,11 @@ void ctkDICOMBrowser::exportSeries(QString dirPath, QStringList uids)
   foreach (const QString& uid, uids)
   {
     QStringList filesForSeries = d->DICOMDatabase->filesForSeries(uid);
+    if (filesForSeries.isEmpty())
+    {
+      qWarning() << Q_FUNC_INFO << " no local files found for series" << uid << ", skipping export.";
+      continue;
+    }
 
     // Use the first file to get the overall series information
     QString firstFilePath = filesForSeries[0];

--- a/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMVisualBrowserWidget.cpp
@@ -3973,6 +3973,11 @@ void ctkDICOMVisualBrowserWidget::exportSeriesToDirectory(const QString& dirPath
   foreach (const QString& uid, uids)
   {
     QStringList filesForSeries = d->DicomDatabase->filesForSeries(uid);
+    if (filesForSeries.isEmpty())
+    {
+      logger.warn(QString("exportSeries: no local files found for series %1, skipping export.\n").arg(uid));
+      continue;
+    }
 
     // Use the first file to get the overall series information
     QString firstFilePath = filesForSeries[0];


### PR DESCRIPTION
filesForSeries() can return an empty list (e.g. for series that have not been retrieved locally yet), in which case indexing element [0] is undefined behavior. Skip such series with a warning instead.