### PR TITLE
STYLE: Replace non-POD string constants with constexpr QLatin1String

### DIFF
--- a/Libs/CommandLineModules/Frontend/QtGui/ctkCmdLineModuleObjectTreeWalker.cpp
+++ b/Libs/CommandLineModules/Frontend/QtGui/ctkCmdLineModuleObjectTreeWalker.cpp
@@ -21,16 +21,21 @@
 
 #include "ctkCmdLineModuleObjectTreeWalker_p.h"
 
+// CTK includes
+#include <ctkStringLiterals.h>
+
 #include <QObject>
 #include <QStack>
 #include <QVariant>
 
 namespace {
 
-static QString PREFIX_EXECUTABLE = "executable:";
-static QString PREFIX_PARAMETER_GROUP = "paramGroup:";
-static QString PREFIX_PARAMETER_CONTAINER = "paramContainer:";
-static QString PREFIX_PARAMETER = "parameter:";
+using namespace ctk::string_literals;
+
+constexpr QLatin1String PREFIX_EXECUTABLE          = "executable:"_L1;
+constexpr QLatin1String PREFIX_PARAMETER_GROUP     = "paramGroup:"_L1;
+constexpr QLatin1String PREFIX_PARAMETER_CONTAINER = "paramContainer:"_L1;
+constexpr QLatin1String PREFIX_PARAMETER           = "parameter:"_L1;
 
 }
 

