### PR TITLE
FIX: configure error on Ubuntu26

### DIFF
--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -137,6 +137,10 @@ macro(ctkMacroSetupQt)
       list(APPEND CTK_QT_COMPONENTS Network)
     endif()
 
+    if(CTK_ENABLE_DICOM)
+      list(APPEND CTK_QT_COMPONENTS Svg)
+    endif()
+
     if(CTK_QT_VERSION VERSION_EQUAL "5")
       find_package(Qt5 COMPONENTS ${CTK_QT_COMPONENTS} REQUIRED)
       mark_as_superbuild(Qt5_DIR) # Qt 5

--- a/CMake/ctkMacroSetupQt.cmake
+++ b/CMake/ctkMacroSetupQt.cmake
@@ -137,7 +137,7 @@ macro(ctkMacroSetupQt)
       list(APPEND CTK_QT_COMPONENTS Network)
     endif()
 
-    if(CTK_ENABLE_DICOM)
+    if(CTK_LIB_DICOM/Core)
       list(APPEND CTK_QT_COMPONENTS Svg)
     endif()
 


### PR DESCRIPTION
```
CMake Error at CMake/ctkMacroBuildLib.cmake:161 (target_link_libraries):
  Target "CTKDICOMCore" links to:

    Qt6::Svg

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  Libs/DICOM/Core/CMakeLists.txt:207 (ctkMacroBuildLib)
```