### PR TITLE
COMP: Do not forward declare OFList

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
       matrix:
         runs-on: ["ubuntu-latest"]
         qt-major-version: [5, 6]
+        dcmtk-enable-stl: ["OFF"]
+        include:
+          # Projects embedding CTK may bring their own DCMTK built with STL
+          # containers, which makes OFList and friends aliases of the STL types.
+          - runs-on: "ubuntu-latest"
+            qt-major-version: 6
+            dcmtk-enable-stl: "ON"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -79,6 +86,7 @@ jobs:
         run: |
           cmake \
             -DCTK_QT_VERSION:STRING=${{ matrix.qt-major-version }} \
+            -DDCMTK_ENABLE_STL:BOOL=${{ matrix.dcmtk-enable-stl }} \
             -DCTK_ENABLE_Widgets:BOOL=ON \
             -DCTK_USE_SYSTEM_VTK:BOOL=$CTK_USE_VTK \
             -DCTK_LIB_Visualization/VTK/Widgets:BOOL=$CTK_USE_VTK \

--- a/CMakeExternals/DCMTK.cmake
+++ b/CMakeExternals/DCMTK.cmake
@@ -44,6 +44,12 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
                       GIT_TAG ${revision_tag})
   endif()
 
+  # DCMTK uses its own container classes by default. With this option its
+  # OFList, OFMap and friends become aliases of the corresponding STL types,
+  # which changes the headers that CTK and its users compile against.
+  option(DCMTK_ENABLE_STL "Build DCMTK with STL containers" OFF)
+  mark_as_advanced(DCMTK_ENABLE_STL)
+
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
 
   if(UNIX)
@@ -77,6 +83,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       -DDCMTK_OVERWRITE_WIN32_COMPILER_FLAGS:BOOL=OFF
       -DDCMTK_DEFAULT_DICT:STRING=builtin
       -DDCMTK_ENABLE_PRIVATE_TAGS:BOOL=ON
+      -DDCMTK_ENABLE_STL:BOOL=${DCMTK_ENABLE_STL}
 
       ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
     DEPENDS

--- a/Libs/DICOM/Core/ctkDICOMQuery.h
+++ b/Libs/DICOM/Core/ctkDICOMQuery.h
@@ -30,6 +30,11 @@
 // ctkCore includes
 #include <ctkPimpl.h>
 
+// DCMTK includes
+// OFList cannot be forward declared: when DCMTK is built with DCMTK_ENABLE_STL
+// it is a macro that aliases std::list.
+#include <dcmtk/ofstd/oflist.h>
+
 // ctkDICOMCore includes
 #include "ctkDICOMCoreExport.h"
 #include "ctkDICOMDatabase.h"
@@ -37,7 +42,6 @@
 class ctkDICOMQueryPrivate;
 class ctkDICOMJobResponseSet;
 class QRResponse;
-template <typename T> class OFList;
 
 /// \ingroup DICOM_Core
 class CTK_DICOM_CORE_EXPORT ctkDICOMQuery : public QObject


### PR DESCRIPTION
**Disclaimer:** We (MITK) are currently catching up on the latest CTK master branch
since we forked for Qt 6 back in 2023. We found a few bugs that are not caught by
your CI and mostly affect external users of CTK.

`Libs/DICOM/Core/ctkDICOMQuery.h` forward declares

```cpp
template <typename T> class OFList;
```

for `reportIncompleteFindStatus(const OFList<QRResponse*>&, const QString&)`.

When DCMTK is built with `DCMTK_ENABLE_STL=ON`, its `osconfig.h` defines
`HAVE_STL_LIST` and `oflist.h` does `#define OFList std::list`. The forward
declaration then expands to a redeclaration of `std::list`, which fails and in
turn breaks every DCMTK header that uses `OFList`:

```
ctkDICOMQuery.h(40,1): error C2976: 'std::list': too few template arguments
dcmtk/dcmnet/lst.h(84,18): error C2955: 'std::list': use of class template
  requires template argument list
```

Including `<dcmtk/ofstd/oflist.h>` works for both DCMTK configurations, and
matches what other public DICOM headers already do (`ctkDICOMItem.h` includes
`<dcmtk/dcmdata/dcdatset.h>`).

**Why CI does not catch it:** CTK's own `CMakeExternals/DCMTK.cmake` does not
enable STL, so `OFList` is a real class template there.