--- a/Libs/Core/CMakeLists.txt
+++ b/Libs/Core/CMakeLists.txt
@@ -81,6 +81,7 @@ set(KIT_SRCS
   ctkScopedCurrentDir.cpp
   ctkScopedCurrentDir.h
   ctkSingleton.h
+  ctkStringLiterals.h
   ctkUtils.cpp
   ctkUtils.h
   ctkUtils.tpp

--- a/Libs/Core/ctkStringLiterals.h
+++ b/Libs/Core/ctkStringLiterals.h
@@ -1,0 +1,54 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+#ifndef __ctkStringLiterals_h
+#define __ctkStringLiterals_h
+
+// Qt includes
+#include <QLatin1String>
+
+#include <cstddef>
+
+namespace ctk {
+inline namespace string_literals {
+
+/// Backport of Qt 6.4's Qt::StringLiterals::operator""_L1.
+///
+/// Allows defining compile-time string constants as
+/// \code
+/// constexpr QLatin1String Example = "example"_L1;
+/// \endcode
+/// avoiding non-POD static QString globals (clazy:non-pod-global-static,
+/// static initialization order fiasco). The compiler supplies the string
+/// length, so no strlen() call is involved and the constructor is fully
+/// constexpr even on Qt 5 / Apple clang, where QLatin1String(const char*)
+/// is not.
+///
+/// Once CTK requires Qt >= 6.4, users of this header can switch to
+/// \c Qt::StringLiterals with no call-site changes.
+constexpr QLatin1String operator""_L1(const char* str, std::size_t size)
+{
+  return QLatin1String{str, static_cast<int>(size)};
+}
+
+} // namespace string_literals
+} // namespace ctk
+
+#endif

--- a/Libs/PluginFramework/ctkBasicLocation.cpp
+++ b/Libs/PluginFramework/ctkBasicLocation.cpp
@@ -24,6 +24,7 @@
 #include "ctkPluginFrameworkProperties_p.h"
 
 #include <ctkException.h>
+#include <ctkStringLiterals.h>
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
 #define HAVE_QT_QLOCKFILE
@@ -37,8 +38,11 @@
 #include <QReadLocker>
 #include <QWriteLocker>
 
-static const QString PROP_OSGI_LOCKING = "blueberry.locking";
-static const QString DEFAULT_LOCK_FILENAME = ".metadata/.lock";
+namespace {
+using namespace ctk::string_literals;
+constexpr QLatin1String PROP_OSGI_LOCKING     = "blueberry.locking"_L1;
+constexpr QLatin1String DEFAULT_LOCK_FILENAME = ".metadata/.lock"_L1;
+} // namespace
 
 
 //----------------------------------------------------------------------------

--- a/Libs/PluginFramework/ctkLocationManager.cpp
+++ b/Libs/PluginFramework/ctkLocationManager.cpp
@@ -27,6 +27,7 @@
 #include "ctkException.h"
 #include "ctkPluginFrameworkLauncher.h"
 #include "ctkPluginConstants.h"
+#include "ctkStringLiterals.h"
 
 #include <QCoreApplication>
 #include <QSettings>
@@ -36,23 +37,25 @@
 
 namespace {
 
-// Constants for configuration location discovery
-static const QString CTK = "commontk";
-static const QString PRODUCT_SITE_MARKER = ".commontkproduct";
-static const QString PRODUCT_SITE_ID = "id";
-static const QString PRODUCT_SITE_VERSION = "version";
+using namespace ctk::string_literals;
 
-static const QString CONFIG_DIR = "configuration";
+// Constants for configuration location discovery
+constexpr QLatin1String CTK                    = "commontk"_L1;
+constexpr QLatin1String PRODUCT_SITE_MARKER    = ".commontkproduct"_L1;
+constexpr QLatin1String PRODUCT_SITE_ID        = "id"_L1;
+constexpr QLatin1String PRODUCT_SITE_VERSION   = "version"_L1;
+
+constexpr QLatin1String CONFIG_DIR             = "configuration"_L1;
 
 // Data mode constants for user, configuration and data locations.
-static const QString NONE = "@none";
-static const QString NO_DEFAULT = "@noDefault";
-static const QString USER_HOME = "@user.home";
-static const QString USER_DIR = "@user.dir";
+constexpr QLatin1String NONE                   = "@none"_L1;
+constexpr QLatin1String NO_DEFAULT             = "@noDefault"_L1;
+constexpr QLatin1String USER_HOME              = "@user.home"_L1;
+constexpr QLatin1String USER_DIR               = "@user.dir"_L1;
 // Placeholder for hashcode of installation directory
-static const QString INSTALL_HASH_PLACEHOLDER = "@install.hash";
+constexpr QLatin1String INSTALL_HASH_PLACEHOLDER = "@install.hash"_L1;
 
-static const QString INSTANCE_DATA_AREA_PREFIX = ".metadata/.plugins/";
+constexpr QLatin1String INSTANCE_DATA_AREA_PREFIX = ".metadata/.plugins/"_L1;
 
 static QScopedPointer<ctkBasicLocation> installLocation;
 static QScopedPointer<ctkBasicLocation> configurationLocation;
@@ -138,7 +141,7 @@ ctkBasicLocation* BuildLocation(const QString& property, const QUrl& defaultLoca
   int idx = location.indexOf(INSTALL_HASH_PLACEHOLDER);
   if (idx == 0)
   {
-    throw ctkRuntimeException("The location cannot start with '" + INSTALL_HASH_PLACEHOLDER + "': " + location);
+    throw ctkRuntimeException(QString("The location cannot start with '") + INSTALL_HASH_PLACEHOLDER + "': " + location);
   }
   else if (idx > 0)
   {
@@ -280,7 +283,7 @@ static QString ComputeDefaultUserAreaLocation(const QString& pathAppendage)
   QFileInfo installDir(installURL.toLocalFile());
   QString installDirHash = GetInstallDirHash();
 
-  QString appName = "." + CTK;
+  QString appName = QString(".") + CTK;
   QFileInfo ctkProduct(QDir(installDir.absoluteFilePath()), PRODUCT_SITE_MARKER);
   if (ctkProduct.exists())
   {

--- a/Libs/PluginFramework/ctkPluginFrameworkDebug.cpp
+++ b/Libs/PluginFramework/ctkPluginFrameworkDebug.cpp
@@ -23,20 +23,6 @@
 #include "ctkPluginFrameworkDebug_p.h"
 
 #include "ctkPluginFrameworkDebugOptions_p.h"
-#include "ctkPluginFrameworkProperties_p.h"
-
-static QString CTK_OSGI = "org.commontk.pluginfw";
-
-QString ctkPluginFrameworkDebug::OPTION_DEBUG_GENERAL = CTK_OSGI + "/debug";
-QString ctkPluginFrameworkDebug::OPTION_DEBUG_FRAMEWORK = CTK_OSGI + "/debug/framework";
-QString ctkPluginFrameworkDebug::OPTION_DEBUG_ERRORS = CTK_OSGI + "/debug/errors";
-QString ctkPluginFrameworkDebug::OPTION_DEBUG_HOOKS = CTK_OSGI + "/debug/hooks";
-QString ctkPluginFrameworkDebug::OPTION_DEBUG_LAZY_ACTIVATION = CTK_OSGI + "/debug/lazy_activation";
-QString ctkPluginFrameworkDebug::OPTION_DEBUG_LDAP = CTK_OSGI + "/debug/ldap";
-QString ctkPluginFrameworkDebug::OPTION_DEBUG_SERVICE_REFERENCE = CTK_OSGI + "/debug/service_reference";
-QString ctkPluginFrameworkDebug::OPTION_DEBUG_STARTLEVEL = CTK_OSGI + "/debug/startlevel";
-QString ctkPluginFrameworkDebug::OPTION_DEBUG_URL = CTK_OSGI + "/debug/url";
-QString ctkPluginFrameworkDebug::OPTION_DEBUG_RESOLVE = CTK_OSGI + "/debug/resolve";
 
 //----------------------------------------------------------------------------
 ctkPluginFrameworkDebug::ctkPluginFrameworkDebug()

--- a/Libs/PluginFramework/ctkPluginFrameworkDebug_p.h
+++ b/Libs/PluginFramework/ctkPluginFrameworkDebug_p.h
@@ -23,7 +23,17 @@
 #ifndef CTKPLUGINFRAMEWORKDEBUG_P_H
 #define CTKPLUGINFRAMEWORKDEBUG_P_H
 
+// Qt includes
+#include <QLatin1String>
+
+// CTK includes
+#include <ctkStringLiterals.h>
+
 #include "ctkPluginFramework_global.h"
+
+using namespace ctk::string_literals;
+
+#define CTK_OSGI "org.commontk.pluginfw"
 
 /**
  * Variables that control debugging of the pluginfw code.
@@ -34,37 +44,37 @@ class ctkPluginFrameworkDebug
 public:
   ctkPluginFrameworkDebug();
 
-  static QString OPTION_DEBUG_GENERAL;
+  static constexpr QLatin1String OPTION_DEBUG_GENERAL         = CTK_OSGI "/debug"_L1;
   bool enabled;
 
   /**
    * Report error handling events.
    */
-  static QString OPTION_DEBUG_ERRORS;
+  static constexpr QLatin1String OPTION_DEBUG_ERRORS          = CTK_OSGI "/debug/errors"_L1;
   bool errors;
 
   /**
    * Report pluginfw create, init, start, stop
    */
-  static QString OPTION_DEBUG_FRAMEWORK;
+  static constexpr QLatin1String OPTION_DEBUG_FRAMEWORK       = CTK_OSGI "/debug/framework"_L1;
   bool framework;
 
   /**
    * Report hooks handling
    */
-  static QString OPTION_DEBUG_HOOKS;
+  static constexpr QLatin1String OPTION_DEBUG_HOOKS           = CTK_OSGI "/debug/hooks"_L1;
   bool hooks;
 
   /**
    * Report triggering of lazy activation
    */
-  static QString OPTION_DEBUG_LAZY_ACTIVATION;
+  static constexpr QLatin1String OPTION_DEBUG_LAZY_ACTIVATION = CTK_OSGI "/debug/lazy_activation"_L1;
   bool lazy_activation;
 
   /**
    * Report LDAP handling
    */
-  static QString OPTION_DEBUG_LDAP;
+  static constexpr QLatin1String OPTION_DEBUG_LDAP            = CTK_OSGI "/debug/ldap"_L1;
   bool ldap;
 
   /**
@@ -72,27 +82,29 @@ public:
    * and rejections due to missing permissions
    * for calling plug-ins.
    */
-  static QString OPTION_DEBUG_SERVICE_REFERENCE;
+  static constexpr QLatin1String OPTION_DEBUG_SERVICE_REFERENCE = CTK_OSGI "/debug/service_reference"_L1;
   bool service_reference;
 
   /**
    * Report startlevel.
    */
-  static QString OPTION_DEBUG_STARTLEVEL;
+  static constexpr QLatin1String OPTION_DEBUG_STARTLEVEL      = CTK_OSGI "/debug/startlevel"_L1;
   bool startlevel;
 
   /**
    * Report url
    */
-  static QString OPTION_DEBUG_URL;
+  static constexpr QLatin1String OPTION_DEBUG_URL             = CTK_OSGI "/debug/url"_L1;
   bool url;
 
   /**
    * Report plug-in resolve progress
    */
-  static QString OPTION_DEBUG_RESOLVE;
+  static constexpr QLatin1String OPTION_DEBUG_RESOLVE         = CTK_OSGI "/debug/resolve"_L1;
   bool resolve;
 
 };
+
+#undef CTK_OSGI
 
 #endif // CTKPLUGINFRAMEWORKDEBUG_P_H

--- a/Libs/PluginFramework/ctkPluginFrameworkLauncher.cpp
+++ b/Libs/PluginFramework/ctkPluginFrameworkLauncher.cpp
@@ -31,6 +31,7 @@
 #include "ctkBasicLocation_p.h"
 
 #include <ctkConfig.h>
+#include <ctkStringLiterals.h>
 
 #include <QStringList>
 #include <QDirIterator>
@@ -82,7 +83,10 @@ const QString ctkPluginFrameworkLauncher::PROP_APPLICATION_LAUNCHDEFAULT = "ctk.
 
 const QString ctkPluginFrameworkLauncher::PROP_OSGI_RELAUNCH = "ctk.pluginfw.relaunch";
 
-static const QString PROP_FORCED_RESTART = "ctk.forcedRestart";
+namespace {
+using namespace ctk::string_literals;
+constexpr QLatin1String PROP_FORCED_RESTART = "ctk.forcedRestart"_L1;
+} // namespace
 
 class ctkPluginFrameworkLauncherPrivate
 {


### PR DESCRIPTION
This is a potential alternative solution to the same problem described in https://github.com/commontk/CTK/pull/1410, with a simpler syntax and without potential ODR violation issue.

---

Static QString variables have non-trivial constructors and destructors, triggering clazy:non-pod-global-static and introducing Static Initialization Order Fiasco (SIOF) risk. All affected constants are pure compile-time string literals, now defined as constexpr QLatin1String. No call-site changes are required -- QLatin1String implicitly converts to QString for all existing uses.

Qt5 / Apple-clang compatibility: QLatin1String(const char*) calls strlen(), which is not constexpr under Apple clang. A new CTKCore header, ctkStringLiterals.h, provides a backport of Qt 6.4's Qt::StringLiterals::operator""_L1:

  constexpr QLatin1String operator""_L1(const char* str, std::size_t size)
  { return QLatin1String{str, static_cast<int>(size)}; }

The compiler supplies the literal length to the user-defined literal operator, so no strlen() is involved and construction is fully constexpr on all supported compilers. Definition sites are one-liners:

  constexpr QLatin1String PREFIX_EXECUTABLE = "executable:"_L1;

The operator has external linkage and is shared by all translation units, so it is also safe to use in headers (an internal-linkage helper in an anonymous namespace would make in-class initializers an ODR violation). Once CTK requires Qt >= 6.4 the header can be retired in favor of Qt::StringLiterals with no call-site changes.

For ctkPluginFrameworkDebug, the ten OPTION_DEBUG_* class static members are converted to static constexpr in the private header using the literal and a #define CTK_OSGI prefix macro (scoped with #undef); string-literal concatenation is applied before the literal suffix, so CTK_OSGI "/debug"_L1 works. The out-of-line QString definitions and the CTK_OSGI QString variable are removed from the .cpp entirely (in-class static constexpr members are implicitly inline in C++17).

The redundant 'static' specifier is omitted on all anonymous-namespace members (internal linkage is already implied by the enclosing namespace).