### PR TITLE
COMP: Propagate CMAKE_VS_GLOBALS to external projects

### DIFF
--- a/CMake/ctkMacroCheckExternalProjectDependency.cmake
+++ b/CMake/ctkMacroCheckExternalProjectDependency.cmake
@@ -483,6 +483,7 @@ function(_sb_get_external_project_arguments proj varname)
     CMAKE_JOB_POOL_COMPILE:STRING
     CMAKE_JOB_POOL_LINK:STRING
     CMAKE_JOB_POOLS:STRING
+    CMAKE_VS_GLOBALS:STRING
     )
   if(NOT CMAKE_VERSION VERSION_LESS "3.16")
     list(APPEND _options


### PR DESCRIPTION
**Disclaimer:** We (MITK) are currently catching up on the latest CTK master branch
since we forked for Qt 6 back in 2023. We found a few bugs that are not caught by
your CI and mostly affect external users of CTK.

CTK is a nested superbuild: the outer project only configures the inner
CTK-build and the third-party projects, so any CMake option not explicitly
forwarded is lost. `_sb_get_external_project_arguments` propagates
`CMAKE_EXPORT_COMPILE_COMMANDS`, `CMAKE_FIND_*_PACKAGE_REGISTRY` and
`CMAKE_JOB_POOL*`, but not `CMAKE_VS_GLOBALS`.

A parent project that sets `UseMultiToolTask` / `EnforceProcessCountAcrossBuilds`
therefore never reaches the projects that actually compile code, and MSBuild
builds CTK with a single `cl.exe`. Ninja is unaffected, since `CMAKE_JOB_POOLS`
is propagated, so this is MSBuild-specific.

The same commit joins all automatically propagated options with
`EP_LIST_SEPARATOR`. Multi-value options were expanded into one
ExternalProject argument per value, which silently corrupts `CMAKE_JOB_POOLS`:

```
before:  -DCMAKE_JOB_POOLS:STRING=compile=4   +   stray argument "link=2"
after:   -DCMAKE_JOB_POOLS:STRING=compile=4^^link=2
```

**Related:** #1349 addresses the same slow-build symptom by adding
`CTK_MSVC_ENABLE_MP` with `/MP /FS`. The two are complementary — this one lets
a parent project's existing scheduling choice through, rather than imposing
`/MP`, which over-subscribes when combined with MultiToolTask.