### PR TITLE
BUG: Do not discard the RESOURCES of a plug-in

### DIFF
--- a/CMake/ctkMacroBuildPlugin.cmake
+++ b/CMake/ctkMacroBuildPlugin.cmake
@@ -160,9 +160,6 @@ macro(ctkMacroBuildPlugin)
   set(dynamicHeaders
     "${dynamicHeaders};${CMAKE_CURRENT_BINARY_DIR}/${MY_EXPORT_HEADER_PREFIX}Export.h")
 
-  # Make sure variable are cleared
-  set(MY_RESOURCES)
-
   # Add the generated manifest qrc file
   set(manifest_qrc_filepath )
   ctkFunctionGeneratePluginManifest(manifest_qrc_filepath


### PR DESCRIPTION
**Disclaimer:** We (MITK) are currently catching up on the latest CTK master branch
since we forked for Qt 6 back in 2023. We found a few bugs that are not caught by
your CI and mostly affect external users of CTK.

**Priority: highest.** Regression that makes `ctkMacroBuildPlugin` silently
ignore a documented parameter.

`ctkMacroBuildPlugin` accepts `RESOURCES`, but clears the variable before use:

```cmake
# Make sure variable are cleared
set(MY_RESOURCES)
```

Only the generated manifest and cached-resource `.qrc` files are appended
afterwards, so a plug-in's own `.qrc` files never become target sources and
AUTORCC never compiles them. Every icon, stylesheet and other embedded file of
a plug-in is missing at runtime.

The clearing made sense while the macro compiled `RESOURCES` into a separate
list of generated sources (`MY_QRC_SRCS`); with AUTORCC the `.qrc` files
themselves are the target sources, so the reset just drops them.

**Why CI does not catch it:** the in-tree plug-ins pass no `RESOURCES`
(`set(PLUGIN_resources )` is empty in both `org.commontk.eventadmin` and
`org.commontk.configadmin`), so nothing exercises the parameter.

**How it presents:** builds and links without a single warning. The plug-in
loads, and only at runtime does every resource lookup fail:

```
WARNING: Could not read :/org.blueberry.ui.qt/darkstyle.qss
WARNING: Could not read :/org_mitk_icons/icons/awesome/scalable/actions/document-open.svg
```

Verifiable in the build tree: no `qrc_<name>.cpp` is generated for the
plug-in's own `.qrc`, only the `_cached` and `_manifest` ones.