### PR TITLE
BUG: Log retrieve progress at debug level

### DIFF
--- a/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
+++ b/Libs/DICOM/Widgets/ctkDICOMQueryRetrieveWidget.cpp
@@ -505,7 +505,7 @@ void ctkDICOMQueryRetrieveWidget::updateRetrieveProgress(int value)
     d->ProgressDialog->resize(targetWidth, d->ProgressDialog->height());
   }
   d->ProgressDialog->setValue( value );
-  logger.error(QString("setting value to %1").arg(value) );
+  logger.debug(QString("setting value to %1").arg(value) );
   QApplication::processEvents();
 }
 


### PR DESCRIPTION
**Disclaimer:** We (MITK) are currently catching up on the latest CTK master branch
since we forked for Qt 6 back in 2023. We found a few bugs that are not caught by
your CI and mostly affect external users of CTK.

`ctkDICOMQueryRetrieveWidget::updateRetrieveProgress()` logs at **error**
level on every progress tick:

```cpp
logger.error(QString("setting value to %1").arg(value));
```

Any application embedding `ctkDICOMQueryRetrieveWidget` gets its log flooded
during a retrieve. One-line change to `logger.debug`.