### PR TITLE
ENH: Set default log level of Event Admin plugin to INFO

### DIFF
--- a/Plugins/org.commontk.eventadmin/util/ctkEALogTracker.cpp
+++ b/Plugins/org.commontk.eventadmin/util/ctkEALogTracker.cpp
@@ -25,7 +25,7 @@
 #include <QDateTime>
 
 ctkEALogTracker::ctkEALogTracker(ctkPluginContext* context, QIODevice* out)
-  : ctkServiceTracker<ctkLogService*>(context), out(out), logLevel(std::numeric_limits<int>::max())
+  : ctkServiceTracker<ctkLogService*>(context), out(out), logLevel(ctkLogService::LOG_INFO)
 {
 
 }


### PR DESCRIPTION
**Disclaimer:** We (MITK) are currently catching up on the latest CTK master branch
since we forked for Qt 6 back in 2023. We found a few bugs that are not caught by
your CI and mostly affect external users of CTK.

`ctkEALogTracker` starts at `std::numeric_limits<int>::max()`, so with no
`ctkLogService` registered the Event Admin plug-in logs at debug level and
drowns out everything else. INFO is a more useful floor for an infrastructure
plug-in; a registered log service reporting a higher level still raises it.

This one is a policy default rather than a defect, so it is the most arguable
of the set — worth splitting off if the maintainers prefer.