### PR TITLE
ENH: Add NO_SOURCE_GROUPS option to ctkBuild macros

### DIFF
--- a/CMake/ctkMacroBuildApp.cmake
+++ b/CMake/ctkMacroBuildApp.cmake
@@ -70,10 +70,12 @@ macro(ctkMacroBuildApp)
     ${my_library_dirs}
     )
 
-  source_group("Resources" FILES
-    ${MY_RESOURCES}
-    ${MY_UI_FORMS}
-    )
+  if(NOT CTK_NO_SOURCE_GROUPS)
+    source_group("Resources" FILES
+      ${MY_RESOURCES}
+      ${MY_UI_FORMS}
+      )
+  endif()
 
   # Create executable
   ctk_add_executable_utf8(${proj_name}

--- a/CMake/ctkMacroBuildLib.cmake
+++ b/CMake/ctkMacroBuildLib.cmake
@@ -102,10 +102,12 @@ ${${MY_EXPORT_CUSTOM_CONTENT_FROM_VARIABLE}}
   set(dynamicHeaders
     "${dynamicHeaders};${CMAKE_CURRENT_BINARY_DIR}/${MY_EXPORT_HEADER_PREFIX}Export.h")
 
-  source_group("Resources" FILES
-    ${MY_RESOURCES}
-    ${MY_UI_FORMS}
-    )
+  if(NOT CTK_NO_SOURCE_GROUPS)
+    source_group("Resources" FILES
+      ${MY_RESOURCES}
+      ${MY_UI_FORMS}
+      )
+  endif()
 
   add_library(${lib_name} ${MY_LIBRARY_TYPE}
     ${MY_SRCS}

--- a/CMake/ctkMacroBuildPlugin.cmake
+++ b/CMake/ctkMacroBuildPlugin.cmake
@@ -237,15 +237,17 @@ macro(ctkMacroBuildPlugin)
       )
   endif()
 
-  source_group("Resources" FILES
-    ${MY_RESOURCES}
-    ${MY_UI_FORMS}
-    ${MY_TRANSLATIONS}
-    )
+  if(NOT CTK_NO_SOURCE_GROUPS)
+    source_group("Resources" FILES
+      ${MY_RESOURCES}
+      ${MY_UI_FORMS}
+      ${MY_TRANSLATIONS}
+      )
 
-  source_group("Generated" FILES
-    ${_plugin_qm_files}
-    )
+    source_group("Generated" FILES
+      ${_plugin_qm_files}
+      )
+  endif()
 
   add_library(${lib_name} ${MY_LIBRARY_TYPE}
     ${MY_SRCS}

--- a/CMake/ctkMacroBuildQtPlugin.cmake
+++ b/CMake/ctkMacroBuildQtPlugin.cmake
@@ -80,10 +80,12 @@ macro(ctkMacroBuildQtPlugin)
   set(dynamicHeaders
     "${dynamicHeaders};${CMAKE_CURRENT_BINARY_DIR}/${MY_EXPORT_HEADER_PREFIX}Export.h")
 
-  source_group("Resources" FILES
-    ${MY_RESOURCES}
-    ${MY_UI_FORMS}
-    )
+  if(NOT CTK_NO_SOURCE_GROUPS)
+    source_group("Resources" FILES
+      ${MY_RESOURCES}
+      ${MY_UI_FORMS}
+      )
+  endif()
 
   add_library(${lib_name} ${MY_LIBRARY_TYPE}
     ${MY_SRCS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,6 +499,11 @@ option(CTK_BUILD_QTDESIGNER_PLUGINS "Build Qt Designer plugins" ON)
 mark_as_advanced(CTK_BUILD_QTDESIGNER_PLUGINS)
 mark_as_superbuild(CTK_BUILD_QTDESIGNER_PLUGINS)
 
+# Source groups
+option(CTK_NO_SOURCE_GROUPS "Do not categorize sources into source groups" OFF)
+mark_as_advanced(CTK_NO_SOURCE_GROUPS)
+mark_as_superbuild(CTK_NO_SOURCE_GROUPS)
+
 #-----------------------------------------------------------------------------
 # CTK Libraries
 #


### PR DESCRIPTION
**Disclaimer:** We (MITK) are currently catching up on the latest CTK master branch
since we forked for Qt 6 back in 2023. We found a few bugs that are not caught by
your CI and mostly affect external users of CTK.

Adds an opt-out so a consumer can apply its own `source_group()` layout.
Without it, CTK's `source_group("Resources" ...)` and
`source_group("Generated" ...)` override the grouping the consumer set up
before calling the macro.

Note this is currently a hard break rather than a cosmetic one for consumers
that already pass the flag: `CtkMacroParseArguments` appends an unrecognised
token to the *preceding* named argument's list, so passing `NO_SOURCE_GROUPS`
after `OUTPUT_DIR <dir>` silently yields `MY_OUTPUT_DIR=<dir>;NO_SOURCE_GROUPS`
and the plug-in lands in a bogus directory.

Applied to all four macros (`ctkMacroBuildApp`, `ctkMacroBuildLib`,
`ctkMacroBuildPlugin`, `ctkMacroBuildQtPlugin`) for consistency.