### PR TITLE
BUG: Keep popup widgets within screen boundaries

### DIFF
--- a/Libs/Visualization/VTK/Core/Testing/Cpp/vtkLightBoxRendererManagerTest1.cpp
+++ b/Libs/Visualization/VTK/Core/Testing/Cpp/vtkLightBoxRendererManagerTest1.cpp
@@ -39,6 +39,7 @@
 
 // STD includes
 #include <cstdlib>
+#include <iostream>
 
 //----------------------------------------------------------------------------
 int vtkLightBoxRendererManagerTest1(int argc, char* argv[])

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKAbstractViewTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKAbstractViewTest1.cpp
@@ -40,6 +40,7 @@
 #else
 #include <time.h>
 #endif
+#include <iostream>
 
 void sleep_ms(int ms)
 {

--- a/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsComboBoxTest1.cpp
+++ b/Libs/Visualization/VTK/Widgets/Testing/Cpp/ctkVTKScalarsToColorsComboBoxTest1.cpp
@@ -32,6 +32,7 @@
 #include <vtkPiecewiseFunction.h>
 
 // STD includes
+#include <iostream>
 
 //-----------------------------------------------------------------------------
 int ctkVTKScalarsToColorsComboBoxTest1(int argc, char * argv [] )

--- a/Libs/Widgets/ctkBasePopupWidget.cpp
+++ b/Libs/Widgets/ctkBasePopupWidget.cpp
@@ -20,6 +20,11 @@
 
 // Qt includes
 #include <QApplication>
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+#include <QScreen>
+#else
+#include <QDesktopWidget>
+#endif
 #include <QDebug>
 #include <QDir>
 #include <QEvent>
@@ -418,6 +423,33 @@ QRect ctkBasePopupWidgetPrivate::desiredOpenGeometry(QRect baseGeometry)const
   else if (this->Alignment & Qt::AlignVCenter)
   {
     geometry.moveTop((topLeft.y() + bottomRight.y()) / 2 - size.height() / 2);
+  }
+
+  // Keep the popup visible on the screen: if the base widget is close to a screen
+  // edge then the popup would be cut off, move it back to the visible area instead.
+  if (!this->BaseWidget.isNull())
+  {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QRect available = this->BaseWidget->screen()->availableGeometry();
+#else
+    QRect available = QApplication::desktop()->availableGeometry(this->BaseWidget);
+#endif
+    if (geometry.right() > available.right())
+    {
+      geometry.moveRight(available.right());
+    }
+    if (geometry.left() < available.left())
+    {
+      geometry.moveLeft(available.left());
+    }
+    if (geometry.bottom() > available.bottom())
+    {
+      geometry.moveBottom(available.bottom());
+    }
+    if (geometry.top() < available.top())
+    {
+      geometry.moveTop(available.top());
+    }
   }
   return geometry;
 }


### PR DESCRIPTION
Popup widget position was computed only from the base widget geometry
and the alignment/direction settings, without taking the screen
geometry into account. For example, the popup slider of a
ctkSliderWidget (which opens toward the left) was cut off when the
widget was near the left edge of the screen.

Clamp the desired open geometry to the available geometry of the screen
of the base widget, similarly to how Qt menus and combobox popups
behave. When there is not enough room the popup now shifts back into
the visible area (partially overlapping the base widget) instead of
being cut off.
